### PR TITLE
Fix CI simulator destination (issue #127)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -94,7 +94,7 @@ jobs:
         xcodebuild clean build \
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+          -destination 'generic/platform=iOS Simulator' \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO
@@ -105,7 +105,7 @@ jobs:
         xcodebuild test \
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+          -destination 'generic/platform=iOS Simulator' \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO \


### PR DESCRIPTION
Replace OS=latest destination with generic/platform=iOS Simulator in both the Build and Run Unit Tests steps. OS=latest fails to resolve on macos-15 + Xcode 16.2 runners (exit code 70 — no matching destination). The generic form is version-agnostic and resolves to whatever iOS Simulator runtime is installed on the runner without requiring a pinned OS version.