### PR TITLE
feat(#105): add server status offline banner and detail sheet

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -213,6 +213,17 @@ enum AccessibilityIdentifiers {
         static let signOutButton = "profile.signOut.button"
     }
     
+    // MARK: - Server Status
+    enum ServerStatus {
+        static let offlineBanner = "serverStatus.offline.banner"
+        static let statusSheet = "serverStatus.sheet"
+        static let recheckCountdown = "serverStatus.recheck.countdown"
+        static let dismissButton = "serverStatus.dismiss.button"
+        static let whatsHappeningSection = "serverStatus.whatsHappening.section"
+        static let whatStillWorksSection = "serverStatus.whatStillWorks.section"
+        static let temporarilyLimitedSection = "serverStatus.temporarilyLimited.section"
+    }
+    
     // MARK: - Common Components
     enum Common {
         static let loadingIndicator = "common.loading"

--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -126,6 +126,7 @@ struct GutCheckApp: App {
     @StateObject private var coreDataStack = CoreDataStack.shared
     @StateObject private var localStorage = CoreDataStorageService.shared
     @StateObject private var dataSyncService = DataSyncService.shared
+    @StateObject private var serverStatusService = ServerStatusService.shared
     @Environment(\.scenePhase) private var scenePhase
     
     static func testFirebaseConnection() async {
@@ -158,6 +159,7 @@ struct GutCheckApp: App {
                         .environmentObject(coreDataStack)
                         .environmentObject(localStorage)
                         .environmentObject(dataSyncService)
+                        .environmentObject(serverStatusService)
                 } else if authService.isAwaitingEmailVerification {
                     EmailVerificationView(authService: authService)
                 } else {
@@ -172,13 +174,24 @@ struct GutCheckApp: App {
                     TimeoutManager.shared.resetTimeoutState()
                 }
             }
+            .onChange(of: authService.isAuthenticated) { _, isAuthenticated in
+                if isAuthenticated {
+                    serverStatusService.startMonitoring()
+                } else {
+                    serverStatusService.stopMonitoring()
+                }
+            }
             .onChange(of: scenePhase) { oldPhase, newPhase in
                 switch newPhase {
                 case .background:
                     TimeoutManager.shared.applicationDidEnterBackground()
+                    serverStatusService.stopMonitoring()
                 case .active:
                     TimeoutManager.shared.applicationWillEnterForeground()
                     Task { await HealthKitSyncManager.shared.syncIfNeeded() }
+                    if authService.isAuthenticated {
+                        serverStatusService.startMonitoring()
+                    }
                 default:
                     break
                 }

--- a/GutCheck/GutCheck/Services/ServerStatusService.swift
+++ b/GutCheck/GutCheck/Services/ServerStatusService.swift
@@ -1,0 +1,131 @@
+//
+//  ServerStatusService.swift
+//  GutCheck
+//
+//  Monitors Firebase connectivity and network reachability.
+//  Publishes state for the offline banner and server status sheet.
+//
+
+import Foundation
+import Network
+import FirebaseFirestore
+
+@MainActor
+class ServerStatusService: ObservableObject {
+    static let shared = ServerStatusService()
+
+    // MARK: - Published State
+
+    @Published private(set) var isFirebaseReachable: Bool = true
+    @Published private(set) var isNetworkAvailable: Bool = true
+    @Published private(set) var secondsUntilRecheck: Int = 0
+    @Published private(set) var isRechecking: Bool = false
+    @Published private(set) var pendingChangesCount: Int = 0
+
+    /// Toggle from debug views to simulate offline mode
+    @Published var isDebugOfflineMode: Bool = false
+
+    /// Convenience: true when the app should show offline UI
+    var isOffline: Bool {
+        isDebugOfflineMode || !isFirebaseReachable || !isNetworkAvailable
+    }
+
+    // MARK: - Private
+
+    private let networkMonitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "com.gutcheck.serverStatus")
+    private var countdownTimer: Timer?
+    private var isMonitoring = false
+
+    private let recheckInterval: Int = 30
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    func startMonitoring() {
+        guard !isMonitoring else { return }
+        isMonitoring = true
+
+        // Start network path monitor
+        networkMonitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                self?.isNetworkAvailable = path.status == .satisfied
+            }
+        }
+        networkMonitor.start(queue: monitorQueue)
+
+        // Initial Firebase probe after a short delay
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s delay
+            await performFirebaseCheck()
+            startCountdown()
+        }
+    }
+
+    func stopMonitoring() {
+        guard isMonitoring else { return }
+        isMonitoring = false
+        networkMonitor.cancel()
+        countdownTimer?.invalidate()
+        countdownTimer = nil
+    }
+
+    // MARK: - Firebase Probe
+
+    private func performFirebaseCheck() async {
+        isRechecking = true
+        do {
+            let testDoc = FirebaseManager.shared.testDocument("status_check")
+            _ = try await testDoc.getDocument(source: .server)
+            // If we get here, the server responded — Firebase is reachable
+            // (even if the document doesn't exist, the server still responded)
+            isFirebaseReachable = true
+        } catch let error as NSError {
+            // Firestore error domain: "FIRFirestoreErrorDomain"
+            // Code 14 = unavailable (server unreachable)
+            // Code 7 = permission denied (server reachable, auth issue — treat as online)
+            // Code 5 = not found (server reachable — treat as online)
+            let firestoreUnavailableCodes = [14, 4, 13] // unavailable, deadline exceeded, internal
+            if firestoreUnavailableCodes.contains(error.code) {
+                isFirebaseReachable = false
+            } else {
+                // Server responded with an error (permission denied, not found, etc.)
+                // This means Firebase IS reachable
+                isFirebaseReachable = true
+            }
+        }
+        isRechecking = false
+
+        // Refresh pending changes count
+        await refreshPendingChangesCount()
+    }
+
+    private func refreshPendingChangesCount() async {
+        do {
+            let unsynced = try await CoreDataStorageService.shared.getUnsyncedData()
+            pendingChangesCount = unsynced.meals.count + unsynced.symptoms.count + unsynced.settings.count
+        } catch {
+            pendingChangesCount = 0
+        }
+    }
+
+    // MARK: - Countdown Timer
+
+    private func startCountdown() {
+        secondsUntilRecheck = recheckInterval
+        countdownTimer?.invalidate()
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, self.isMonitoring else { return }
+                if self.secondsUntilRecheck > 1 {
+                    self.secondsUntilRecheck -= 1
+                } else {
+                    self.secondsUntilRecheck = 0
+                    await self.performFirebaseCheck()
+                    self.startCountdown()
+                }
+            }
+        }
+    }
+}

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -4,6 +4,8 @@ struct AppRoot: View {
     @StateObject private var router = AppRouter.shared
     @StateObject private var refreshManager = RefreshManager.shared
     @EnvironmentObject var authService: AuthService
+    @EnvironmentObject var serverStatusService: ServerStatusService
+    @State private var showingServerStatusSheet = false
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -50,6 +52,17 @@ struct AppRoot: View {
                     Label("Insights", systemImage: "chart.bar.fill")
                 }
                 .tag(Tab.insights)
+            }
+            
+            .safeAreaInset(edge: .top) {
+                OfflineBannerView(showingStatusSheet: $showingServerStatusSheet)
+                    .animation(.easeInOut(duration: 0.3), value: serverStatusService.isOffline)
+            }
+            
+            // Server status sheet (separate from router sheets)
+            .sheet(isPresented: $showingServerStatusSheet) {
+                ServerStatusSheet()
+                    .environmentObject(serverStatusService)
             }
             
             // Handle the sheet presentations

