### PR TITLE
feat(#233): replace .tabItem with modern Tab API in AppRoot

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -293,8 +293,8 @@ extension View {
  
  5. Tab bar items:
  ```swift
- .tabItem {
-     Label("Dashboard", systemImage: "house.fill")
+ Tab("Dashboard", systemImage: "house.fill", value: .dashboard) {
+     DashboardView()
  }
  .accessibilityId(AccessibilityIdentifiers.TabBar.dashboard)
  ```

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -10,48 +10,38 @@ struct AppRoot: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $router.selectedTab) {
-                NavigationStack(path: $router.dashboardPath) {
-                    DashboardView()
-                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
+                SwiftUI.Tab("Dashboard", systemImage: "house.fill", value: GutCheck.Tab.dashboard) {
+                    NavigationStack(path: $router.dashboardPath) {
+                        DashboardView()
+                            .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
+                    }
                 }
-                .tabItem {
-                    Label("Dashboard", systemImage: "house.fill")
-                }
-                .tag(Tab.dashboard)
-                
-                NavigationStack(path: $router.mealsPath) {
-                    CalendarView(selectedTab: .meals)
-                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
-                }
-                .tabItem {
-                    Label("Meals", systemImage: "fork.knife")
-                }
-                .tag(Tab.meals)
-                
-                NavigationStack(path: $router.symptomsPath) {
-                    CalendarView(selectedTab: .symptoms)
-                        .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
-                }
-                .tabItem {
-                    Label("Symptoms", systemImage: "heart.text.square.fill")
-                }
-                .tag(Tab.symptoms)
-                
-                NavigationStack {
-                    MedicationCalendarView()
-                }
-                .tabItem {
-                    Label("Meds", systemImage: "pills.fill")
-                }
-                .tag(Tab.medications)
 
-                NavigationStack {
-                    InsightsView()
+                SwiftUI.Tab("Meals", systemImage: "fork.knife", value: GutCheck.Tab.meals) {
+                    NavigationStack(path: $router.mealsPath) {
+                        CalendarView(selectedTab: .meals)
+                            .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
+                    }
                 }
-                .tabItem {
-                    Label("Insights", systemImage: "chart.bar.fill")
+
+                SwiftUI.Tab("Symptoms", systemImage: "heart.text.square.fill", value: GutCheck.Tab.symptoms) {
+                    NavigationStack(path: $router.symptomsPath) {
+                        CalendarView(selectedTab: .symptoms)
+                            .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
+                    }
                 }
-                .tag(Tab.insights)
+
+                SwiftUI.Tab("Meds", systemImage: "pills.fill", value: GutCheck.Tab.medications) {
+                    NavigationStack {
+                        MedicationCalendarView()
+                    }
+                }
+
+                SwiftUI.Tab("Insights", systemImage: "chart.bar.fill", value: GutCheck.Tab.insights) {
+                    NavigationStack {
+                        InsightsView()
+                    }
+                }
             }
             
             .safeAreaInset(edge: .top) {


### PR DESCRIPTION
## Summary

- Replaces the legacy `.tabItem { Label(...) }.tag(...)` pattern with the modern `Tab(_:systemImage:value:content:)` API in `AppRoot.swift`
- Uses `SwiftUI.Tab` and `GutCheck.Tab` fully-qualified names to disambiguate from the project's existing `Tab` enum
- Updates the tab bar code example in `AccessibilityIdentifiers.swift` to reflect the new pattern

## Details

The `Tab` struct was introduced in iOS 18 and is the recommended way to define tabs in a `TabView`. It combines the label, selection value, and content into a single declarative construct, replacing the separate `.tabItem {}` + `.tag()` modifiers.

**Before:**
```swift
NavigationStack { ... }
    .tabItem { Label("Dashboard", systemImage: "house.fill") }
    .tag(Tab.dashboard)
```

**After:**
```swift
SwiftUI.Tab("Dashboard", systemImage: "house.fill", value: GutCheck.Tab.dashboard) {
    NavigationStack { ... }
}
```

Note: `WelcomeView.swift` also uses `TabView` but with `.tabViewStyle(PageTabViewStyle(...))` for an onboarding carousel — this is not a tab bar and was intentionally left unchanged.

## Test plan

- [x] Verify all 5 tabs (Dashboard, Meals, Symptoms, Meds, Insights) appear and are selectable
- [x] Verify programmatic tab selection still works (e.g., deep links, router.selectedTab changes)
- [x] Verify tab icons display correctly (system auto-selects filled variant)
- [ ] Verify navigation stacks within each tab work correctly
- [x] Verify sheet presentations still work from the tab view

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)