### PR TITLE
fix(#198): show loading state while Firebase restores auth session

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -142,7 +142,15 @@ struct GutCheckApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if authService.isAuthenticated {
+                if !authService.isAuthStateResolved {
+                    // Show loading while Firebase restores auth session
+                    ZStack {
+                        ColorTheme.background
+                            .ignoresSafeArea()
+                        ProgressView()
+                            .tint(ColorTheme.primary)
+                    }
+                } else if authService.isAuthenticated {
                     AppRoot()
                         .environmentObject(authService)
                         .environmentObject(settingsVM)

--- a/GutCheck/GutCheck/Services/Firebase/AuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthService.swift
@@ -15,6 +15,7 @@ import AuthenticationServices
 class AuthService: AuthenticationProtocol, HasLoadingState {
     @Published private(set) var authUser: FirebaseAuth.User?
     @Published private(set) var currentUser: User?
+    @Published private(set) var isAuthStateResolved = false
     @Published private(set) var isAuthenticated = false
     @Published private(set) var isAwaitingEmailVerification = false
     private var verificationId: String?
@@ -55,6 +56,8 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
                     self.isAuthenticated = false
                     self.currentUser = nil
                 }
+                
+                self.isAuthStateResolved = true
             }
         }
     }

--- a/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
@@ -2,6 +2,7 @@ import Foundation
 
 @MainActor
 protocol AuthenticationProtocol: ObservableObject {
+    var isAuthStateResolved: Bool { get }
     var isAuthenticated: Bool { get }
     var isLoading: Bool { get }
     var errorMessage: String? { get set }

--- a/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
@@ -3,6 +3,7 @@ import FirebaseAuth
 
 @MainActor
 class PreviewAuthService: AuthenticationProtocol {
+    @Published private(set) var isAuthStateResolved: Bool = true
     @Published private(set) var isAuthenticated: Bool = true
     @Published private(set) var isLoading: Bool = false
     @Published var errorMessage: String?

--- a/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
@@ -109,6 +109,7 @@ private struct WelcomePageView: View {
 // MARK: - Preview Helpers
 
 private class MockAuthService: AuthenticationProtocol {
+    @Published var isAuthStateResolved = true
     @Published var isAuthenticated = false
     @Published var isLoading = false
     @Published var errorMessage: String?


### PR DESCRIPTION
## Summary
- Prevents the login screen from flashing on app launch when the user is already authenticated
- Adds an `isAuthStateResolved` flag that stays `false` until Firebase's auth state listener fires for the first time
- Shows a simple `ProgressView` on the app background color while auth state is being determined

## Changes
- **AuthenticationProtocol.swift**: Added `isAuthStateResolved` to protocol
- **AuthService.swift**: Added `isAuthStateResolved` property, set to `true` at end of auth listener callback
- **PreviewAuthService.swift**: Added `isAuthStateResolved = true` for previews
- **WelcomeView.swift**: Added `isAuthStateResolved = true` to MockAuthService
- **GutCheckApp.swift**: Added loading state branch before the auth check

## Test plan
- [x] Launch app while logged in — should see brief spinner, then dashboard (no login flash)
- [x] Launch app while logged out — should see brief spinner, then login screen
- [x] Sign out and relaunch — login screen appears after spinner
- [x] Force-quit and relaunch while logged in — dashboard appears after spinner

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)