--- a/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
@@ -1,0 +1,44 @@
+//
+//  OfflineBannerView.swift
+//  GutCheck
+//
+//  Tappable orange "Offline" pill that appears at the top of the app
+//  when Firebase is unreachable. Opens the ServerStatusSheet on tap.
+//
+
+import SwiftUI
+
+struct OfflineBannerView: View {
+    @EnvironmentObject private var serverStatus: ServerStatusService
+    @Binding var showingStatusSheet: Bool
+
+    var body: some View {
+        if serverStatus.isOffline {
+            Button {
+                HapticManager.shared.medium()
+                showingStatusSheet = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "icloud.slash")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text("Offline")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule()
+                        .fill(ColorTheme.warning)
+                )
+            }
+            .accessibilityId(AccessibilityIdentifiers.ServerStatus.offlineBanner)
+            .accessibilityLabel("Offline status")
+            .accessibilityHint("Tap to view server status details")
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .padding(.top, 4)
+            .padding(.bottom, 8)
+        }
+    }
+}

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusRow.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusRow.swift
@@ -1,0 +1,46 @@
+//
+//  ServerStatusRow.swift
+//  GutCheck
+//
+//  Reusable row for the Server Status sheet — icon + title + optional subtitle.
+//
+
+import SwiftUI
+
+struct ServerStatusRow: View {
+    let icon: String
+    let iconColor: Color
+    let title: String
+    var subtitle: String? = nil
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(iconColor)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(ColorTheme.primaryText)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(ColorTheme.secondaryText)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(ColorTheme.cardBackground)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title)\(subtitle.map { ", \($0)" } ?? "")")
+    }
+}

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -1,0 +1,244 @@
+//
+//  ServerStatusSheet.swift
+//  GutCheck
+//
+//  Half-sheet / full-sheet showing server status details, recheck countdown,
+//  and lists of working vs. limited features.
+//
+
+import SwiftUI
+
+struct ServerStatusSheet: View {
+    @EnvironmentObject private var serverStatus: ServerStatusService
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    // Recheck countdown pill
+                    HStack {
+                        Spacer()
+                        recheckCountdownPill
+                        Spacer()
+                    }
+
+                    // Warning badges
+                    warningBadges
+
+                    // What's happening
+                    whatsHappeningSection
+
+                    // What still works
+                    whatStillWorksSection
+
+                    // Temporarily limited
+                    temporarilyLimitedSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 32)
+            }
+            .background(ColorTheme.background)
+            .navigationTitle("Server Status")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Image(systemName: "icloud.slash")
+                        .foregroundColor(ColorTheme.warning)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(ColorTheme.secondaryText)
+                    }
+                    .accessibilityId(AccessibilityIdentifiers.ServerStatus.dismissButton)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .onChange(of: serverStatus.isOffline) { _, isOffline in
+            if !isOffline {
+                dismiss()
+            }
+        }
+    }
+
+    // MARK: - Recheck Countdown Pill
+
+    private var recheckCountdownPill: some View {
+        HStack(spacing: 6) {
+            if serverStatus.isRechecking {
+                ProgressView()
+                    .tint(.white)
+                    .scaleEffect(0.7)
+                Text("Checking...")
+                    .font(.caption)
+                    .fontWeight(.medium)
+            } else {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Rechecking in \(serverStatus.secondsUntilRecheck)s")
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(ColorTheme.warning))
+        .accessibilityId(AccessibilityIdentifiers.ServerStatus.recheckCountdown)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            serverStatus.isRechecking
+                ? "Checking server connectivity"
+                : "Rechecking server in \(serverStatus.secondsUntilRecheck) seconds"
+        )
+    }
+
+    // MARK: - Warning Badges
+
+    private var warningBadges: some View {
+        VStack(spacing: 8) {
+            if !serverStatus.isNetworkAvailable {
+                warningBadge("No internet connection")
+            }
+            if !serverStatus.isFirebaseReachable && serverStatus.isNetworkAvailable {
+                warningBadge("Firebase is experiencing issues")
+            }
+            if serverStatus.isDebugOfflineMode {
+                warningBadge("Simulated server outage (debug)")
+            }
+        }
+    }
+
+    private func warningBadge(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(ColorTheme.warning)
+            Text(message)
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(ColorTheme.warning)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(ColorTheme.warning.opacity(0.1))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(ColorTheme.warning.opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - What's Happening
+
+    private var whatsHappeningSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("What's happening")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            ServerStatusRow(
+                icon: "exclamationmark.triangle.fill",
+                iconColor: ColorTheme.warning,
+                title: "Services degraded",
+                subtitle: serverStatus.isNetworkAvailable
+                    ? "Firebase servers are unreachable"
+                    : "No internet connection detected"
+            )
+
+            ServerStatusRow(
+                icon: "lock.shield.fill",
+                iconColor: ColorTheme.success,
+                title: "Your data is safe",
+                subtitle: "All entries are stored locally on this device"
+            )
+
+            ServerStatusRow(
+                icon: "arrow.triangle.2.circlepath",
+                iconColor: ColorTheme.info,
+                title: "Automatic sync",
+                subtitle: "Any changes you make will sync automatically when servers return"
+            )
+
+            ServerStatusRow(
+                icon: "clock.fill",
+                iconColor: ColorTheme.warning,
+                title: "Pending changes",
+                subtitle: "\(serverStatus.pendingChangesCount) item\(serverStatus.pendingChangesCount == 1 ? "" : "s") waiting to sync"
+            )
+        }
+        .accessibilityId(AccessibilityIdentifiers.ServerStatus.whatsHappeningSection)
+    }
+
+    // MARK: - What Still Works
+
+    private var whatStillWorksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("What still works")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            ServerStatusRow(
+                icon: "checkmark.circle.fill",
+                iconColor: ColorTheme.success,
+                title: "Logging food"
+            )
+
+            ServerStatusRow(
+                icon: "checkmark.circle.fill",
+                iconColor: ColorTheme.success,
+                title: "Viewing your journal"
+            )
+
+            ServerStatusRow(
+                icon: "checkmark.circle.fill",
+                iconColor: ColorTheme.success,
+                title: "Tracking daily totals"
+            )
+
+            ServerStatusRow(
+                icon: "checkmark.circle.fill",
+                iconColor: ColorTheme.success,
+                title: "Saving meals"
+            )
+        }
+        .accessibilityId(AccessibilityIdentifiers.ServerStatus.whatStillWorksSection)
+    }
+
+    // MARK: - Temporarily Limited
+
+    private var temporarilyLimitedSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Temporarily limited")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            ServerStatusRow(
+                icon: "exclamationmark.triangle.fill",
+                iconColor: ColorTheme.warning,
+                title: "AI food analysis"
+            )
+
+            ServerStatusRow(
+                icon: "exclamationmark.triangle.fill",
+                iconColor: ColorTheme.warning,
+                title: "Cross-device sync"
+            )
+        }
+        .accessibilityId(AccessibilityIdentifiers.ServerStatus.temporarilyLimitedSection)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ServerStatusSheet()
+        .environmentObject(ServerStatusService.shared)
+}


