### PR TITLE
feat(#74): require email verification before granting access

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -150,6 +150,8 @@ struct GutCheckApp: App {
                         .environmentObject(coreDataStack)
                         .environmentObject(localStorage)
                         .environmentObject(dataSyncService)
+                } else if authService.isAwaitingEmailVerification {
+                    EmailVerificationView(authService: authService)
                 } else {
                     AuthenticationView(authService: authService)
                 }

--- a/GutCheck/GutCheck/Services/Firebase/AuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthService.swift
@@ -15,8 +15,12 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
     @Published private(set) var authUser: FirebaseAuth.User?
     @Published private(set) var currentUser: User?
     @Published private(set) var isAuthenticated = false
+    @Published private(set) var isAwaitingEmailVerification = false
     private var verificationId: String?
     @Published private(set) var isPhoneVerificationInProgress = false
+    /// Temporarily holds the email for resending verification when the user is signed out
+    private var pendingVerificationEmail: String?
+    private var pendingVerificationPassword: String?
     
     let loadingState = LoadingStateManager()
     
@@ -30,13 +34,24 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
         // Listen for auth state changes
         authStateListenerHandle = auth.addStateDidChangeListener { [weak self] _, user in
             Task { @MainActor in
-                self?.authUser = user
-                self?.isAuthenticated = user != nil
+                guard let self = self else { return }
+                self.authUser = user
                 
                 if let authUser = user {
-                    await self?.loadCurrentUser(userId: authUser.uid)
+                    await self.loadCurrentUser(userId: authUser.uid)
+                    
+                    // Check if this is an email user who hasn't verified yet
+                    let isEmailUser = authUser.providerData.contains { $0.providerID == "password" }
+                    if isEmailUser && !authUser.isEmailVerified {
+                        self.isAuthenticated = false
+                        self.isAwaitingEmailVerification = true
+                    } else {
+                        self.isAuthenticated = true
+                        self.isAwaitingEmailVerification = false
+                    }
                 } else {
-                    self?.currentUser = nil
+                    self.isAuthenticated = false
+                    self.currentUser = nil
                 }
             }
         }
@@ -60,6 +75,16 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
         do {
             let result = try await auth.signIn(withEmail: email, password: password)
             authUser = result.user
+            
+            // Block unverified email users
+            if !result.user.isEmailVerified {
+                pendingVerificationEmail = email
+                pendingVerificationPassword = password
+                isAwaitingEmailVerification = true
+                isAuthenticated = false
+                return
+            }
+            
             isAuthenticated = true
             await loadCurrentUser(userId: result.user.uid)
         } catch {
@@ -77,7 +102,6 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
         do {
             let result = try await auth.createUser(withEmail: email, password: password)
             authUser = result.user
-            isAuthenticated = true
             
             // Create user profile in Firestore
             let newUser = try await createUserProfile(
@@ -89,6 +113,13 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
                 privacyPolicyAccepted: privacyPolicyAccepted
             )
             currentUser = newUser
+            
+            // Send verification email and hold at verification screen
+            try await result.user.sendEmailVerification()
+            pendingVerificationEmail = email
+            pendingVerificationPassword = password
+            isAwaitingEmailVerification = true
+            isAuthenticated = false
             
         } catch {
             errorMessage = handleAuthError(error)
@@ -168,6 +199,100 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
             errorMessage = handleAuthError(error)
             throw error
         }
+    }
+    
+    // MARK: - Email Verification
+    
+    func resendVerificationEmail() async throws {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        
+        // If we have a signed-in user, use them directly
+        if let user = auth.currentUser {
+            try await user.reload()
+            if user.isEmailVerified {
+                // Already verified — proceed to authenticated state
+                isAwaitingEmailVerification = false
+                isAuthenticated = true
+                await loadCurrentUser(userId: user.uid)
+                return
+            }
+            try await user.sendEmailVerification()
+            return
+        }
+        
+        // Otherwise, sign in temporarily to resend
+        guard let email = pendingVerificationEmail,
+              let password = pendingVerificationPassword else {
+            throw AuthError.custom("No pending verification. Please sign in again.")
+        }
+        
+        do {
+            let result = try await auth.signIn(withEmail: email, password: password)
+            try await result.user.sendEmailVerification()
+            authUser = result.user
+        } catch {
+            errorMessage = handleAuthError(error)
+            throw error
+        }
+    }
+    
+    func checkEmailVerification() async throws {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        
+        // If we have a signed-in user, reload and check
+        if let user = auth.currentUser {
+            try await user.reload()
+            if user.isEmailVerified {
+                isAwaitingEmailVerification = false
+                isAuthenticated = true
+                pendingVerificationEmail = nil
+                pendingVerificationPassword = nil
+                await loadCurrentUser(userId: user.uid)
+                return
+            } else {
+                throw AuthError.custom("Email not yet verified. Please check your inbox and tap the verification link.")
+            }
+        }
+        
+        // If no current user, try signing in with stored credentials
+        guard let email = pendingVerificationEmail,
+              let password = pendingVerificationPassword else {
+            throw AuthError.custom("No pending verification. Please sign in again.")
+        }
+        
+        do {
+            let result = try await auth.signIn(withEmail: email, password: password)
+            try await result.user.reload()
+            
+            if result.user.isEmailVerified {
+                authUser = result.user
+                isAwaitingEmailVerification = false
+                isAuthenticated = true
+                pendingVerificationEmail = nil
+                pendingVerificationPassword = nil
+                await loadCurrentUser(userId: result.user.uid)
+            } else {
+                authUser = result.user
+                throw AuthError.custom("Email not yet verified. Please check your inbox and tap the verification link.")
+            }
+        } catch let error as AuthError {
+            errorMessage = error.errorDescription
+            throw error
+        } catch {
+            errorMessage = handleAuthError(error)
+            throw error
+        }
+    }
+    
+    func cancelEmailVerification() throws {
+        isAwaitingEmailVerification = false
+        pendingVerificationEmail = nil
+        pendingVerificationPassword = nil
+        try signOut()
     }
     
     // MARK: - Re-authentication Methods

--- a/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
@@ -6,6 +6,7 @@ protocol AuthenticationProtocol: ObservableObject {
     var isLoading: Bool { get }
     var errorMessage: String? { get set }
     var isPhoneVerificationInProgress: Bool { get }
+    var isAwaitingEmailVerification: Bool { get }
     var currentUser: User? { get }
     
     func signIn(email: String, password: String) async throws

--- a/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
@@ -7,6 +7,7 @@ class PreviewAuthService: AuthenticationProtocol {
     @Published private(set) var isLoading: Bool = false
     @Published var errorMessage: String?
     @Published private(set) var isPhoneVerificationInProgress: Bool = false
+    @Published private(set) var isAwaitingEmailVerification: Bool = false
     @Published private(set) var currentUser: User? = User(
         id: "preview",
         email: "preview@example.com",

--- a/GutCheck/GutCheck/ViewModels/AuthenticationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/AuthenticationViewModel.swift
@@ -140,6 +140,30 @@ class AuthenticationViewModel: ObservableObject {
         }
     }
     
+    func resendVerificationEmail() async {
+        do {
+            try await authService.resendVerificationEmail()
+        } catch {
+            // Error is handled by AuthService
+        }
+    }
+    
+    func checkEmailVerification() async {
+        do {
+            try await authService.checkEmailVerification()
+        } catch {
+            // Error is handled by AuthService
+        }
+    }
+    
+    func cancelEmailVerification() {
+        do {
+            try authService.cancelEmailVerification()
+        } catch {
+            // Error is handled by AuthService
+        }
+    }
+    
     func toggleAuthMode() {
         isShowingSignUp.toggle()
         clearForm()
@@ -164,21 +188,18 @@ class AuthenticationViewModel: ObservableObject {
     }
     
     private func isValidPhoneNumber(_ phone: String) -> Bool {
-        let phoneRegex = "^[+]?[1-9]\\d{1,14}$"
-        let phonePredicate = NSPredicate(format: "SELF MATCHES %@", phoneRegex)
-        return phonePredicate.evaluate(with: phone.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "-", with: ""))
+        let cleaned = phone.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+        // Accept 10 digits (US) or 11 digits starting with 1 (US with country code)
+        return cleaned.count == 10 || (cleaned.count == 11 && cleaned.hasPrefix("1"))
     }
     
     private func formatPhoneNumber(_ phone: String) -> String {
-        let cleanedPhone = phone.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "-", with: "")
-        if cleanedPhone.hasPrefix("+") {
-            return cleanedPhone
-        } else if cleanedPhone.hasPrefix("1") && cleanedPhone.count == 11 {
-            return "+\(cleanedPhone)"
-        } else if cleanedPhone.count == 10 {
-            return "+1\(cleanedPhone)"
+        var digits = phone.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+        // Normalize to 10 digits without country code
+        if digits.count == 11 && digits.hasPrefix("1") {
+            digits = String(digits.dropFirst())
         }
-        return cleanedPhone
+        return "+1\(digits)"
     }
     
     private func getPasswordStrength(_ password: String) -> PasswordStrength {

--- a/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
@@ -1,0 +1,101 @@
+//
+//  EmailVerificationView.swift
+//  GutCheck
+//
+//  Created by Mark Conley on 3/6/26.
+//
+
+import SwiftUI
+
+struct EmailVerificationView: View {
+    @ObservedObject var authService: AuthService
+    @State private var showResendSuccess = false
+    
+    var body: some View {
+        VStack(spacing: 30) {
+            Spacer()
+            
+            // Icon
+            Image(systemName: "envelope.badge")
+                .font(.system(size: 60))
+                .foregroundColor(ColorTheme.primary)
+            
+            // Title
+            VStack(spacing: 12) {
+                Text("Verify Your Email")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(ColorTheme.text)
+                
+                Text("We sent a verification link to your email address. Please check your inbox and tap the link to continue.")
+                    .font(.subheadline)
+                    .foregroundColor(ColorTheme.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+            }
+            
+            // Buttons
+            VStack(spacing: 16) {
+                CustomButton(
+                    title: "I've Verified My Email",
+                    action: {
+                        Task {
+                            do {
+                                try await authService.checkEmailVerification()
+                            } catch {
+                                // Error displayed via authService.errorMessage
+                            }
+                        }
+                    }
+                )
+                .loading(authService.isLoading)
+                
+                CustomButton(
+                    title: "Resend Verification Email",
+                    action: {
+                        Task {
+                            do {
+                                try await authService.resendVerificationEmail()
+                                showResendSuccess = true
+                            } catch {
+                                // Error displayed via authService.errorMessage
+                            }
+                        }
+                    },
+                    style: .outline
+                )
+                .loading(authService.isLoading)
+                
+                Button {
+                    try? authService.cancelEmailVerification()
+                } label: {
+                    Text("Back to Sign In")
+                        .font(.footnote)
+                        .foregroundColor(ColorTheme.primary)
+                }
+            }
+            .padding(.horizontal, 24)
+            
+            Spacer()
+        }
+        .background(ColorTheme.background)
+        .alert("Success", isPresented: $showResendSuccess) {
+            Button("OK") { }
+        } message: {
+            Text("Verification email sent. Please check your inbox.")
+        }
+        .alert("Error", isPresented: .constant(authService.errorMessage != nil)) {
+            Button("OK") {
+                authService.errorMessage = nil
+            }
+        } message: {
+            if let errorMessage = authService.errorMessage {
+                Text(errorMessage)
+            }
+        }
+    }
+}
+
+#Preview {
+    EmailVerificationView(authService: AuthService())
+}

--- a/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
@@ -113,6 +113,7 @@ private class MockAuthService: AuthenticationProtocol {
     @Published var isLoading = false
     @Published var errorMessage: String?
     @Published var isPhoneVerificationInProgress = false
+    @Published var isAwaitingEmailVerification = false
     @Published var currentUser: User?
     
     func signIn(email: String, password: String) async throws {}

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -55,9 +55,10 @@ struct AuthenticationView: View {
         .sheet(isPresented: $viewModel.isShowingForgotPassword) {
             forgotPasswordSheet
         }
-        .sheet(isPresented: $viewModel.isShowingPhoneAuth) {
-            PhoneAuthView(authService: authService)
-        }
+        // Phone auth disabled for now
+        // .sheet(isPresented: $viewModel.isShowingPhoneAuth) {
+        //     PhoneAuthView(authService: authService)
+        // }
     }
     
     // MARK: - Header Section
@@ -227,23 +228,8 @@ struct AuthenticationView: View {
     
     private var authToggleSection: some View {
         VStack(spacing: 20) {
-            // Social Sign-In Options
-            socialSignInSection
-            
-            // Divider
-            HStack {
-                Rectangle()
-                    .fill(ColorTheme.secondaryText.opacity(0.3))
-                    .frame(height: 1)
-                
-                Text("or")
-                    .font(.footnote)
-                    .foregroundColor(ColorTheme.secondaryText)
-                
-                Rectangle()
-                    .fill(ColorTheme.secondaryText.opacity(0.3))
-                    .frame(height: 1)
-            }
+            // Social Sign-In Options (disabled for now)
+            // socialSignInSection
             
             Button(action: viewModel.toggleAuthMode) {
                 Text(viewModel.isShowingSignUp ? "Already have an account? Sign In" : "Don't have an account? Sign Up")
@@ -286,13 +272,14 @@ struct AuthenticationView: View {
             .frame(height: 50)
             */
             
-            SocialSignInButton(
-                provider: .phone,
-                action: {
-                    viewModel.isShowingPhoneAuth = true
-                },
-                isLoading: authService.isLoading
-            )
+            // Phone sign-in disabled for now
+            // SocialSignInButton(
+            //     provider: .phone,
+            //     action: {
+            //         viewModel.isShowingPhoneAuth = true
+            //     },
+            //     isLoading: authService.isLoading
+            // )
         }
     }
     

--- a/GutCheck/GutCheck/Views/PhoneAuthView.swift
+++ b/GutCheck/GutCheck/Views/PhoneAuthView.swift
@@ -80,8 +80,11 @@ struct PhoneAuthView: View {
                     keyboardType: .phonePad
                 )
                 .onChange(of: viewModel.phoneNumber) { _, newValue in
-                    // Format phone number as user types
-                    viewModel.phoneNumber = formatPhoneDisplay(newValue)
+                    // Format phone number as user types, avoiding re-entrant updates
+                    let formatted = formatPhoneDisplay(newValue)
+                    if formatted != newValue {
+                        viewModel.phoneNumber = formatted
+                    }
                 }
                 
                 Text("Format: +1 (555) 123-4567")
@@ -164,22 +167,31 @@ struct PhoneAuthView: View {
     
     // MARK: - Helper Methods
     
-    private func formatPhoneDisplay(_ phone: String, mask: String = "(XXX) XXX-XXXX") -> String {
-        let digits = phone.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
-        
-        var formatted = ""
-        var index = digits.startIndex
-        
-        for char in mask where index < digits.endIndex {
-            if char == "X" {
-                formatted.append(digits[index])
-                index = digits.index(after: index)
-            } else {
-                formatted.append(char)
-            }
+    private func formatPhoneDisplay(_ phone: String) -> String {
+        // Strip the +1 prefix we add, so we only work with the local digits
+        var raw = phone
+        if raw.hasPrefix("+1 ") {
+            raw = String(raw.dropFirst(3))
+        } else if raw.hasPrefix("+1") {
+            raw = String(raw.dropFirst(2))
         }
         
-        return formatted
+        // Extract only digits
+        let digits = String(raw.unicodeScalars.filter(CharacterSet.decimalDigits.contains).prefix(10))
+        
+        if digits.isEmpty {
+            return ""
+        }
+        
+        // Build formatted string: +1 (XXX) XXX-XXXX
+        var result = "+1 ("
+        for (i, d) in digits.enumerated() {
+            if i == 3 { result += ") " }
+            if i == 6 { result += "-" }
+            result.append(d)
+        }
+        
+        return result
     }
 }
 


### PR DESCRIPTION
## Summary
- Blocks sign-in for email/password users whose email is not yet verified
- Sends a verification email automatically on sign-up
- Shows an `EmailVerificationView` with options to resend the verification email, check verification status, or go back to sign in
- Phone sign-in UI temporarily disabled due to Firebase APNs requirements on simulators

## Changes
- **AuthenticationProtocol**: Added `isAwaitingEmailVerification` property
- **AuthService**: Added verification state management, `resendVerificationEmail()`, `checkEmailVerification()`, `cancelEmailVerification()` methods; auth state listener checks `isEmailVerified` for email users
- **AuthenticationViewModel**: Added delegation methods for verification actions; fixed phone number validation/formatting
- **GutCheckApp**: Added third UI state branch for email verification pending screen
- **EmailVerificationView** (new): Verification pending screen with resend, check, and cancel actions
- **AuthenticationView**: Commented out phone sign-in button and sheet
- **PhoneAuthView**: Fixed phone number formatter re-entrant update loop

## Test plan
- [x] Sign up with email → verification email sent, verification screen shown
- [x] Sign in before verifying → blocked, shown verification screen with resend option
- [x] Click "I've Verified My Email" after verifying email → proceeds to app
- [ ] "Resend Verification Email" sends a new email
- [x] "Back to Sign In" returns to login screen
- [x] Phone sign-in button no longer visible

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)