### PR TITLE
Fix CI simulator runtime detection (issue #132)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -90,25 +90,53 @@ jobs:
       working-directory: GutCheck
 
     - name: Prepare iOS Simulator
+      working-directory: GutCheck
       run: |
-        # Initialise CoreSimulator so it picks up the Xcode 16.2 runtimes
+        # Step 1: Initialise CoreSimulator under the active Xcode 16.2 toolchain
         xcrun simctl list runtimes
 
-        # Find the UDID of the most recent available iPhone simulator
-        UDID=$(xcrun simctl list devices available | \
-          grep -E "^ +iPhone" | \
-          tail -1 | \
-          grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}')
+        # Step 2: Check whether an iOS Simulator runtime is ACTUALLY installed.
+        # simctl device records can exist in the database even when the runtime
+        # files themselves are missing, causing a false-positive UDID match.
+        IOS_RUNTIME=$(xcrun simctl list runtimes 2>&1 | \
+          grep -E "^iOS [0-9]" | grep -v "unavailable" | head -1)
 
-        # If no simulator runtime is present, download the iOS platform
-        if [ -z "$UDID" ]; then
-          echo "No iPhone simulator found — downloading iOS platform (this may take a few minutes)"
+        if [ -z "$IOS_RUNTIME" ]; then
+          echo "No installed iOS Simulator runtime found — downloading iOS platform (may take several minutes)"
           xcodebuild -downloadPlatform iOS
+          xcrun simctl list runtimes
+        fi
+
+        # Step 3: Ask xcodebuild itself which destinations it can use.
+        # This is more reliable than xcrun simctl, which can list device UDIDs
+        # even when the corresponding runtime files are not installed.
+        UDID=$(xcodebuild -showdestinations \
+          -project GutCheck.xcodeproj \
+          -scheme GutCheck 2>&1 | \
+          grep "platform:iOS Simulator" | \
+          grep -i "name:iPhone" | \
+          tail -1 | \
+          grep -oE 'id:[0-9A-Fa-f-]+' | \
+          sed 's/id://')
+
+        # Step 4: Fall back to simctl only if xcodebuild found nothing
+        if [ -z "$UDID" ]; then
           UDID=$(xcrun simctl list devices available | \
             grep -E "^ +iPhone" | \
             tail -1 | \
             grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}')
         fi
+
+        # Step 5: Fail loudly with full diagnostics if still no simulator found
+        if [ -z "$UDID" ]; then
+          echo "ERROR: No iPhone simulator found even after runtime download" >&2
+          xcrun simctl list runtimes
+          xcrun simctl list devices available
+          exit 1
+        fi
+
+        # Step 6: Boot the simulator so xcodebuild can attach to it immediately
+        xcrun simctl boot "$UDID" 2>/dev/null || true
 
         echo "SIMULATOR_UDID=$UDID" >> $GITHUB_ENV
         echo "Using simulator UDID: $UDID"


### PR DESCRIPTION
The previous "Prepare iOS Simulator" step used `xcrun simctl list devices available` to find a simulator UDID. This returns a UDID even when the iOS Simulator runtime files are not installed — so the `xcodebuild -downloadPlatform iOS` fallback never fired, and the build failed with:
  "Unable to find a destination matching { id:73FFFAA3... }"

Changes:
- Add `working-directory: GutCheck` so -showdestinations can resolve the project file
- Check `xcrun simctl list runtimes` for an actually-installed (non- unavailable) iOS runtime before trusting any UDID
- Download iOS platform if no installed runtime is found
- Use `xcodebuild -showdestinations` as the primary UDID source — this is xcodebuild's own ground truth, not simctl's device database
- Keep simctl as a fallback if -showdestinations finds nothing
- Exit 1 with full diagnostics if still no simulator found
- Boot the simulator before handing it to xcodebuild

Closes #132