### PR DESCRIPTION
## Summary
- Added `ServerStatusService` that monitors Firebase connectivity via periodic server probes (30s interval) and `NWPathMonitor` for network reachability
- When offline, an orange "Offline" pill badge appears at the top of all tabs via `.safeAreaInset`
- Tapping the pill opens a half-sheet (expandable to full) with server status details, recheck countdown timer, and feature availability lists
- Firebase probe correctly distinguishes between server unreachable (codes 14, 4, 13) vs. server-responded errors (permission denied, not found)

## New Files
- `ServerStatusService.swift` — core monitoring service with countdown timer
- `OfflineBannerView.swift` — tappable orange capsule badge
- `ServerStatusSheet.swift` — detail sheet with `.presentationDetents([.medium, .large])`
- `ServerStatusRow.swift` — reusable status row component

## Modified Files
- `AppRoot.swift` — wired in banner overlay and server status sheet
- `GutCheckApp.swift` — injected service, start/stop monitoring on auth and scene phase
- `AccessibilityIdentifiers.swift` — added `ServerStatus` identifiers

## Test plan
- [ ] Verify no offline banner appears when connected normally
- [ ] Enable airplane mode — verify orange "Offline" pill appears at top
- [ ] Tap the pill — verify half-sheet opens with countdown timer
- [ ] Drag sheet to expand — verify "What still works" and "Temporarily limited" sections
- [ ] Disable airplane mode — verify banner disappears and sheet auto-dismisses
- [ ] Verify banner is visible across all 5 tabs

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)