### PR TITLE
feat(#59): disable AI and food search when offline

### DIFF
--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -10,6 +10,7 @@ import Combine
 
 struct FoodSearchView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var serverStatus: ServerStatusService
     @StateObject private var viewModel = FoodSearchViewModel()
     @State private var navigationPath = NavigationPath()
     @State private var selectedFoodItem: FoodItem?
@@ -29,6 +30,7 @@ struct FoodSearchView: View {
                             .textFieldStyle(RoundedBorderTextFieldStyle())
                             .typography(Typography.body)
                             .onSubmit {
+                                guard !serverStatus.isOffline else { return }
                                 HapticManager.shared.light()
                                 viewModel.search()
                             }
@@ -52,7 +54,7 @@ struct FoodSearchView: View {
                             .background(ColorTheme.accent)
                             .cornerRadius(8)
                         }
-                        .disabled(viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || serverStatus.isOffline)
                         .accessibleButton(
                             label: "Search",
                             hint: viewModel.searchQuery.isEmpty 
@@ -86,7 +88,9 @@ struct FoodSearchView: View {
                 .padding()
 
                 // Results or suggestions
-                if viewModel.isSearching {
+                if serverStatus.isOffline {
+                    offlineView
+                } else if viewModel.isSearching {
                     loadingView
                 } else if !viewModel.hasSearched && viewModel.searchQuery.isEmpty {
                     suggestionsList
@@ -100,11 +104,11 @@ struct FoodSearchView: View {
                         Image(systemName: "magnifyingglass")
                             .font(.system(size: 36))
                             .foregroundColor(ColorTheme.accent.opacity(0.6))
-                        
+
                         Text("Ready to Search")
                             .font(.headline)
                             .foregroundColor(ColorTheme.primaryText)
-                        
+
                         Text("Tap the Search button to find foods")
                             .font(.subheadline)
                             .foregroundColor(ColorTheme.secondaryText)
@@ -150,6 +154,50 @@ struct FoodSearchView: View {
         }
     }
     
+    private var offlineView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 48))
+                .foregroundColor(ColorTheme.warning)
+
+            Text("You're Offline")
+                .typography(Typography.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            Text("Food search requires an internet connection.\nYou can still add food manually.")
+                .typography(Typography.subheadline)
+                .foregroundColor(ColorTheme.secondaryText)
+                .multilineTextAlignment(.center)
+
+            Button {
+                HapticManager.shared.medium()
+                let customFoodItem = FoodItem(
+                    name: viewModel.searchQuery.isEmpty ? "Custom Food" : viewModel.searchQuery,
+                    quantity: "1 serving",
+                    nutrition: NutritionInfo()
+                )
+                selectedFoodItem = customFoodItem
+            } label: {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Custom Food")
+                        .typography(Typography.button)
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(ColorTheme.primary)
+                .cornerRadius(10)
+            }
+            .accessibleButton(
+                label: "Add Custom Food",
+                hint: "Create a custom food item with manual entry"
+            )
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var loadingView: some View {
         VStack(spacing: 16) {
             ProgressView()

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -4,6 +4,7 @@ struct MealConfirmationView: View {
     let meal: Meal
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var router: AppRouter
+    @EnvironmentObject private var serverStatus: ServerStatusService
     @StateObject private var viewModel = MealConfirmationViewModel()
     
     var body: some View {
@@ -60,21 +61,32 @@ struct MealConfirmationView: View {
                 .roundedCard()
                 
                 // AI Analysis
-                if let analysis = viewModel.aiAnalysis {
+                if serverStatus.isOffline {
+                    HStack(spacing: 8) {
+                        Image(systemName: "wifi.slash")
+                            .foregroundColor(ColorTheme.secondaryText)
+                        Text("AI analysis unavailable while offline")
+                            .font(.subheadline)
+                            .foregroundColor(ColorTheme.secondaryText)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .roundedCard()
+                } else if let analysis = viewModel.aiAnalysis {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Smart Analysis")
                             .font(.title2)
                             .bold()
-                        
+
                         ForEach(analysis.insights, id: \.self) { insight in
                             Label(insight, systemImage: "brain")
                                 .font(.subheadline)
                                 .padding(.vertical, 4)
                         }
-                        
+
                         if !analysis.warnings.isEmpty {
                             Divider()
-                            
+
                             ForEach(analysis.warnings, id: \.self) { warning in
                                 Label(warning, systemImage: "exclamationmark.triangle")
                                     .font(.subheadline)
@@ -128,6 +140,7 @@ struct MealConfirmationView: View {
             Text(viewModel.errorMessage ?? "An unknown error occurred")
         })
         .task {
+            guard !serverStatus.isOffline else { return }
             await viewModel.analyzeMeal(meal)
         }
     }
@@ -286,5 +299,6 @@ struct MealAnalysis {
             createdBy: "preview-user"
         ))
         .environmentObject(AppRouter.shared)
+        .environmentObject(ServerStatusService.shared)
     }
 }


### PR DESCRIPTION
## Summary
- Disables food search in `FoodSearchView` when offline — shows a "You're Offline" message with `wifi.slash` icon and a prominent "Add Custom Food" button for manual entry fallback
- Skips AI meal analysis in `MealConfirmationView` when offline — shows "AI analysis unavailable while offline" info row instead
- Search button and keyboard submit are disabled when offline to prevent failed network requests

Note: AI Photo recognition and Barcode Scanner features are scaffolded but have no active UI entry points yet, so no additional gating was needed for those.

Closes #59

## Test plan
- [ ] Toggle airplane mode and open food search — verify offline view appears with "Add Custom Food" button
- [ ] Verify "Add Custom Food" opens manual food entry while offline
- [ ] Toggle airplane mode off — verify normal search behavior resumes
- [ ] Confirm a meal while offline — verify "AI analysis unavailable while offline" message appears
- [ ] Confirm a meal while online — verify Smart Analysis section works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)