### PR TITLE
feat(#58): handle offline mode UI state with sync timestamp and retry

### DIFF
--- a/GutCheck/GutCheck/Services/ServerStatusService.swift
+++ b/GutCheck/GutCheck/Services/ServerStatusService.swift
@@ -30,6 +30,16 @@ class ServerStatusService: ObservableObject {
         isDebugOfflineMode || !isFirebaseReachable || !isNetworkAvailable
     }
 
+    /// Human-readable description of the last successful sync time
+    var lastSyncDescription: String {
+        guard let date = DataSyncService.shared.lastSyncDate else {
+            return "Never synced"
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
     // MARK: - Private
 
     private let networkMonitor = NWPathMonitor()

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ServerStatusSheet: View {
     @EnvironmentObject private var serverStatus: ServerStatusService
+    @ObservedObject private var syncService = DataSyncService.shared
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -173,6 +174,15 @@ struct ServerStatusSheet: View {
                 title: "Pending changes",
                 subtitle: "\(serverStatus.pendingChangesCount) item\(serverStatus.pendingChangesCount == 1 ? "" : "s") waiting to sync"
             )
+
+            ServerStatusRow(
+                icon: "checkmark.icloud.fill",
+                iconColor: syncService.lastSyncDate != nil ? ColorTheme.success : ColorTheme.secondaryText,
+                title: "Last synced",
+                subtitle: serverStatus.lastSyncDescription
+            )
+
+            syncNowButton
         }
         .accessibilityId(AccessibilityIdentifiers.ServerStatus.whatsHappeningSection)
     }
@@ -233,6 +243,40 @@ struct ServerStatusSheet: View {
             )
         }
         .accessibilityId(AccessibilityIdentifiers.ServerStatus.temporarilyLimitedSection)
+    }
+
+    // MARK: - Sync Now Button
+
+    private var syncNowButton: some View {
+        Button {
+            Task {
+                try? await syncService.performFullSync()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if syncService.isSyncing {
+                    ProgressView()
+                        .tint(.white)
+                        .scaleEffect(0.7)
+                    Text("Syncing...")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                } else {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text("Sync Now")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+            .background(Capsule().fill(syncService.isSyncing ? ColorTheme.secondaryText : ColorTheme.info))
+        }
+        .disabled(syncService.isSyncing)
+        .accessibilityLabel(syncService.isSyncing ? "Syncing in progress" : "Sync now")
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Last synced" row to the Server Status sheet showing the last successful sync time using `RelativeDateTimeFormatter` (e.g., "5 minutes ago") or "Never synced"
- Adds a "Sync Now" capsule button that triggers `DataSyncService.performFullSync()`, with a spinner while syncing and disabled state during active sync
- The offline banner/icon requirement was already implemented in PR #209 (Issue #105)

Closes #58

## Test plan
- [ ] Verify "Last synced" row appears in the Server Status sheet with correct relative timestamp
- [ ] Verify "Never synced" displays when no sync has occurred
- [ ] Tap "Sync Now" and verify spinner appears while syncing
- [ ] Verify button is disabled during active sync
- [ ] Verify offline banner still appears correctly when toggling airplane mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)