### PR TITLE
Fix CI simulator destination resolution (issue #127)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -89,12 +89,36 @@ jobs:
           -scheme GutCheck
       working-directory: GutCheck
 
+    - name: Prepare iOS Simulator
+      run: |
+        # Initialise CoreSimulator so it picks up the Xcode 16.2 runtimes
+        xcrun simctl list runtimes
+
+        # Find the UDID of the most recent available iPhone simulator
+        UDID=$(xcrun simctl list devices available | \
+          grep -E "^ +iPhone" | \
+          tail -1 | \
+          grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}')
+
+        # If no simulator runtime is present, download the iOS platform
+        if [ -z "$UDID" ]; then
+          echo "No iPhone simulator found — downloading iOS platform (this may take a few minutes)"
+          xcodebuild -downloadPlatform iOS
+          UDID=$(xcrun simctl list devices available | \
+            grep -E "^ +iPhone" | \
+            tail -1 | \
+            grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}')
+        fi
+
+        echo "SIMULATOR_UDID=$UDID" >> $GITHUB_ENV
+        echo "Using simulator UDID: $UDID"
+
     - name: Build GutCheck
       run: |
         xcodebuild clean build \
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
-          -destination 'generic/platform=iOS Simulator' \
+          -destination "id=${{ env.SIMULATOR_UDID }}" \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO
@@ -105,7 +129,7 @@ jobs:
         xcodebuild test \
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
-          -destination 'generic/platform=iOS Simulator' \
+          -destination "id=${{ env.SIMULATOR_UDID }}" \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO \


### PR DESCRIPTION
Add a Prepare iOS Simulator step that initialises CoreSimulator against the Xcode 16.2 path (via xcrun simctl list runtimes) before building, then captures the most recent available iPhone simulator UDID. Build and test steps now target that specific UDID instead of the generic/platform specifier, which failed because CoreSimulator had not yet discovered any runtimes after setup-xcode switched the active Xcode path.

Falls back to xcodebuild -downloadPlatform iOS if no simulator runtime is found at all on the runner.