### PR TITLE
fix(#168): show logged medication doses in Dashboard Today's Summary

### DIFF
--- a/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
@@ -11,12 +11,15 @@ class RecentActivityViewModel: ObservableObject {
     // Repository dependencies
     private let mealRepository: MealRepository
     private let symptomRepository: SymptomRepository
+    private let medicationDoseRepository: MedicationDoseRepository
     private var medicationService: HealthKitMedicationService?
-    
+
     init(mealRepository: MealRepository = MealRepository.shared,
-         symptomRepository: SymptomRepository = SymptomRepository.shared) {
+         symptomRepository: SymptomRepository = SymptomRepository.shared,
+         medicationDoseRepository: MedicationDoseRepository = MedicationDoseRepository.shared) {
         self.mealRepository = mealRepository
         self.symptomRepository = symptomRepository
+        self.medicationDoseRepository = medicationDoseRepository
     }
     
     func loadRecentActivity(for date: Date, authService: AuthService) {
@@ -69,12 +72,43 @@ class RecentActivityViewModel: ObservableObject {
             print("   - Symptom: \(symptom.id) at \(symptom.date)")
         }
         
-        // Fetch medications for the date
+        // Fetch logged medication doses from repository (primary source)
+        // This covers doses the user logs manually via the app.
+        do {
+            let doses = try await medicationDoseRepository.fetchDosesForDate(date, userId: currentUser.id)
+            print("💊 RecentActivityViewModel: Found \(doses.count) logged medication doses")
+            for dose in doses {
+                // Convert MedicationDoseLog → MedicationRecord for ActivityEntry display
+                let record = MedicationRecord(
+                    id: dose.id,
+                    createdBy: dose.createdBy,
+                    name: dose.medicationName,
+                    dosage: MedicationDosage(
+                        amount: dose.dosageAmount,
+                        unit: dose.dosageUnit,
+                        frequency: .asNeeded
+                    ),
+                    startDate: dose.dateTaken,
+                    endDate: nil,
+                    isActive: true,
+                    notes: dose.notes,
+                    source: .manual,
+                    privacyLevel: dose.privacyLevel,
+                    healthKitUUID: nil
+                )
+                entries.append(ActivityEntry(type: .medication(record), timestamp: dose.dateTaken))
+                print("   - Dose: \(dose.medicationName) at \(dose.dateTaken)")
+            }
+        } catch {
+            print("⚠️ RecentActivityViewModel: Could not fetch medication doses: \(error.localizedDescription)")
+        }
+
+        // Also fetch from HealthKit (supplemental: doctor-prescribed clinical records)
         let medications = try await fetchMedicationsForDate(date)
-        print("💊 RecentActivityViewModel: Found \(medications.count) medications")
+        print("💊 RecentActivityViewModel: Found \(medications.count) HealthKit medication records")
         for medication in medications {
             entries.append(ActivityEntry(type: .medication(medication), timestamp: medication.startDate))
-            print("   - Medication: \(medication.name) at \(medication.startDate)")
+            print("   - HK Medication: \(medication.name) at \(medication.startDate)")
         }
         
         // Sort by timestamp (most recent first) - no limit, show all entries for the day


### PR DESCRIPTION
The medication count in Today's Summary was always 0 because RecentActivityViewModel only queried HealthKit for MedicationRecord (clinical records), which returns empty when HealthKit authorization has not been granted.

Fix: add MedicationDoseRepository as a primary data source. Logged doses are now fetched via fetchDosesForDate(_:userId:) and converted to MedicationRecord for display in the existing ActivityEntry.medication case. HealthKit clinical records remain as a supplemental source for doctor-prescribed records when access is granted.