### PR TITLE
Improve HealthKit settings UI and add daily nutrition to calendar view

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,11 @@
       "WebFetch(domain:github.com)",
       "Bash(xcodebuild:*)",
       "Bash(gh auth:*)",
-      "Bash(gh issue list:*)"
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(curl:*)",
+      "Bash(python3:*)",
+      "Bash(xargs ls:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
- Rebuild HealthDataIntegrationView with MFP-style layout: step-by-step permissions guide sheet, deep link to Apple Health app, and clearly separated "reads" vs "writes" sections with per-category toggles
- Add HealthKit preference toggles to SettingsViewModel (sync on launch, write meals, write symptoms) and gate all sync/write calls behind them
- Replace toolbar + button on meals tab with inline full-width Log Meal button
- Add DailyNutritionCard above meal list showing calories and macro pills; tappable to open full breakdown sheet (macros, fats, minerals, vitamins)

Closes #89, #95, #101 (parent #98)