### PR TITLE
fix(#199): reset to Dashboard after background timeout, per-tab navigation paths

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -166,8 +166,8 @@ struct GutCheckApp: App {
             }
             .onChange(of: TimeoutManager.shared.shouldResetToHome) { _, shouldReset in
                 if shouldReset {
-                    // Reset navigation state
-                    AppRouter.shared.navigateToRoot()
+                    // Reset navigation state and return to Dashboard tab
+                    AppRouter.shared.resetToHome()
                     // Reset the timeout state
                     TimeoutManager.shared.resetTimeoutState()
                 }

--- a/GutCheck/GutCheck/Navigation/AppRouter.swift
+++ b/GutCheck/GutCheck/Navigation/AppRouter.swift
@@ -33,15 +33,37 @@ enum SheetDestination: Identifiable {
 class AppRouter: ObservableObject {
     static let shared = AppRouter()
     
-    @Published var path = NavigationPath()
+    // Per-tab navigation paths to prevent cross-tab state leakage
+    @Published var dashboardPath = NavigationPath()
+    @Published var mealsPath = NavigationPath()
+    @Published var symptomsPath = NavigationPath()
     @Published var activeSheet: SheetDestination?
     @Published var selectedTab: Tab = .dashboard
     @Published private var isNavigating = false
     
+    /// The navigation path for the currently selected tab
+    private var activePath: NavigationPath {
+        get {
+            switch selectedTab {
+            case .dashboard: return dashboardPath
+            case .meals: return mealsPath
+            case .symptoms: return symptomsPath
+            default: return NavigationPath()
+            }
+        }
+        set {
+            switch selectedTab {
+            case .dashboard: dashboardPath = newValue
+            case .meals: mealsPath = newValue
+            case .symptoms: symptomsPath = newValue
+            default: break
+            }
+        }
+    }
+    
     // Navigation methods
     func navigateTo(_ destination: AppDestination) {
         print("🧭 AppRouter: Navigating to \(destination)")
-        print("🧭 AppRouter: Current path before navigation: \(path)")
         
         // Prevent duplicate navigation while one is in progress
         guard !isNavigating else {
@@ -51,8 +73,7 @@ class AppRouter: ObservableObject {
         
         isNavigating = true
         
-        path.append(destination)
-        print("🧭 AppRouter: Path now contains \(path.count) destinations: \(path)")
+        activePath.append(destination)
         
         // Reset navigation flag after a short delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -61,18 +82,26 @@ class AppRouter: ObservableObject {
     }
     
     func navigateBack() {
-        if !path.isEmpty {
-            path.removeLast()
+        if !activePath.isEmpty {
+            activePath.removeLast()
         }
     }
     
     func clearNavigationPath() {
-        // NavigationPath doesn't have removeAll, so we'll clear it by setting to empty
-        path = NavigationPath()
+        activePath = NavigationPath()
     }
     
     func navigateToRoot() {
-        path = NavigationPath()
+        activePath = NavigationPath()
+    }
+    
+    /// Reset everything back to the Dashboard tab with empty navigation stacks
+    func resetToHome() {
+        dashboardPath = NavigationPath()
+        mealsPath = NavigationPath()
+        symptomsPath = NavigationPath()
+        activeSheet = nil
+        selectedTab = .dashboard
     }
     
     // Sheet presentation methods

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -7,111 +7,33 @@ struct AppRoot: View {
     
     var body: some View {
         ZStack(alignment: .bottom) {
-            TabView {
-                NavigationStack(path: $router.path) {
+            TabView(selection: $router.selectedTab) {
+                NavigationStack(path: $router.dashboardPath) {
                     DashboardView()
-                        .navigationDestination(for: AppDestination.self) { destination in
-                            switch destination {
-                            case .dashboard:
-                                DashboardView()
-                            case .calendar(let date):
-                                CalendarView(selectedDate: date)
-                            case .mealDetail(let id):
-                                if let id = id {
-                                    MealDetailView(mealId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid meal")
-                                }
-                            case .symptomDetail(let id):
-                                if let id = id {
-                                    SymptomDetailView(symptomId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid symptom")
-                                }
-                            case .settings:
-                                SettingsView()
-                            case .analytics:
-                                InsightsView()
-                            }
-                        }
+                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
                 }
                 .tabItem {
                     Label("Dashboard", systemImage: "house.fill")
                 }
+                .tag(Tab.dashboard)
                 
-                NavigationStack(path: $router.path) {
+                NavigationStack(path: $router.mealsPath) {
                     CalendarView(selectedTab: .meals)
-                        .navigationDestination(for: AppDestination.self) { destination in
-                            switch destination {
-                            case .dashboard:
-                                DashboardView()
-                            case .calendar(let date):
-                                CalendarView(selectedDate: date)
-                            case .mealDetail(let id):
-                                if let id = id {
-                                    MealDetailView(mealId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid meal")
-                                }
-                            case .symptomDetail(let id):
-                                if let id = id {
-                                    SymptomDetailView(symptomId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid symptom")
-                                }
-                            case .settings:
-                                SettingsView()
-                            case .analytics:
-                                InsightsView()
-                            }
-                        }
+                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
                 }
                 .tabItem {
                     Label("Meals", systemImage: "fork.knife")
                 }
+                .tag(Tab.meals)
                 
-                NavigationStack(path: $router.path) {
+                NavigationStack(path: $router.symptomsPath) {
                     CalendarView(selectedTab: .symptoms)
-                        .navigationDestination(for: AppDestination.self) { destination in
-                            switch destination {
-                            case .dashboard:
-                                DashboardView()
-                            case .calendar(let date):
-                                CalendarView(selectedDate: date)
-                            case .mealDetail(let id):
-                                if let id = id {
-                                    MealDetailView(mealId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid meal")
-                                }
-                            case .symptomDetail(let id):
-                                if let id = id {
-                                    SymptomDetailView(symptomId: id)
-                                        .environmentObject(router)
-                                        .environmentObject(refreshManager)
-                                } else {
-                                    Text("Invalid symptom")
-                                }
-                            case .settings:
-                                SettingsView()
-                            case .analytics:
-                                InsightsView()
-                            }
-                        }
+                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
                 }
                 .tabItem {
                     Label("Symptoms", systemImage: "heart.text.square.fill")
                 }
+                .tag(Tab.symptoms)
                 
                 NavigationStack {
                     MedicationCalendarView()
@@ -119,6 +41,7 @@ struct AppRoot: View {
                 .tabItem {
                     Label("Meds", systemImage: "pills.fill")
                 }
+                .tag(Tab.medications)
 
                 NavigationStack {
                     InsightsView()
@@ -126,6 +49,7 @@ struct AppRoot: View {
                 .tabItem {
                     Label("Insights", systemImage: "chart.bar.fill")
                 }
+                .tag(Tab.insights)
             }
             
             // Handle the sheet presentations
@@ -166,6 +90,51 @@ struct AppRoot: View {
 
         .environmentObject(router)
         .environmentObject(refreshManager)
+    }
+}
+
+// MARK: - Shared Navigation Destinations
+
+private struct AppNavigationDestinations: ViewModifier {
+    @ObservedObject var router: AppRouter
+    @ObservedObject var refreshManager: RefreshManager
+
+    func body(content: Content) -> some View {
+        content
+            .navigationDestination(for: AppDestination.self) { destination in
+                switch destination {
+                case .dashboard:
+                    DashboardView()
+                case .calendar(let date):
+                    CalendarView(selectedDate: date)
+                case .mealDetail(let id):
+                    if let id = id {
+                        MealDetailView(mealId: id)
+                            .environmentObject(router)
+                            .environmentObject(refreshManager)
+                    } else {
+                        Text("Invalid meal")
+                    }
+                case .symptomDetail(let id):
+                    if let id = id {
+                        SymptomDetailView(symptomId: id)
+                            .environmentObject(router)
+                            .environmentObject(refreshManager)
+                    } else {
+                        Text("Invalid symptom")
+                    }
+                case .settings:
+                    SettingsView()
+                case .analytics:
+                    InsightsView()
+                }
+            }
+    }
+}
+
+extension View {
+    func withAppNavigationDestinations(router: AppRouter, refreshManager: RefreshManager) -> some View {
+        modifier(AppNavigationDestinations(router: router, refreshManager: refreshManager))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
@@ -53,7 +53,7 @@ struct CustomTabBar: View {
     private func handleTabSelection(_ tab: Tab) {
         print("🔧 CustomTabBar: Handling tab selection for \(tab)")
         print("🔧 Current tab: \(selectedTab), switching to: \(tab)")
-        print("🔧 Current navigation path count: \(router.path.count)")
+        print("🔧 Current tab: \(selectedTab)")
         
         // If switching to a different tab, reset navigation and switch tab
         if selectedTab != tab {
@@ -63,7 +63,7 @@ struct CustomTabBar: View {
             print("🔧 Tab switch completed")
         } else {
             // Same tab selected - pop to root if we're in a navigation stack
-            if !router.path.isEmpty {
+            if true {
                 router.navigateToRoot()
                 print("🔧 Same tab selected - popped to root for tab: \(tab)")
             }

--- a/GutCheck/GutCheck/Views/ContentView.swift
+++ b/GutCheck/GutCheck/Views/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
     
     var body: some View {
         ZStack(alignment: .bottom) {
-            NavigationStack(path: $router.path) {
+            NavigationStack(path: $router.dashboardPath) {
                 Group {
                     switch router.selectedTab {
                     case .dashboard:


### PR DESCRIPTION
## Summary
- App now returns to the Dashboard tab after the 5-minute background timeout instead of staying on the last-visited tab
- Each tab (Dashboard, Meals, Symptoms) now has its own independent `NavigationPath`, fixing cross-tab state leakage from the previously shared single path
- Added `resetToHome()` to `AppRouter` that clears all navigation stacks, dismisses sheets, and switches to Dashboard
- Extracted triplicated `navigationDestination` block into a reusable `withAppNavigationDestinations()` view modifier

Closes #199

## Test plan
- [ ] Navigate to Meals/Symptoms/Meds tab, background app for 5+ minutes, reopen — should return to Dashboard
- [ ] Navigate into a meal detail on Meals tab, switch to Symptoms tab — Meals tab navigation should be independent
- [ ] Tap a tab you're already on — should pop to root of that tab
- [ ] Notification deep-links should still navigate to the correct tab
- [ ] Verify all tabs load and navigate correctly (Dashboard, Meals, Symptoms, Meds, Insights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)