### PR TITLE
Add HealthKit read/write integration with user-controlled preferences

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -113,6 +113,7 @@ struct GutCheckApp: App {
                     TimeoutManager.shared.applicationDidEnterBackground()
                 case .active:
                     TimeoutManager.shared.applicationWillEnterForeground()
+                    Task { await HealthKitSyncManager.shared.syncIfNeeded() }
                 default:
                     break
                 }

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
@@ -5,8 +5,12 @@ import HealthKit
 struct UserHealthData {
     var dateOfBirth: Date?
     var biologicalSex: HKBiologicalSex?
-    var weight: Double? // in kg
-    var height: Double? // in meters
+    var weight: Double?                  // kg
+    var height: Double?                  // meters
+    var bloodPressureSystolic: Double?   // mmHg
+    var bloodPressureDiastolic: Double?  // mmHg
+    var bloodGlucose: Double?            // mg/dL
+    var heartRate: Double?               // bpm
 }
 
 final class HealthKitManager {
@@ -105,6 +109,31 @@ final class HealthKitManager {
             group.enter()
             fetchLatestQuantity(for: .height) { quantity in
                 healthData.height = quantity?.doubleValue(for: .meter())
+                group.leave()
+            }
+
+            group.enter()
+            fetchLatestQuantity(for: .bloodPressureSystolic) { quantity in
+                healthData.bloodPressureSystolic = quantity?.doubleValue(for: .millimeterOfMercury())
+                group.leave()
+            }
+
+            group.enter()
+            fetchLatestQuantity(for: .bloodPressureDiastolic) { quantity in
+                healthData.bloodPressureDiastolic = quantity?.doubleValue(for: .millimeterOfMercury())
+                group.leave()
+            }
+
+            group.enter()
+            fetchLatestQuantity(for: .bloodGlucose) { quantity in
+                let mgPerDL = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
+                healthData.bloodGlucose = quantity?.doubleValue(for: mgPerDL)
+                group.leave()
+            }
+
+            group.enter()
+            fetchLatestQuantity(for: .heartRate) { quantity in
+                healthData.heartRate = quantity?.doubleValue(for: .count().unitDivided(by: .minute()))
                 group.leave()
             }
 

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
@@ -1,0 +1,96 @@
+//
+//  HealthKitSyncManager.swift
+//  GutCheck
+//
+//  Manages automatic HealthKit data sync on app launch.
+//  Skips the fetch if data was pulled within the last 15 minutes,
+//  and skips the update if none of the tracked metrics have changed.
+//
+
+import Foundation
+import HealthKit
+
+@MainActor
+class HealthKitSyncManager: ObservableObject {
+    static let shared = HealthKitSyncManager()
+
+    @Published var latestHealthData: UserHealthData?
+
+    private let syncInterval: TimeInterval = 15 * 60 // 15 minutes
+    private let authorizedKey   = "healthKitEverAuthorized"
+    private let lastSyncKey     = "lastHealthKitSyncTimestamp"
+
+    // UserDefaults keys for stored snapshot (change detection)
+    private enum SnapshotKey {
+        static let weight    = "hkSnap_weight"
+        static let height    = "hkSnap_height"
+        static let systolic  = "hkSnap_systolic"
+        static let diastolic = "hkSnap_diastolic"
+        static let glucose   = "hkSnap_glucose"
+        static let heartRate = "hkSnap_heartRate"
+    }
+
+    private init() {}
+
+    // Call this after the user successfully grants HealthKit authorization.
+    func markAuthorized() {
+        UserDefaults.standard.set(true, forKey: authorizedKey)
+    }
+
+    // Runs on every app-foreground event; skips quickly if not needed.
+    func syncIfNeeded() async {
+        guard UserDefaults.standard.bool(forKey: authorizedKey) else { return }
+        guard UserDefaults.standard.bool(forKey: "healthKitSyncEnabled") else {
+            print("ℹ️ HealthKitSyncManager: Skipping — sync disabled by user preference")
+            return
+        }
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+
+        let now = Date().timeIntervalSince1970
+        let lastSync = UserDefaults.standard.double(forKey: lastSyncKey)
+
+        guard now - lastSync >= syncInterval else {
+            print("ℹ️ HealthKitSyncManager: Skipping — synced \(Int((now - lastSync) / 60)) min ago")
+            return
+        }
+
+        guard let data = await HealthKitAsyncWrapper.shared.fetchUserHealthData() else {
+            print("⚠️ HealthKitSyncManager: No data returned from HealthKit")
+            return
+        }
+
+        // Always update the timestamp so we don't hammer HealthKit on failures
+        UserDefaults.standard.set(now, forKey: lastSyncKey)
+
+        guard hasChanges(data) else {
+            print("ℹ️ HealthKitSyncManager: No changes detected in HealthKit data")
+            return
+        }
+
+        saveSnapshot(data)
+        latestHealthData = data
+        print("✅ HealthKitSyncManager: Health data updated — changes detected")
+    }
+
+    // MARK: - Change Detection
+
+    private func hasChanges(_ data: UserHealthData) -> Bool {
+        let d = UserDefaults.standard
+        return (data.weight ?? 0)                != d.double(forKey: SnapshotKey.weight)
+            || (data.height ?? 0)                != d.double(forKey: SnapshotKey.height)
+            || (data.bloodPressureSystolic ?? 0)  != d.double(forKey: SnapshotKey.systolic)
+            || (data.bloodPressureDiastolic ?? 0) != d.double(forKey: SnapshotKey.diastolic)
+            || (data.bloodGlucose ?? 0)           != d.double(forKey: SnapshotKey.glucose)
+            || (data.heartRate ?? 0)              != d.double(forKey: SnapshotKey.heartRate)
+    }
+
+    private func saveSnapshot(_ data: UserHealthData) {
+        let d = UserDefaults.standard
+        d.set(data.weight ?? 0,                forKey: SnapshotKey.weight)
+        d.set(data.height ?? 0,                forKey: SnapshotKey.height)
+        d.set(data.bloodPressureSystolic ?? 0,  forKey: SnapshotKey.systolic)
+        d.set(data.bloodPressureDiastolic ?? 0, forKey: SnapshotKey.diastolic)
+        d.set(data.bloodGlucose ?? 0,           forKey: SnapshotKey.glucose)
+        d.set(data.heartRate ?? 0,              forKey: SnapshotKey.heartRate)
+    }
+}

--- a/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
@@ -5,6 +5,7 @@ final class HealthKitViewModel: ObservableObject {
     @Published var healthData: UserHealthData?
     @Published var isAuthorized = false
     @Published var showPermissionError = false
+    @AppStorage("lastHealthKitSyncTimestamp") private var lastSyncTimestamp: Double = 0
     
     // Inject settings and auth service for unit preferences and profile updates
     private var settingsViewModel: SettingsViewModel
@@ -32,6 +33,7 @@ final class HealthKitViewModel: ObservableObject {
         if granted {
             await fetchHealthData()
             isAuthorized = true
+            HealthKitSyncManager.shared.markAuthorized()
         } else {
             showPermissionError = true
         }
@@ -39,6 +41,9 @@ final class HealthKitViewModel: ObservableObject {
 
     func fetchHealthData() async {
         healthData = await HealthKitAsyncWrapper.shared.fetchUserHealthDataWithLogging()
+        if healthData != nil {
+            lastSyncTimestamp = Date().timeIntervalSince1970
+        }
     }
     
     // Update user profile with health data

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -163,7 +163,12 @@ class MealBuilderViewModel: ObservableObject {
                 
                 // Save to repository (using the new repository pattern)
                 try await mealRepository.save(meal)
-                
+
+                // Write nutrition data to HealthKit (respects user preference)
+                if UserDefaults.standard.bool(forKey: "healthKitWriteMeals") {
+                    await HealthKitAsyncWrapper.shared.writeMealWithLogging(meal)
+                }
+
                 // Update UI
                 await MainActor.run {
                     self.isSaving = false

--- a/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
@@ -5,6 +5,11 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("unitOfMeasure") var unitRaw: String = UnitSystem.metric.rawValue
     @AppStorage("appColorScheme") var colorSchemeRaw: String = AppColorScheme.system.rawValue
 
+    // HealthKit write preferences
+    @AppStorage("healthKitSyncEnabled") var healthKitSyncEnabled: Bool = true
+    @AppStorage("healthKitWriteMeals") var healthKitWriteMeals: Bool = true
+    @AppStorage("healthKitWriteSymptoms") var healthKitWriteSymptoms: Bool = true
+
     var language: AppLanguage {
         get { AppLanguage(rawValue: languageRaw) ?? .english }
         set { languageRaw = newValue.rawValue }

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -160,6 +160,7 @@ class LogSymptomViewModel: ObservableObject, HasLoadingState {
     
     // MARK: - HealthKit Integration
     private func writeToHealthKit(_ symptom: Symptom) async {
+        guard UserDefaults.standard.bool(forKey: "healthKitWriteSymptoms") else { return }
         await HealthKitAsyncWrapper.shared.writeSymptomWithLogging(symptom)
     }
     

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -220,25 +220,15 @@ struct ProfileInfoSection: View {
 
 struct ProfileActionSection: View {
     @Binding var showSettings: Bool
-    @Binding var showHealthData: Bool
-    @Binding var showReminder: Bool
     let authService: AuthService
     @Environment(\.dismiss) private var dismiss
-    
+
     var body: some View {
         VStack(spacing: 12) {
             Button(action: { showSettings = true }) {
                 ProfileActionRow(icon: "gearshape", title: "Settings")
             }
 
-            Button(action: { showHealthData = true }) {
-                ProfileActionRow(icon: "heart", title: "Health Data Integration")
-            }
-            
-            Button(action: { showReminder = true }) {
-                ProfileActionRow(icon: "bell.badge", title: "Reminders")
-            }
-            
             Button(action: signOut) {
                 ProfileActionRow(icon: "arrow.right.square", title: "Sign Out", textColor: ColorTheme.error)
             }
@@ -267,8 +257,6 @@ struct UserProfileView: View {
     @State private var profileImage: UIImage? = nil
     @State private var showImagePicker = false
     @State private var showSettings = false
-    @State private var showHealthData = false
-    @State private var showReminder = false
     @EnvironmentObject var settingsVM: SettingsViewModel
 
     var body: some View {
@@ -282,8 +270,6 @@ struct UserProfileView: View {
                     
                     ProfileActionSection(
                         showSettings: $showSettings,
-                        showHealthData: $showHealthData, 
-                        showReminder: $showReminder,
                         authService: authService
                     )
                     
@@ -304,14 +290,7 @@ struct UserProfileView: View {
             .sheet(isPresented: $showSettings) {
                 SettingsView()
                     .environmentObject(settingsVM)
-            }
-            .sheet(isPresented: $showHealthData) {
-                HealthDataIntegrationView()
-                    .environmentObject(settingsVM)
                     .environmentObject(authService)
-            }
-            .sheet(isPresented: $showReminder) {
-                UserRemindersView()
             }
         }
     }


### PR DESCRIPTION
- Expand UserHealthData with blood pressure, glucose, and heart rate
- Add HealthKitSyncManager with 15-min debounce and change detection
- Auto-sync HealthKit data on app foreground via scenePhase
- Write meals and symptoms to Apple Health on save
- Add in-app toggles for sync-on-launch, meal writes, and symptom writes
- Rebuild HealthDataIntegrationView with connection status, data snapshot, and granular read/write preferences