### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: iOS Build & Test
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eyeMNaughtReal/GutCheck/security/code-scanning/3](https://github.com/eyeMNaughtReal/GutCheck/security/code-scanning/3)

To fix the issue, add an explicit `permissions` key at the root of the workflow file. Based on the workflow's purpose (building and testing an iOS application), the `contents: read` permission should suffice, as there is no indication that the workflow requires write access to the repository. This ensures that the workflow adheres to the principle of least privilege.

The change should be made at the top level of the workflow file, immediately after the `name` key, so that it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
