### PR TITLE
Fix local storage sync errors (issue #122)

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -71,6 +71,7 @@ struct GutCheckApp: App {
     @StateObject private var authService = AuthService()
     @StateObject private var settingsVM = SettingsViewModel()
     @StateObject private var coreDataStack = CoreDataStack.shared
+    @StateObject private var localStorage = CoreDataStorageService.shared
     @StateObject private var dataSyncService = DataSyncService.shared
     @Environment(\.scenePhase) private var scenePhase
     
@@ -94,6 +95,7 @@ struct GutCheckApp: App {
                         .environmentObject(settingsVM)
                         .environmentObject(TimeoutManager.shared)
                         .environmentObject(coreDataStack)
+                        .environmentObject(localStorage)
                         .environmentObject(dataSyncService)
                 } else {
                     AuthenticationView(authService: authService)

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
@@ -337,8 +337,17 @@ class CoreDataStorageService: ObservableObject {
             localSettings.syncStatus = syncStatus
             localSettings.lastModified = Date()
         }
-        
-        coreDataStack.save()
+
+        guard let context = entity.managedObjectContext else { return }
+        context.perform {
+            if context.hasChanges {
+                do {
+                    try context.save()
+                } catch {
+                    print("Error saving sync status: \(error)")
+                }
+            }
+        }
     }
     
     func getUnsyncedData() async throws -> (meals: [LocalMeal], symptoms: [LocalSymptom], settings: [LocalReminderSettings]) {

--- a/GutCheck/GutCheck/Services/ReminderSettingsService.swift
+++ b/GutCheck/GutCheck/Services/ReminderSettingsService.swift
@@ -205,24 +205,21 @@ class ReminderSettingsRepository {
     private init() {}
     
     func fetch(forUser userId: String) async throws -> ReminderSettings {
-        let document = try await db.collection(collectionPath)
-            .whereField("createdBy", isEqualTo: userId)
-            .limit(to: 1)
-            .getDocuments()
-        
-        guard let doc = document.documents.first else {
+        let doc = try await db.collection(collectionPath).document(userId).getDocument()
+
+        guard doc.exists else {
             throw RepositoryError.documentNotFound("No reminder settings found for user")
         }
-        
+
         return try ReminderSettings(from: doc)
     }
-    
+
     func save(_ settings: ReminderSettings) async throws {
         let data = settings.toFirestoreData()
-        try await db.collection(collectionPath).document(settings.id).setData(data)
+        try await db.collection(collectionPath).document(settings.createdBy).setData(data)
     }
-    
+
     func delete(_ settings: ReminderSettings) async throws {
-        try await db.collection(collectionPath).document(settings.id).delete()
+        try await db.collection(collectionPath).document(settings.createdBy).delete()
     }
 }

--- a/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
+++ b/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
@@ -95,7 +95,7 @@ struct LocalStorageSettingsView: View {
                     }
                 }) {
                     HStack {
-                        Image(systemName: "broom")
+                        Image(systemName: "clock.arrow.circlepath")
                             .foregroundColor(.orange)
                         Text("Clean Up Old Data")
                     }


### PR DESCRIPTION
- Inject CoreDataStorageService into the environment so LocalStorageSettingsView no longer crashes on open
- Fix markAsSynced saving to the view context instead of the entity's own background context, which caused sync status to never persist and the same data to be re-uploaded every sync
- Scope DataSyncService download queries by current user ID to satisfy Firestore security rules (previously queried all docs, which was denied with PERMISSION_DENIED)
- Fix ReminderSettingsRepository to fetch/write by document ID (userId) instead of querying by the createdBy field; the Firestore rule match /reminderSettings/{userId} grants access via the document path, not a field filter, so collection queries were always denied
- Replace invalid SF Symbol "broom" with "clock.arrow.circlepath"
- This resolves issue #122 and #121 