### PR TITLE
feat(#47): add account & security management to Settings

### DIFF
--- a/GutCheck/GutCheck/Services/Firebase/AuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthService.swift
@@ -380,6 +380,36 @@ class AuthService: AuthenticationProtocol, HasLoadingState {
         }
     }
     
+    /// Delete the account after the user has already been re-authenticated.
+    /// Call this after ReauthenticationView succeeds.
+    func deleteAuthenticatedAccount() async throws {
+        guard let currentFirebaseUser = authUser else {
+            throw AuthError.noUser
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        defer { isLoading = false }
+        
+        do {
+            print("🗑️ AuthService: Deleting user data from Firestore")
+            try await deleteUserData(userId: currentFirebaseUser.uid)
+            
+            print("🗑️ AuthService: Deleting Firebase Auth account")
+            try await currentFirebaseUser.delete()
+            
+            authUser = nil
+            currentUser = nil
+            isAuthenticated = false
+            
+            print("✅ AuthService: Account deleted successfully")
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+    
     /// Convenience method for deleting account with email/password
     func deleteAccountWithEmail(email: String, password: String) async throws {
         let credential = EmailAuthProvider.credential(withEmail: email, password: password)

--- a/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
+++ b/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
@@ -16,7 +16,7 @@ struct ReauthenticationView: View {
     let onSuccess: () -> Void
     let onCancel: () -> Void
     
-    @StateObject private var authService = AuthService()
+    @EnvironmentObject var authService: AuthService
     @State private var email = ""
     @State private var password = ""
     @State private var showPhoneAuth = false
@@ -147,7 +147,7 @@ struct PhoneReauthenticationView: View {
     let onSuccess: () -> Void
     let onCancel: () -> Void
     
-    @StateObject private var authService = AuthService()
+    @EnvironmentObject var authService: AuthService
     @State private var phoneNumber = ""
     @State private var verificationCode = ""
     @State private var codeSent = false

--- a/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
+++ b/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct DeleteAccountView: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var authService = AuthService()
+    @EnvironmentObject var authService: AuthService
     @State private var showingReauthentication = false
     @State private var showingFinalConfirmation = false
     @State private var showingAlert = false
@@ -117,7 +117,11 @@ struct DeleteAccountView: View {
             Text("Are you absolutely sure you want to delete your account? This action is permanent and cannot be undone.")
         }
         .alert(alertTitle, isPresented: $showingAlert) {
-            Button("OK") { }
+            Button("OK") {
+                if alertTitle == "Account Deleted" {
+                    dismiss()
+                }
+            }
         } message: {
             Text(alertMessage)
         }
@@ -128,16 +132,13 @@ struct DeleteAccountView: View {
         
         Task {
             do {
-                // For now, we'll use a placeholder credential
-                // In a real implementation, you'd collect the user's password or use a stored credential
-                // This is a simplified version - you might want to enhance this
-                try await authService.deleteAccountWithEmail(email: "user@example.com", password: "password")
+                // User was already re-authenticated via ReauthenticationView
+                try await authService.deleteAuthenticatedAccount()
                 
                 await MainActor.run {
                     alertTitle = "Account Deleted"
-                    alertMessage = "Your account has been successfully deleted. You will be signed out."
+                    alertMessage = "Your account has been successfully deleted."
                     showingAlert = true
-                    dismiss()
                 }
             } catch {
                 await MainActor.run {
@@ -192,5 +193,6 @@ struct DataRow: View {
 #Preview {
     NavigationStack {
         DeleteAccountView()
+            .environmentObject(AuthService())
     }
 }

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -196,6 +196,45 @@ struct SettingsView: View {
                 }
                 
                 Section("Account Management") {
+                    // Linked account display
+                    if let user = authService.currentUser {
+                        HStack(spacing: 12) {
+                            Image(systemName: user.signInMethod.icon)
+                                .foregroundColor(ColorTheme.primary)
+                                .frame(width: 20)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Signed in with \(user.signInMethod.displayName)")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Text(user.email)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(ColorTheme.success)
+                        }
+                        .padding(.vertical, 4)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Signed in with \(user.signInMethod.displayName), \(user.email)")
+                    }
+                    
+                    // Sign out
+                    Button {
+                        HapticManager.shared.medium()
+                        try? authService.signOut()
+                    } label: {
+                        HStack {
+                            Image(systemName: "rectangle.portrait.and.arrow.right")
+                                .foregroundColor(.orange)
+                            Text("Sign Out")
+                                .foregroundColor(ColorTheme.primaryText)
+                        }
+                    }
+                    .accessibilityLabel("Sign Out")
+                    .accessibilityHint("Tap to sign out of your account")
+                    
+                    // Delete account
                     NavigationLink(destination: DeleteAccountView()) {
                         HStack {
                             Image(systemName: "trash")


### PR DESCRIPTION
## Summary
- Added **linked account display** in Settings > Account Management showing the user's sign-in method (Email/Apple/Phone) with provider icon and email
- Added **Sign Out button** to Settings for discoverability (previously only in Profile view)
- **Fixed critical bug** in DeleteAccountView where hardcoded dummy credentials were used, causing account deletion to always fail
- Fixed `DeleteAccountView` and `ReauthenticationView` to use `@EnvironmentObject` instead of creating duplicate `AuthService` instances (which caused re-auth to operate on a different session)
- Added `deleteAuthenticatedAccount()` to `AuthService` — deletes data + account after re-auth has already succeeded

## Files Changed
- `SettingsView.swift` — added linked account row and sign out button to Account Management section
- `DeleteAccountView.swift` — fixed `@EnvironmentObject`, replaced dummy credentials with `deleteAuthenticatedAccount()`
- `ReauthenticationView.swift` — fixed both `ReauthenticationView` and `PhoneReauthenticationView` to use `@EnvironmentObject`
- `AuthService.swift` — added `deleteAuthenticatedAccount()` method

## Test plan
- [ ] Open Settings > Account Management — verify linked account shows correct provider and email
- [ ] Tap Sign Out in Settings — verify user is signed out
- [ ] Tap Delete Account — verify re-authentication flow works
- [ ] After re-auth, confirm deletion — verify account is deleted and user is signed out
- [ ] Test with Email sign-in method
- [ ] Test with Apple sign-in method (if available)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)