### PR TITLE
feat(#36): build insights dashboard summary cards

### DIFF
--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Ranked item for display in summary cards
+struct RankedItem: Identifiable {
+    let id = UUID()
+    let name: String
+    let count: Int
+}
+
 @MainActor
 class InsightsViewModel: ObservableObject {
     @Published var recentInsights: [HealthInsight] = []
@@ -7,7 +14,15 @@ class InsightsViewModel: ObservableObject {
     @Published var recommendations: [HealthRecommendation] = []
     @Published var isLoading = false
     @Published var error: String?
-    
+
+    // MARK: - Weekly Summary Data
+
+    @Published var weeklyMealCount: Int = 0
+    @Published var weeklySymptomCount: Int = 0
+    @Published var topSymptoms: [RankedItem] = []
+    @Published var topTriggerFoods: [RankedItem] = []
+    @Published var bestDays: [RankedItem] = []
+
     private let insightsService = InsightsService.shared
     private let mealRepository = MealRepository.shared
     private let symptomRepository = SymptomRepository.shared
@@ -57,7 +72,10 @@ class InsightsViewModel: ObservableObject {
             // Convert insights to patterns and recommendations
             patterns = convertInsightsToPatterns(recentInsights)
             recommendations = convertInsightsToRecommendations(recentInsights)
-            
+
+            // Compute weekly summary cards
+            computeWeeklySummaries(meals: meals, symptoms: symptoms)
+
         } catch {
             self.error = error.localizedDescription
             print("❌ Error loading insights: \(error)")
@@ -119,14 +137,144 @@ class InsightsViewModel: ObservableObject {
     }
     
     private func getCurrentUserId() -> String {
-        // Get the current user ID from the authentication service
         if let currentUser = authService.currentUser {
             return currentUser.id
         } else {
-            // Fallback to a default if no user is authenticated
-            // This should rarely happen in a properly authenticated app
             print("⚠️ InsightsViewModel: No authenticated user found, using default user ID")
             return "default_user"
         }
+    }
+
+    // MARK: - Weekly Summary Computation
+
+    private func computeWeeklySummaries(meals: [Meal], symptoms: [Symptom]) {
+        let calendar = Calendar.current
+        let now = Date()
+        let weekAgo = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+
+        let weekMeals = meals.filter { $0.date >= weekAgo }
+        let weekSymptoms = symptoms.filter { $0.date >= weekAgo }
+
+        weeklyMealCount = weekMeals.count
+        weeklySymptomCount = weekSymptoms.count
+
+        computeTopSymptoms(from: weekSymptoms)
+        computeTriggerFoods(meals: meals, symptoms: symptoms)
+        computeBestDays(symptoms: symptoms)
+    }
+
+    /// Rank symptom characteristics by frequency this week
+    private func computeTopSymptoms(from symptoms: [Symptom]) {
+        var counts: [String: Int] = [:]
+
+        for symptom in symptoms {
+            if symptom.painLevel != .none {
+                let label: String
+                switch symptom.painLevel {
+                case .mild: label = "Mild Pain"
+                case .moderate: label = "Moderate Pain"
+                case .severe: label = "Severe Pain"
+                case .none: continue
+                }
+                counts[label, default: 0] += 1
+            }
+
+            if symptom.urgencyLevel != .none {
+                let label: String
+                switch symptom.urgencyLevel {
+                case .mild: label = "Mild Urgency"
+                case .moderate: label = "Moderate Urgency"
+                case .urgent: label = "High Urgency"
+                case .none: continue
+                }
+                counts[label, default: 0] += 1
+            }
+
+            // Count abnormal stool types (Bristol 1-2 = constipation, 6-7 = diarrhea)
+            switch symptom.stoolType {
+            case .type1, .type2:
+                counts["Constipation", default: 0] += 1
+            case .type6, .type7:
+                counts["Loose Stool", default: 0] += 1
+            default:
+                break
+            }
+        }
+
+        topSymptoms = counts
+            .sorted { $0.value > $1.value }
+            .prefix(3)
+            .map { RankedItem(name: $0.key, count: $0.value) }
+    }
+
+    /// Find foods eaten 2-8 hours before symptoms, rank by frequency
+    private func computeTriggerFoods(meals: [Meal], symptoms: [Symptom]) {
+        var foodCounts: [String: Int] = [:]
+
+        for symptom in symptoms {
+            // Only consider symptoms with actual issues
+            guard symptom.painLevel != .none || symptom.urgencyLevel != .none
+                    || symptom.stoolType == .type1 || symptom.stoolType == .type2
+                    || symptom.stoolType == .type6 || symptom.stoolType == .type7 else {
+                continue
+            }
+
+            // Find meals eaten 2-8 hours before this symptom
+            let windowStart = symptom.date.addingTimeInterval(-8 * 3600)
+            let windowEnd = symptom.date.addingTimeInterval(-2 * 3600)
+
+            let precedingMeals = meals.filter { $0.date >= windowStart && $0.date <= windowEnd }
+
+            for meal in precedingMeals {
+                for item in meal.foodItems {
+                    foodCounts[item.name, default: 0] += 1
+                }
+            }
+        }
+
+        topTriggerFoods = foodCounts
+            .sorted { $0.value > $1.value }
+            .prefix(3)
+            .map { RankedItem(name: $0.key, count: $0.value) }
+    }
+
+    /// Rank days of the week by lowest symptom count (last 30 days)
+    private func computeBestDays(symptoms: [Symptom]) {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        let dayNames = formatter.weekdaySymbols ?? ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+        // Count symptoms per weekday
+        var dayCounts: [Int: Int] = [:]  // weekday (1=Sun..7=Sat) → count
+        var dayOccurrences: [Int: Int] = [:]  // how many of each weekday are in the 30-day range
+
+        let now = Date()
+        let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now) ?? now
+
+        // Count occurrences of each weekday in the range
+        var cursor = thirtyDaysAgo
+        while cursor <= now {
+            let weekday = calendar.component(.weekday, from: cursor)
+            dayOccurrences[weekday, default: 0] += 1
+            cursor = calendar.date(byAdding: .day, value: 1, to: cursor) ?? now.addingTimeInterval(86400)
+        }
+
+        for symptom in symptoms {
+            let weekday = calendar.component(.weekday, from: symptom.date)
+            dayCounts[weekday, default: 0] += 1
+        }
+
+        // Rank by lowest average symptoms per day occurrence
+        bestDays = (1...7)
+            .map { weekday -> (String, Double) in
+                let count = Double(dayCounts[weekday] ?? 0)
+                let occurrences = Double(dayOccurrences[weekday] ?? 1)
+                let avg = occurrences > 0 ? count / occurrences : 0
+                return (dayNames[weekday - 1], avg)
+            }
+            .sorted { $0.1 < $1.1 }
+            .prefix(3)
+            .map { RankedItem(name: $0.0, count: Int($0.1 * 10)) }  // Store avg * 10 for display precision
     }
 }

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -16,6 +16,14 @@ struct InsightsView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
+                    // Weekly Stats Row
+                    weeklyStatsRow
+
+                    // Top Summary Cards
+                    topSymptomsCard
+                    triggerFoodsCard
+                    bestDaysCard
+
                     // Recent Insights Section
                     if !viewModel.recentInsights.isEmpty {
                         recentInsightsSection
@@ -112,9 +120,193 @@ struct InsightsView: View {
             }
         }
     }
+
+    // MARK: - Summary Cards
+
+    private var weeklyStatsRow: some View {
+        HStack(spacing: 12) {
+            WeeklyStatPill(
+                icon: "fork.knife",
+                value: "\(viewModel.weeklyMealCount)",
+                label: "Meals",
+                color: ColorTheme.primary
+            )
+            WeeklyStatPill(
+                icon: "heart.text.clipboard",
+                value: "\(viewModel.weeklySymptomCount)",
+                label: "Symptoms",
+                color: viewModel.weeklySymptomCount > 0 ? ColorTheme.warning : ColorTheme.success
+            )
+            WeeklyStatPill(
+                icon: "calendar",
+                value: "7d",
+                label: "This Week",
+                color: ColorTheme.accent
+            )
+        }
+    }
+
+    private var topSymptomsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Most Frequent Symptoms", systemImage: "chart.bar.fill")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            if viewModel.topSymptoms.isEmpty {
+                Text("No symptoms logged this week")
+                    .font(.subheadline)
+                    .foregroundColor(ColorTheme.secondaryText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+            } else {
+                ForEach(Array(viewModel.topSymptoms.enumerated()), id: \.element.id) { index, item in
+                    HStack(spacing: 12) {
+                        Text("\(index + 1)")
+                            .font(.caption.bold())
+                            .foregroundColor(.white)
+                            .frame(width: 22, height: 22)
+                            .background(Circle().fill(rankColor(index)))
+
+                        Text(item.name)
+                            .font(.subheadline)
+                            .foregroundColor(ColorTheme.primaryText)
+
+                        Spacer()
+
+                        Text("\(item.count)×")
+                            .font(.subheadline.bold())
+                            .foregroundColor(ColorTheme.secondaryText)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    private var triggerFoodsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Top Triggering Foods", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            if viewModel.topTriggerFoods.isEmpty {
+                Text("Not enough data to identify triggers yet")
+                    .font(.subheadline)
+                    .foregroundColor(ColorTheme.secondaryText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+            } else {
+                ForEach(Array(viewModel.topTriggerFoods.enumerated()), id: \.element.id) { index, item in
+                    HStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundColor(rankColor(index))
+
+                        Text(item.name)
+                            .font(.subheadline)
+                            .foregroundColor(ColorTheme.primaryText)
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        Text("\(item.count) correlation\(item.count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundColor(ColorTheme.secondaryText)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    private var bestDaysCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Best Days", systemImage: "checkmark.seal.fill")
+                .font(.headline)
+                .foregroundColor(ColorTheme.primaryText)
+
+            if viewModel.bestDays.isEmpty {
+                Text("Log symptoms for a week to see your best days")
+                    .font(.subheadline)
+                    .foregroundColor(ColorTheme.secondaryText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+            } else {
+                ForEach(Array(viewModel.bestDays.enumerated()), id: \.element.id) { index, item in
+                    HStack(spacing: 12) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(ColorTheme.success)
+
+                        Text(item.name)
+                            .font(.subheadline)
+                            .foregroundColor(ColorTheme.primaryText)
+
+                        Spacer()
+
+                        if item.count == 0 {
+                            Text("Symptom-free")
+                                .font(.caption)
+                                .foregroundColor(ColorTheme.success)
+                        } else {
+                            Text("Low symptoms")
+                                .font(.caption)
+                                .foregroundColor(ColorTheme.secondaryText)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    private func rankColor(_ index: Int) -> Color {
+        switch index {
+        case 0: return .red
+        case 1: return .orange
+        case 2: return .yellow
+        default: return .gray
+        }
+    }
 }
 
 // MARK: - Supporting Views
+
+private struct WeeklyStatPill: View {
+    let icon: String
+    let value: String
+    let label: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundColor(color)
+
+            Text(value)
+                .font(.title2.bold())
+                .foregroundColor(ColorTheme.primaryText)
+
+            Text(label)
+                .font(.caption)
+                .foregroundColor(ColorTheme.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(ColorTheme.surface)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+    }
+}
 
 private struct AnalyticsInsightCard: View {
     let insight: HealthInsight


### PR DESCRIPTION
## Summary
- Adds weekly stats row (meals count, symptoms count, 7-day window) at the top of the Insights tab
- Adds "Most Frequent Symptoms" card ranking pain levels, urgency, and stool type issues by frequency
- Adds "Top Triggering Foods" card correlating foods eaten 2-8 hours before symptoms
- Adds "Best Days" card ranking weekdays by lowest symptom count over the last 30 days
- Computes all summary data in `InsightsViewModel.computeWeeklySummaries()` from existing meal/symptom repositories
- Graceful empty states when insufficient data is available

## Test plan
- [ ] Verify the Insights tab displays the three stat pills at the top
- [ ] Verify empty state messages appear when no meals/symptoms are logged
- [ ] Log meals and symptoms, confirm summary cards populate with correct data
- [ ] Verify trigger food correlations use the 2-8 hour window correctly
- [ ] Verify best days ranking reflects actual symptom patterns
- [ ] Confirm existing insights sections (recent insights, categories, patterns, recommendations) remain unchanged below the new cards

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)