### PR TITLE
feat(#159): apply card-style button design to Log Meal, Log Symptom, …

### DIFF
--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -263,15 +263,18 @@ struct CalendarMealsSectionHeader: View {
                 router.startMealLogging()
             } label: {
                 HStack {
-                    Image(systemName: "plus.circle.fill")
+                    Image(systemName: "fork.knife")
+                        .font(.title2)
                     Text("Log Meal")
-                        .fontWeight(.semibold)
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 13)
-                .background(Color.accentColor)
-                .foregroundColor(.white)
-                .cornerRadius(12)
+                .padding()
+                .background(Color.green.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+                .foregroundColor(.green)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
@@ -310,15 +313,18 @@ struct CalendarSymptomsSectionHeader: View {
                 router.startSymptomLogging()
             } label: {
                 HStack {
-                    Image(systemName: "plus.circle.fill")
+                    Image(systemName: "waveform.path.ecg")
+                        .font(.title2)
                     Text("Log Symptom")
-                        .fontWeight(.semibold)
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 13)
-                .background(Color.accentColor)
-                .foregroundColor(.white)
-                .cornerRadius(12)
+                .padding()
+                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+                .foregroundColor(.orange)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 12)

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -149,15 +149,18 @@ struct CalendarMedicationsSectionHeader: View {
                 onLogDose()
             } label: {
                 HStack {
-                    Image(systemName: "plus.circle.fill")
+                    Image(systemName: "pills.fill")
+                        .font(.title2)
                     Text("Log Dose")
-                        .fontWeight(.semibold)
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 13)
-                .background(Color.purple)
-                .foregroundColor(.white)
-                .cornerRadius(12)
+                .padding()
+                .background(Color.purple.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+                .foregroundColor(.purple)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 12)


### PR DESCRIPTION
…Log Dose

Replace the solid full-width buttons with the inline card style already used by Log Dose in MedicationsView: left icon, title, spacer, chevron, tinted background with opacity, rounded rectangle.

- Log Meal:    green tint,  fork.knife icon
- Log Symptom: orange tint, waveform.path.ecg icon
- Log Dose (MedicationCalendarView): purple tint, pills.fill icon
  (now matches the identical button in MedicationsView)