### PR TITLE
fix(162): resolve medication HealthKit auth error and Firestore permi…

### DIFF
--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
@@ -173,6 +173,11 @@ class HealthKitMedicationService: ObservableObject {
     }
     
     func fetchMedicationsFromHealthKit() async throws -> [MedicationRecord] {
+        // Skip the query entirely if authorization has not been granted.
+        // This avoids a noisy "Authorization not determined" HKError in the console
+        // when the user has not yet connected HealthKit medication access.
+        guard isAuthorized else { return [] }
+
         let medicationType = HKObjectType.clinicalType(forIdentifier: .medicationRecord)!
         
         let predicate = HKQuery.predicateForSamples(

--- a/GutCheck/firestore.rules
+++ b/GutCheck/firestore.rules
@@ -168,6 +168,28 @@ service cloud.firestore {
     }
     
     // ============================================================================
+    // MEDICATION DOSE LOGS SECURITY
+    // ============================================================================
+
+    match /medicationDoses/{doseId} {
+      // Users can read their own medication dose logs
+      allow read: if isCreator(resource.data.createdBy);
+
+      // Users can create dose logs (must include createdBy field matching auth UID)
+      allow create: if isAuthenticated() &&
+        request.auth.uid == request.resource.data.createdBy &&
+        hasRequiredFields(request.resource.data, ['createdBy', 'medicationId', 'medicationName', 'dosageAmount', 'dosageUnit', 'dateTaken']);
+
+      // Users can update their own dose logs; createdBy cannot be changed
+      allow update: if isCreator(resource.data.createdBy) &&
+        request.auth.uid == request.resource.data.createdBy &&
+        request.resource.data.createdBy == resource.data.createdBy;
+
+      // Users can delete their own dose logs
+      allow delete: if isCreator(resource.data.createdBy);
+    }
+
+    // ============================================================================
     // REMINDER SETTINGS SECURITY
     // ============================================================================
     


### PR DESCRIPTION
…ssions

- HealthKitMedicationService.fetchMedicationsFromHealthKit() now guards on isAuthorized before executing the query, preventing a noisy "Authorization not determined" HKError when the user has not yet connected HealthKit medication access.

- Added Firestore security rule for the `medicationDoses` collection (previously missing, falling through to the default-deny rule). Follows the same owner-only pattern as `meals` and `symptoms`: createdBy must match the authenticated user's UID on all read/write ops.