### PR TITLE
fix(#235): replace Date() with Date.now across codebase

### DIFF
--- a/GutCheck/GutCheck/Models/Core/MedicationModels.swift
+++ b/GutCheck/GutCheck/Models/Core/MedicationModels.swift
@@ -42,15 +42,15 @@ struct MedicationRecord: Identifiable, Codable, Hashable, FirestoreModel {
         createdBy: String = "",
         name: String,
         dosage: MedicationDosage,
-        startDate: Date = Date(),
+        startDate: Date = Date.now,
         endDate: Date? = nil,
         isActive: Bool = true,
         notes: String? = nil,
         source: MedicationSource = .manual,
         privacyLevel: DataPrivacyLevel = .private,
         healthKitUUID: UUID? = nil,
-        createdAt: Date = Date(),
-        updatedAt: Date = Date()
+        createdAt: Date = Date.now,
+        updatedAt: Date = Date.now
     ) {
         self.id = id
         self.createdBy = createdBy
@@ -81,7 +81,7 @@ struct MedicationRecord: Identifiable, Codable, Hashable, FirestoreModel {
         let name = data["name"] as? String ?? ""
         let dosageData = data["dosage"] as? [String: Any] ?? [:]
         let dosage = MedicationDosage(from: dosageData)
-        let startDate = (data["startDate"] as? Timestamp)?.dateValue() ?? Date()
+        let startDate = (data["startDate"] as? Timestamp)?.dateValue() ?? Date.now
         let endDate = (data["endDate"] as? Timestamp)?.dateValue()
         let isActive = data["isActive"] as? Bool ?? true
         let notes = data["notes"] as? String
@@ -91,8 +91,8 @@ struct MedicationRecord: Identifiable, Codable, Hashable, FirestoreModel {
         let privacyLevel = DataPrivacyLevel(rawValue: privacyRaw) ?? .private
         let healthKitUUIDString = data["healthKitUUID"] as? String
         let healthKitUUID = healthKitUUIDString.flatMap { UUID(uuidString: $0) }
-        let createdAt = (data["createdAt"] as? Timestamp)?.dateValue() ?? Date()
-        let updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue() ?? Date()
+        let createdAt = (data["createdAt"] as? Timestamp)?.dateValue() ?? Date.now
+        let updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue() ?? Date.now
         
         self.init(
             id: id,
@@ -121,7 +121,7 @@ struct MedicationRecord: Identifiable, Codable, Hashable, FirestoreModel {
             "source": source.rawValue,
             "privacyLevel": privacyLevel.rawValue,
             "createdAt": Timestamp(date: createdAt),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date.now)
         ]
         
         if let endDate = endDate {
@@ -253,10 +253,10 @@ struct MedicationDoseLog: Identifiable, Codable, FirestoreModel {
         medicationName: String,
         dosageAmount: Double,
         dosageUnit: String,
-        dateTaken: Date = Date(),
+        dateTaken: Date = Date.now,
         notes: String? = nil,
         privacyLevel: DataPrivacyLevel = .private,
-        createdAt: Date = Date()
+        createdAt: Date = Date.now
     ) {
         self.id             = id
         self.createdBy      = createdBy
@@ -284,11 +284,11 @@ struct MedicationDoseLog: Identifiable, Codable, FirestoreModel {
         self.medicationName = data["medicationName"] as? String ?? ""
         self.dosageAmount   = data["dosageAmount"]   as? Double ?? 0.0
         self.dosageUnit     = data["dosageUnit"]     as? String ?? "mg"
-        self.dateTaken      = (data["dateTaken"]  as? Timestamp)?.dateValue() ?? Date()
+        self.dateTaken      = (data["dateTaken"]  as? Timestamp)?.dateValue() ?? Date.now
         self.notes          = data["notes"]          as? String
         let privacyRaw      = data["privacyLevel"]   as? String ?? "private"
         self.privacyLevel   = DataPrivacyLevel(rawValue: privacyRaw) ?? .private
-        self.createdAt      = (data["createdAt"] as? Timestamp)?.dateValue() ?? Date()
+        self.createdAt      = (data["createdAt"] as? Timestamp)?.dateValue() ?? Date.now
     }
 
     func toFirestoreData() -> [String: Any] {
@@ -329,7 +329,7 @@ struct MedicationInteraction: Identifiable, Codable {
         description: String,
         recommendations: [String],
         source: String = "AI Analysis",
-        createdAt: Date = Date()
+        createdAt: Date = Date.now
     ) {
         self.id = id
         self.medicationId = medicationId
@@ -410,7 +410,7 @@ struct SideEffect: Identifiable, Codable {
         frequency: SideEffectFrequency,
         onset: SideEffectOnset,
         duration: SideEffectDuration,
-        createdAt: Date = Date()
+        createdAt: Date = Date.now
     ) {
         self.id = id
         self.medicationId = medicationId

--- a/GutCheck/GutCheck/Models/DataDeletionRequest.swift
+++ b/GutCheck/GutCheck/Models/DataDeletionRequest.swift
@@ -68,7 +68,7 @@ struct DataDeletionRequest: Codable, Identifiable, Hashable, Equatable {
          userId: String,
          userEmail: String,
          userName: String,
-         requestDate: Date = Date(),
+         requestDate: Date = Date.now,
          reason: String? = nil,
          status: DeletionStatus = .pending,
          adminNotes: String? = nil,

--- a/GutCheck/GutCheck/Models/Meal.swift
+++ b/GutCheck/GutCheck/Models/Meal.swift
@@ -98,7 +98,7 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
         if let timestamp = data["date"] as? Timestamp {
             self.date = timestamp.dateValue()
         } else {
-            self.date = Date()
+            self.date = Date.now
         }
         
         // Handle enum types

--- a/GutCheck/GutCheck/Models/ReminderSettings.swift
+++ b/GutCheck/GutCheck/Models/ReminderSettings.swift
@@ -22,31 +22,31 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
 
     // Other Daily Reminders
     var symptomReminderEnabled: Bool = false
-    var symptomReminderTime: Date = Date()
+    var symptomReminderTime: Date = Date.now
     var medicationReminderEnabled: Bool = false
-    var medicationReminderTime: Date = Date()
+    var medicationReminderTime: Date = Date.now
     var remindMeLaterInterval: Int = 15 // minutes
 
     // Weekly Reports
     var weeklyInsightEnabled: Bool = false
-    var weeklyInsightTime: Date = Date()
+    var weeklyInsightTime: Date = Date.now
 
     // Smart Notifications (server-triggered via FCM)
     var newInsightsEnabled: Bool = true
     var patternAlertEnabled: Bool = true
 
     // Metadata
-    var lastUpdated: Date = Date()
+    var lastUpdated: Date = Date.now
 
     // MARK: - Helpers
 
     /// Returns a Date set to today at the given hour (minute 0) in the current calendar.
     static func defaultTime(hour: Int) -> Date {
-        var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: Date.now)
         components.hour = hour
         components.minute = 0
         components.second = 0
-        return Calendar.current.date(from: components) ?? Date()
+        return Calendar.current.date(from: components) ?? Date.now
     }
 
     // MARK: - DataClassifiable Conformance
@@ -66,12 +66,12 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
          dinnerReminderEnabled: Bool = false,
          dinnerReminderTime: Date = ReminderSettings.defaultTime(hour: 18),
          symptomReminderEnabled: Bool = false,
-         symptomReminderTime: Date = Date(),
+         symptomReminderTime: Date = Date.now,
          medicationReminderEnabled: Bool = false,
-         medicationReminderTime: Date = Date(),
+         medicationReminderTime: Date = Date.now,
          remindMeLaterInterval: Int = 15,
          weeklyInsightEnabled: Bool = false,
-         weeklyInsightTime: Date = Date(),
+         weeklyInsightTime: Date = Date.now,
          newInsightsEnabled: Bool = true,
          patternAlertEnabled: Bool = true) {
         self.id = id
@@ -91,7 +91,7 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
         self.weeklyInsightTime = weeklyInsightTime
         self.newInsightsEnabled = newInsightsEnabled
         self.patternAlertEnabled = patternAlertEnabled
-        self.lastUpdated = Date()
+        self.lastUpdated = Date.now
     }
 
     // MARK: - FirestoreModel Implementation
@@ -146,19 +146,19 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
         if let ts = data["symptomReminderTime"] as? Timestamp {
             self.symptomReminderTime = ts.dateValue()
         } else {
-            self.symptomReminderTime = Date()
+            self.symptomReminderTime = Date.now
         }
 
         if let ts = data["medicationReminderTime"] as? Timestamp {
             self.medicationReminderTime = ts.dateValue()
         } else {
-            self.medicationReminderTime = Date()
+            self.medicationReminderTime = Date.now
         }
 
         if let ts = data["weeklyInsightTime"] as? Timestamp {
             self.weeklyInsightTime = ts.dateValue()
         } else {
-            self.weeklyInsightTime = Date()
+            self.weeklyInsightTime = Date.now
         }
 
         self.weeklyInsightEnabled = data["weeklyInsightEnabled"] as? Bool ?? false
@@ -166,7 +166,7 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
         if let ts = data["lastUpdated"] as? Timestamp {
             self.lastUpdated = ts.dateValue()
         } else {
-            self.lastUpdated = Date()
+            self.lastUpdated = Date.now
         }
     }
 
@@ -194,8 +194,8 @@ struct ReminderSettings: Identifiable, Codable, Hashable, Equatable, FirestoreMo
             "newInsightsEnabled": newInsightsEnabled,
             "patternAlertEnabled": patternAlertEnabled,
             // Metadata
-            "lastUpdated": Timestamp(date: Date()),
-            "createdAt": Timestamp(date: Date())
+            "lastUpdated": Timestamp(date: Date.now),
+            "createdAt": Timestamp(date: Date.now)
         ]
     }
 }

--- a/GutCheck/GutCheck/Models/Symptom.swift
+++ b/GutCheck/GutCheck/Models/Symptom.swift
@@ -144,7 +144,7 @@ struct Symptom: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
             "urgencyLevel": urgencyLevel.rawValue,
             "tags": tags,
             "createdBy": createdBy,
-            "createdAt": Timestamp(date: Date())
+            "createdAt": Timestamp(date: Date.now)
         ]
         
         if let notes = notes {

--- a/GutCheck/GutCheck/Models/User.swift
+++ b/GutCheck/GutCheck/Models/User.swift
@@ -46,7 +46,7 @@ struct User: Codable, Identifiable, Hashable, Equatable {
     var age: Int? {
         guard let dateOfBirth = dateOfBirth else { return nil }
         let calendar = Calendar.current
-        let ageComponents = calendar.dateComponents([.year], from: dateOfBirth, to: Date())
+        let ageComponents = calendar.dateComponents([.year], from: dateOfBirth, to: Date.now)
         return ageComponents.year
     }
     
@@ -127,7 +127,7 @@ struct User: Codable, Identifiable, Hashable, Equatable {
     }
     
     // Standard initializer
-    init(id: String, email: String, firstName: String, lastName: String, signInMethod: SignInMethod = .email, createdAt: Date = Date(), updatedAt: Date = Date(), privacyPolicyAccepted: Bool = false, privacyPolicyAcceptedDate: Date? = nil, privacyPolicyVersion: String = "1.0") {
+    init(id: String, email: String, firstName: String, lastName: String, signInMethod: SignInMethod = .email, createdAt: Date = Date.now, updatedAt: Date = Date.now, privacyPolicyAccepted: Bool = false, privacyPolicyAcceptedDate: Date? = nil, privacyPolicyVersion: String = "1.0") {
         self.id = id
         self.email = email
         self.firstName = firstName

--- a/GutCheck/GutCheck/Models/UserProfile.swift
+++ b/GutCheck/GutCheck/Models/UserProfile.swift
@@ -7,5 +7,5 @@ struct UserProfile: Identifiable, Codable {
     var age: Int?
     var weight: Double?  // kg
     var height: Double?  // cm
-    var createdAt: Date = Date()
+    var createdAt: Date = Date.now
 }

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
@@ -174,7 +174,7 @@ class CoreDataStack: ObservableObject {
         
         // Clean up old sync records
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "LocalMeal")
-        fetchRequest.predicate = NSPredicate(format: "syncStatus == %@ AND lastModified < %@", "synced", Date().addingTimeInterval(-30*24*60*60) as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "syncStatus == %@ AND lastModified < %@", "synced", Date.now.addingTimeInterval(-30*24*60*60) as CVarArg)
         
         do {
             let oldMeals = try context.fetch(fetchRequest) as? [LocalMeal] ?? []

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
@@ -30,8 +30,8 @@ class CoreDataStorageService: ObservableObject {
             localMeal.source = meal.source.rawValue
             localMeal.notes = meal.notes
             localMeal.createdBy = meal.createdBy
-            localMeal.createdAt = Date()
-            localMeal.lastModified = Date()
+            localMeal.createdAt = Date.now
+            localMeal.lastModified = Date.now
             localMeal.syncStatus = "local"
             
             // Save food items
@@ -153,8 +153,8 @@ class CoreDataStorageService: ObservableObject {
             localSymptom.bloating = false
             localSymptom.notes = symptom.notes
             localSymptom.createdBy = symptom.createdBy
-            localSymptom.createdAt = Date()
-            localSymptom.lastModified = Date()
+            localSymptom.createdAt = Date.now
+            localSymptom.lastModified = Date.now
             localSymptom.syncStatus = "local"
             
             try context.save()
@@ -233,7 +233,7 @@ class CoreDataStorageService: ObservableObject {
             localUser.privacyPolicyAccepted = user.privacyPolicyAccepted
             localUser.privacyPolicyAcceptedDate = user.privacyPolicyAcceptedDate
             localUser.privacyPolicyVersion = user.privacyPolicyVersion
-            localUser.lastSync = Date()
+            localUser.lastSync = Date.now
             localUser.syncStatus = "synced"
             
             try context.save()
@@ -289,7 +289,7 @@ class CoreDataStorageService: ObservableObject {
             localSettings.remindMeLaterInterval = Int16(settings.remindMeLaterInterval)
             localSettings.weeklyInsightEnabled = settings.weeklyInsightEnabled
             localSettings.weeklyInsightTime = settings.weeklyInsightTime
-            localSettings.lastModified = Date()
+            localSettings.lastModified = Date.now
             localSettings.syncStatus = "local"
             
             try context.save()
@@ -316,10 +316,10 @@ class CoreDataStorageService: ObservableObject {
                 breakfastReminderEnabled: localSetting.mealReminderEnabled,
                 breakfastReminderTime: localSetting.mealReminderTime ?? ReminderSettings.defaultTime(hour: 7),
                 symptomReminderEnabled: localSetting.symptomReminderEnabled,
-                symptomReminderTime: localSetting.symptomReminderTime ?? Date(),
+                symptomReminderTime: localSetting.symptomReminderTime ?? Date.now,
                 remindMeLaterInterval: Int(localSetting.remindMeLaterInterval),
                 weeklyInsightEnabled: localSetting.weeklyInsightEnabled,
-                weeklyInsightTime: localSetting.weeklyInsightTime ?? Date()
+                weeklyInsightTime: localSetting.weeklyInsightTime ?? Date.now
             )
         }
     }
@@ -329,16 +329,16 @@ class CoreDataStorageService: ObservableObject {
     func markAsSynced<T: NSManagedObject>(_ entity: T, syncStatus: String = "synced") {
         if let localMeal = entity as? LocalMeal {
             localMeal.syncStatus = syncStatus
-            localMeal.lastModified = Date()
+            localMeal.lastModified = Date.now
         } else if let localSymptom = entity as? LocalSymptom {
             localSymptom.syncStatus = syncStatus
-            localSymptom.lastModified = Date()
+            localSymptom.lastModified = Date.now
         } else if let localUser = entity as? LocalUser {
             localUser.syncStatus = syncStatus
-            localUser.lastSync = Date()
+            localUser.lastSync = Date.now
         } else if let localSettings = entity as? LocalReminderSettings {
             localSettings.syncStatus = syncStatus
-            localSettings.lastModified = Date()
+            localSettings.lastModified = Date.now
         }
 
         guard let context = entity.managedObjectContext else { return }
@@ -378,7 +378,7 @@ class CoreDataStorageService: ObservableObject {
         do {
             try await coreDataStack.performBackgroundTask { context in
             // Remove data older than 90 days
-            let cutoffDate = Calendar.current.date(byAdding: .day, value: -90, to: Date()) ?? Date()
+            let cutoffDate = Calendar.current.date(byAdding: .day, value: -90, to: Date.now) ?? Date.now
             
             let mealFetchRequest: NSFetchRequest<LocalMeal> = LocalMeal.fetchRequest()
             mealFetchRequest.predicate = NSPredicate(format: "date < %@ AND syncStatus == %@", cutoffDate as CVarArg, "synced")

--- a/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
@@ -37,7 +37,7 @@ class DataSyncService: ObservableObject {
         defer {
             isSyncing = false
             syncProgress = 1.0
-            lastSyncDate = Date()
+            lastSyncDate = Date.now
         }
         
         do {
@@ -190,10 +190,10 @@ class DataSyncService: ObservableObject {
             breakfastReminderEnabled: localSettings.mealReminderEnabled,
             breakfastReminderTime: localSettings.mealReminderTime ?? ReminderSettings.defaultTime(hour: 7),
             symptomReminderEnabled: localSettings.symptomReminderEnabled,
-            symptomReminderTime: localSettings.symptomReminderTime ?? Date(),
+            symptomReminderTime: localSettings.symptomReminderTime ?? Date.now,
             remindMeLaterInterval: Int(localSettings.remindMeLaterInterval),
             weeklyInsightEnabled: localSettings.weeklyInsightEnabled,
-            weeklyInsightTime: localSettings.weeklyInsightTime ?? Date()
+            weeklyInsightTime: localSettings.weeklyInsightTime ?? Date.now
         )
         
         // Upload to Firestore

--- a/GutCheck/GutCheck/Services/DataSyncManager.swift
+++ b/GutCheck/GutCheck/Services/DataSyncManager.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class DataSyncManager: ObservableObject {
     static let shared = DataSyncManager()
     
-    @Published private(set) var lastRefreshTime: Date = Date()
+    @Published private(set) var lastRefreshTime: Date = Date.now
     @Published private(set) var isRefreshing: Bool = false
     
     // Refresh triggers for different data types
@@ -102,7 +102,7 @@ class DataSyncManager: ObservableObject {
     @MainActor
     private func updateRefreshStates() {
         shouldRefreshDashboard.toggle()
-        lastRefreshTime = Date()
+        lastRefreshTime = Date.now
     }
     
     @MainActor
@@ -111,7 +111,7 @@ class DataSyncManager: ObservableObject {
         shouldRefreshMeals.toggle()
         shouldRefreshSymptoms.toggle()
         shouldRefreshCalendar.toggle()
-        lastRefreshTime = Date()
+        lastRefreshTime = Date.now
     }
     
     // MARK: - Reset Methods
@@ -137,7 +137,7 @@ class DataSyncManager: ObservableObject {
     }
     
     var timeSinceLastRefresh: TimeInterval {
-        Date().timeIntervalSince(lastRefreshTime)
+        Date.now.timeIntervalSince(lastRefreshTime)
     }
 }
 

--- a/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
@@ -15,8 +15,8 @@ class PreviewAuthService: AuthenticationProtocol {
         firstName: "Preview",
         lastName: "User",
         signInMethod: .email,
-        createdAt: Date(),
-        updatedAt: Date()
+        createdAt: Date.now,
+        updatedAt: Date.now
     )
     
     // MARK: - Protocol Methods (Preview Implementation)

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
@@ -379,7 +379,7 @@ final class HealthKitManager {
     }
     
     /// Write water intake to HealthKit
-    func writeWaterIntakeToHealthKit(amount: Double, date: Date = Date(), completion: @escaping (Bool, Error?) -> Void) {
+    func writeWaterIntakeToHealthKit(amount: Double, date: Date = Date.now, completion: @escaping (Bool, Error?) -> Void) {
         guard let waterType = HKQuantityType.quantityType(forIdentifier: .dietaryWater) else {
             completion(false, HealthKitError.invalidData)
             return

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
@@ -165,7 +165,7 @@ class HealthKitMedicationService: ObservableObject {
             await MainActor.run {
                 self.currentMedications = medications.filter { $0.isActive }
                 self.medicationHistory = medications
-                self.lastUpdateTime = Date()
+                self.lastUpdateTime = Date.now
             }
         } catch {
             print("Failed to fetch medications: \(error)")
@@ -181,7 +181,7 @@ class HealthKitMedicationService: ObservableObject {
         let medicationType = HKObjectType.clinicalType(forIdentifier: .medicationRecord)!
         
         let predicate = HKQuery.predicateForSamples(
-            withStart: Calendar.current.date(byAdding: .month, value: -3, to: Date()),
+            withStart: Calendar.current.date(byAdding: .month, value: -3, to: Date.now),
             end: nil,
             options: .strictStartDate
         )
@@ -226,7 +226,7 @@ class HealthKitMedicationService: ObservableObject {
         let endDate: Date?
         
         // Check if endDate is a reasonable date (not distant future)
-        let distantFuture = Calendar.current.date(byAdding: .year, value: 100, to: Date()) ?? Date.distantFuture
+        let distantFuture = Calendar.current.date(byAdding: .year, value: 100, to: Date.now) ?? Date.distantFuture
         if sample.endDate > distantFuture {
             // This represents "no end date" in HealthKit
             endDate = nil
@@ -234,7 +234,7 @@ class HealthKitMedicationService: ObservableObject {
         } else {
             endDate = sample.endDate
             if let endDate = endDate {
-                isActive = endDate > Date()
+                isActive = endDate > Date.now
             } else {
                 isActive = true
             }
@@ -285,7 +285,7 @@ class HealthKitMedicationService: ObservableObject {
         await MainActor.run {
             self.currentMedications.append(medication)
             self.medicationHistory.append(medication)
-            self.lastUpdateTime = Date()
+            self.lastUpdateTime = Date.now
         }
     }
     
@@ -314,13 +314,13 @@ class HealthKitMedicationService: ObservableObject {
 extension HKClinicalRecord {
     var isActive: Bool {
         // In HealthKit, endDate might be a distant future date to represent "no end date"
-        let distantFuture = Calendar.current.date(byAdding: .year, value: 100, to: Date()) ?? Date.distantFuture
+        let distantFuture = Calendar.current.date(byAdding: .year, value: 100, to: Date.now) ?? Date.distantFuture
         
         if self.endDate > distantFuture {
             // This represents "no end date" in HealthKit
             return true
         } else {
-            return self.endDate > Date()
+            return self.endDate > Date.now
         }
     }
 }

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
@@ -46,7 +46,7 @@ class HealthKitSyncManager: ObservableObject {
         }
         guard HKHealthStore.isHealthDataAvailable() else { return }
 
-        let now = Date().timeIntervalSince1970
+        let now = Date.now.timeIntervalSince1970
         let lastSync = UserDefaults.standard.double(forKey: lastSyncKey)
 
         guard now - lastSync >= syncInterval else {

--- a/GutCheck/GutCheck/Services/HealthcareExportService.swift
+++ b/GutCheck/GutCheck/Services/HealthcareExportService.swift
@@ -37,7 +37,7 @@ struct ExportOptions {
     var anonymizeData: Bool
     
     static let `default` = ExportOptions(
-        dateRange: Calendar.current.date(byAdding: .month, value: -3, to: Date())!...Date(),
+        dateRange: Calendar.current.date(byAdding: .month, value: -3, to: Date.now)!...Date.now,
         includePrivateData: false,
         includeNutritionData: true,
         includeSymptomData: true,
@@ -514,7 +514,7 @@ class HealthcareExportService: ObservableObject {
         
         // Generated timestamp
         let generatedY = dateBoxY + 80
-        let generatedString = "Generated: \(DateFormatter().string(from: Date()))"
+        let generatedString = "Generated: \(DateFormatter().string(from: Date.now))"
         let generatedSize = generatedString.size(withAttributes: dateAttributes)
         generatedString.draw(at: CGPoint(x: (pageRect.width - generatedSize.width) / 2, y: generatedY), withAttributes: dateAttributes)
         

--- a/GutCheck/GutCheck/Services/Insights/InsightsService.swift
+++ b/GutCheck/GutCheck/Services/Insights/InsightsService.swift
@@ -46,7 +46,7 @@ class InsightsService: ObservableObject {
     
     /// Generates insights for the last 30 days
     func generateRecentInsights() async {
-        let endDate = Date()
+        let endDate = Date.now
         let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
         let timeRange = DateInterval(start: startDate, end: endDate)
         

--- a/GutCheck/GutCheck/Services/Insights/PatternRecognitionService.swift
+++ b/GutCheck/GutCheck/Services/Insights/PatternRecognitionService.swift
@@ -461,7 +461,7 @@ class PatternRecognitionService {
     }
     
     private func analyzeMealTimingConsistency(meals: [Meal]) -> NutritionTrendInsight? {
-        let recentMeals = meals.filter { $0.date > Date().addingTimeInterval(-7 * 24 * 3600) }
+        let recentMeals = meals.filter { $0.date > Date.now.addingTimeInterval(-7 * 24 * 3600) }
         
         let mealHours = recentMeals.map { Calendar.current.component(.hour, from: $0.date) }
         let mealCounts = Dictionary(grouping: mealHours, by: { $0 }).mapValues { $0.count }

--- a/GutCheck/GutCheck/Services/MealBuilderService.swift
+++ b/GutCheck/GutCheck/Services/MealBuilderService.swift
@@ -17,7 +17,7 @@ class MealBuilderService: ObservableObject {
     // MARK: - Published Properties
     @Published var currentMeal: [FoodItem] = []
     @Published var mealType: MealType = .lunch
-    @Published var mealDate: Date = Date()
+    @Published var mealDate: Date = Date.now
     @Published var mealName: String = ""
     @Published var notes: String = ""
     @Published var isBuilding: Bool = false
@@ -86,7 +86,7 @@ class MealBuilderService: ObservableObject {
         Swift.print("🆕 MealBuilderService: Starting new \(type.rawValue) meal")
         clearMeal()
         mealType = type
-        mealDate = Date()
+        mealDate = Date.now
         isBuilding = false
     }
     
@@ -96,7 +96,7 @@ class MealBuilderService: ObservableObject {
         currentMeal.removeAll()
         mealName = ""
         notes = ""
-        mealDate = Date()
+        mealDate = Date.now
         isBuilding = false
         editingMealId = nil
         shouldNavigateToBuilder = false

--- a/GutCheck/GutCheck/Services/PrivacyPolicyManager.swift
+++ b/GutCheck/GutCheck/Services/PrivacyPolicyManager.swift
@@ -54,7 +54,7 @@ class PrivacyPolicyManager: ObservableObject {
         
         // Update local status
         isPrivacyPolicyAccepted = true
-        privacyPolicyAcceptedDate = Date()
+        privacyPolicyAcceptedDate = Date.now
         savePrivacyPolicyStatus()
         
         // Update Firestore

--- a/GutCheck/GutCheck/Services/ReminderSettingsService.swift
+++ b/GutCheck/GutCheck/Services/ReminderSettingsService.swift
@@ -66,7 +66,7 @@ class ReminderSettingsService: ObservableObject {
         
         var updatedSettings = settings
         updatedSettings.createdBy = userId
-        updatedSettings.lastUpdated = Date()
+        updatedSettings.lastUpdated = Date.now
         
         do {
             try await reminderRepository.save(updatedSettings)

--- a/GutCheck/GutCheck/Services/RemindersKitService.swift
+++ b/GutCheck/GutCheck/Services/RemindersKitService.swift
@@ -218,7 +218,7 @@ final class RemindersKitService: ObservableObject {
         // We use today's date as the anchor; the recurrence rule handles repeating.
         let cal = Calendar.current
         let timeComponents = cal.dateComponents([.hour, .minute], from: time)
-        var components = cal.dateComponents([.year, .month, .day], from: Date())
+        var components = cal.dateComponents([.year, .month, .day], from: Date.now)
         components.hour = timeComponents.hour
         components.minute = timeComponents.minute
         components.second = 0

--- a/GutCheck/GutCheck/Services/ServerStatusService.swift
+++ b/GutCheck/GutCheck/Services/ServerStatusService.swift
@@ -37,7 +37,7 @@ class ServerStatusService: ObservableObject {
         }
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .full
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return formatter.localizedString(for: date, relativeTo: Date.now)
     }
 
     // MARK: - Private

--- a/GutCheck/GutCheck/Services/Strategies/LocalProfileImageStrategy.swift
+++ b/GutCheck/GutCheck/Services/Strategies/LocalProfileImageStrategy.swift
@@ -127,7 +127,7 @@ class LocalProfileImageStrategy: ProfileImageStrategy {
         
         try await userRef.updateData([
             "profileImageURL": imageURL,
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date.now)
         ])
         
         print("🔥 LocalProfileImageStrategy: Firestore update completed successfully")
@@ -145,7 +145,7 @@ class LocalProfileImageStrategy: ProfileImageStrategy {
         
         try await userRef.updateData([
             "profileImageURL": FieldValue.delete(),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date.now)
         ])
     }
 }

--- a/GutCheck/GutCheck/Services/TimeoutManager.swift
+++ b/GutCheck/GutCheck/Services/TimeoutManager.swift
@@ -12,13 +12,13 @@ class TimeoutManager: ObservableObject {
     private init() {}
     
     func applicationDidEnterBackground() {
-        backgroundEnteredTime = Date()
+        backgroundEnteredTime = Date.now
     }
     
     func applicationWillEnterForeground() {
         guard let backgroundTime = backgroundEnteredTime else { return }
         
-        let timeInBackground = Date().timeIntervalSince(backgroundTime)
+        let timeInBackground = Date.now.timeIntervalSince(backgroundTime)
         if timeInBackground >= timeoutInterval {
             shouldResetToHome = true
         }

--- a/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
@@ -21,7 +21,7 @@ class CategoryInsightsViewModel: ObservableObject {
             let userId = getCurrentUserId()
             
             // Calculate time range for last 30 days
-            let endDate = Date()
+            let endDate = Date.now
             let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
             let timeRange = DateInterval(start: startDate, end: endDate)
             

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -38,7 +38,7 @@ class InsightsViewModel: ObservableObject {
             let userId = getCurrentUserId()
             
             // Calculate time range for last 30 days
-            let endDate = Date()
+            let endDate = Date.now
             let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
             let timeRange = DateInterval(start: startDate, end: endDate)
             
@@ -131,7 +131,7 @@ class InsightsViewModel: ObservableObject {
                 priority: priority,
                 actionItems: insight.recommendations,
                 source: "AI Analysis",
-                dateCreated: Date()
+                dateCreated: Date.now
             )
         }
     }
@@ -149,7 +149,7 @@ class InsightsViewModel: ObservableObject {
 
     private func computeWeeklySummaries(meals: [Meal], symptoms: [Symptom]) {
         let calendar = Calendar.current
-        let now = Date()
+        let now = Date.now
         let weekAgo = calendar.date(byAdding: .day, value: -7, to: now) ?? now
 
         let weekMeals = meals.filter { $0.date >= weekAgo }
@@ -249,7 +249,7 @@ class InsightsViewModel: ObservableObject {
         var dayCounts: [Int: Int] = [:]  // weekday (1=Sun..7=Sat) → count
         var dayOccurrences: [Int: Int] = [:]  // how many of each weekday are in the 30-day range
 
-        let now = Date()
+        let now = Date.now
         let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now) ?? now
 
         // Count occurrences of each weekday in the range

--- a/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
@@ -43,7 +43,7 @@ final class DashboardDataStore: ObservableObject {
     @Published var avoidanceTip: String = ""
     
     /// Currently selected date for dashboard data display
-    @Published var selectedDate: Date = Date()
+    @Published var selectedDate: Date = Date.now
     
     // MARK: - Private Properties
     
@@ -172,7 +172,7 @@ final class DashboardDataStore: ObservableObject {
             Meal(
                 id: "preview-1",
                 name: "Breakfast",
-                date: Date().addingTimeInterval(-3600 * 3),
+                date: Date.now.addingTimeInterval(-3600 * 3),
                 type: .breakfast,
                 source: .manual,
                 foodItems: [],
@@ -183,7 +183,7 @@ final class DashboardDataStore: ObservableObject {
             Meal(
                 id: "preview-2",
                 name: "Lunch",
-                date: Date(),
+                date: Date.now,
                 type: .lunch,
                 source: .manual,
                 foodItems: [],

--- a/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
@@ -68,7 +68,7 @@ final class HealthKitViewModel: ObservableObject {
     func fetchHealthData() async {
         healthData = await HealthKitAsyncWrapper.shared.fetchUserHealthDataWithLogging()
         if healthData != nil {
-            lastSyncTimestamp = Date().timeIntervalSince1970
+            lastSyncTimestamp = Date.now.timeIntervalSince1970
         }
     }
 
@@ -132,7 +132,7 @@ final class HealthKitViewModel: ObservableObject {
     func formattedAge() -> String {
         guard let dob = healthData?.dateOfBirth else { return "-" }
         let calendar = Calendar.current
-        let ageComponents = calendar.dateComponents([.year], from: dob, to: Date())
+        let ageComponents = calendar.dateComponents([.year], from: dob, to: Date.now)
         if let years = ageComponents.year {
             return String(years)
         }

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -14,7 +14,7 @@ class MealBuilderViewModel: ObservableObject {
     // Meal properties
     @Published var mealName: String = ""
     @Published var mealType: MealType = .lunch
-    @Published var mealDate: Date = Date()
+    @Published var mealDate: Date = Date.now
     @Published var notes: String = ""
     @Published var foodItems: [FoodItem] = []
     @Published var isSaving: Bool = false
@@ -206,7 +206,7 @@ class MealBuilderViewModel: ObservableObject {
     private func resetForm() {
         mealName = ""
         mealType = .lunch
-        mealDate = Date()
+        mealDate = Date.now
         notes = ""
         foodItems = []
         editingFoodItem = nil

--- a/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
@@ -130,7 +130,7 @@ extension Meal {
         return Meal(
             id: "",
             name: "Loading...",
-            date: Date(),
+            date: Date.now,
             type: .breakfast,
             source: .manual,
             foodItems: []
@@ -141,7 +141,7 @@ extension Meal {
         return Meal(
             id: UUID().uuidString,
             name: "Sample Lunch",
-            date: Date(),
+            date: Date.now,
             type: .lunch,
             source: .manual,
             foodItems: [

--- a/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
@@ -98,9 +98,9 @@ class AddMedicationViewModel: ObservableObject, HasLoadingState {
     @Published var dosageAmount:  String             = ""
     @Published var dosageUnit:    String             = "mg"
     @Published var frequency:     MedicationFrequency = .onceDaily
-    @Published var startDate:     Date               = Date()
+    @Published var startDate:     Date               = Date.now
     @Published var hasEndDate:    Bool               = false
-    @Published var endDate:       Date               = Date()
+    @Published var endDate:       Date               = Date.now
     @Published var isActive:      Bool               = true
     @Published var notes:         String             = ""
 
@@ -185,9 +185,9 @@ class AddMedicationViewModel: ObservableObject, HasLoadingState {
         dosageAmount = ""
         dosageUnit   = "mg"
         frequency    = .onceDaily
-        startDate    = Date()
+        startDate    = Date.now
         hasEndDate   = false
-        endDate      = Date()
+        endDate      = Date.now
         isActive     = true
         notes        = ""
         loadingState.reset()
@@ -209,7 +209,7 @@ class LogMedicationDoseViewModel: ObservableObject, HasLoadingState {
     // MARK: - Published: Form Fields
 
     /// Date and time the dose was taken (defaults to now).
-    @Published var dateTaken: Date = Date()
+    @Published var dateTaken: Date = Date.now
     @Published var notes: String   = ""
 
     // MARK: - Published: UI State
@@ -305,7 +305,7 @@ class LogMedicationDoseViewModel: ObservableObject, HasLoadingState {
 
     func resetForm() {
         selectedMedication = availableMedications.first
-        dateTaken          = Date()
+        dateTaken          = Date.now
         notes              = ""
         loadingState.reset()
     }

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -13,7 +13,7 @@ import UserNotifications
 @MainActor
 class LogSymptomViewModel: ObservableObject, HasLoadingState {
     // Form state (unchanged)
-    @Published var symptomDate = Date()
+    @Published var symptomDate = Date.now
     @Published var selectedStoolType: StoolType?
     @Published var selectedPainLevel: Int = 0
     @Published var selectedUrgencyLevel: UrgencyLevel = .none
@@ -52,7 +52,7 @@ class LogSymptomViewModel: ObservableObject, HasLoadingState {
         selectedUrgencyLevel != .none ||
         !selectedTags.isEmpty ||
         !notes.isEmpty ||
-        !Calendar.current.isDate(symptomDate, inSameDayAs: Date())
+        !Calendar.current.isDate(symptomDate, inSameDayAs: Date.now)
     }
     
     // MARK: - Tag Management (unchanged)
@@ -124,8 +124,8 @@ class LogSymptomViewModel: ObservableObject, HasLoadingState {
         )
         
         print("🕐 LogSymptom: Symptom date: \(symptomDate)")
-        print("📝 LogSymptom: Current date: \(Date())")
-        print("🗓️ LogSymptom: Same day check: \(Calendar.current.isDate(symptomDate, inSameDayAs: Date()))")
+        print("📝 LogSymptom: Current date: \(Date.now)")
+        print("🗓️ LogSymptom: Same day check: \(Calendar.current.isDate(symptomDate, inSameDayAs: Date.now))")
         print("🕐 LogSymptom: Symptom date components - year: \(Calendar.current.component(.year, from: symptomDate)), month: \(Calendar.current.component(.month, from: symptomDate)), day: \(Calendar.current.component(.day, from: symptomDate))")
         
         Task {
@@ -193,7 +193,7 @@ class LogSymptomViewModel: ObservableObject, HasLoadingState {
     }
     
     func resetForm() {
-        symptomDate = Date()
+        symptomDate = Date.now
         selectedStoolType = nil
         selectedPainLevel = 0
         selectedUrgencyLevel = .none

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
@@ -128,7 +128,7 @@ extension Symptom {
     static func emptySymptom() -> Symptom {
         return Symptom(
             id: "",
-            date: Date(),
+            date: Date.now,
             stoolType: .type4,
             painLevel: .none,
             urgencyLevel: .none,

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -446,7 +446,7 @@ extension Symptom {
     static func sampleSymptom() -> Symptom {
         return Symptom(
             id: "sample-id",
-            date: Date(),
+            date: Date.now,
             stoolType: .type4,
             painLevel: .none,
             urgencyLevel: .none,

--- a/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
@@ -11,7 +11,7 @@ struct SymptomEditView: View {
     @State private var selectedPainLevel: Int = 0
     @State private var selectedUrgencyLevel: UrgencyLevel = .none
     @State private var notes: String = ""
-    @State private var symptomDate: Date = Date()
+    @State private var symptomDate: Date = Date.now
     @State private var isSaving = false
     @State private var showingSuccessAlert = false
 
@@ -237,7 +237,7 @@ extension PainLevel {
 #Preview {
     SymptomEditView(
         symptom: Symptom(
-            date: Date(),
+            date: Date.now,
             stoolType: .type4,
             painLevel: .moderate,
             urgencyLevel: .mild,

--- a/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
@@ -90,7 +90,7 @@ struct CalendarDetailView: View {
 
 #Preview {
     NavigationView {
-        CalendarDetailView(date: Date())
+        CalendarDetailView(date: Date.now)
     }
     .environmentObject(AuthService())
     .environmentObject(AppRouter.shared)

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -369,7 +369,7 @@ struct EmptyStateCard: View {
 
 // MARK: - ViewModel
 class CalendarViewModel: ObservableObject {
-    @Published var selectedDate = Date()
+    @Published var selectedDate = Date.now
     @Published var meals: [Meal] = []
     @Published var symptoms: [Symptom] = []
     @Published var isLoadingMeals = false

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -28,7 +28,7 @@ struct MealSummaryCard: View {
     MealSummaryCard(meal: Meal(
         id: "1",
         name: "Breakfast",
-        date: Date(),
+        date: Date.now,
         type: .breakfast,
         source: .manual,
         foodItems: [

--- a/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
@@ -35,7 +35,7 @@ struct SymptomSummaryCard: View {
 #Preview {
     SymptomSummaryCard(symptom: Symptom(
         id: "1",
-        date: Date(),
+        date: Date.now,
         stoolType: .type4,
         painLevel: .moderate,
         urgencyLevel: .mild,

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct UnifiedCalendarView: View {
     @StateObject private var viewModel = CalendarViewModel()
-    @State private var selectedDate = Date()
+    @State private var selectedDate = Date.now
     @State private var showingDatePicker = false
     
     private let calendar = Calendar.current

--- a/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
@@ -389,13 +389,13 @@ struct DateRangePickerSheet: View {
         NavigationView {
             VStack(spacing: 20) {
                 DatePicker("Start Date", selection: Binding(
-                    get: { startDate ?? Date() },
+                    get: { startDate ?? Date.now },
                     set: { startDate = $0 }
                 ), displayedComponents: .date)
                 .datePickerStyle(.compact)
                 
                 DatePicker("End Date", selection: Binding(
-                    get: { endDate ?? Date() },
+                    get: { endDate ?? Date.now },
                     set: { endDate = $0 }
                 ), displayedComponents: .date)
                 .datePickerStyle(.compact)

--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -129,8 +129,8 @@ struct ProfileAvatarButton: View {
                 firstName: "John",
                 lastName: "Doe",
                 signInMethod: .email,
-                createdAt: Date(),
-                updatedAt: Date()
+                createdAt: Date.now,
+                updatedAt: Date.now
             ),
             size: 50
         ) { }

--- a/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
+++ b/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
@@ -156,7 +156,7 @@ struct AppleSignInButtonView: UIViewRepresentable {
             NSLog("🍎 [SocialSignInButton] Performing authorization request...")
             
             // Save the attempt time for debugging
-            UserDefaults.standard.set(Date(), forKey: "lastAppleSignInRequestTime")
+            UserDefaults.standard.set(Date.now, forKey: "lastAppleSignInRequestTime")
             
             controller.performRequests()
         }

--- a/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CalendarShortcutButton: View {
     var body: some View {
-        NavigationLink(destination: CalendarView(selectedDate: Date())) {
+        NavigationLink(destination: CalendarView(selectedDate: Date.now)) {
             HStack {
                 Image(systemName: "calendar")
                     .foregroundColor(ColorTheme.accent)

--- a/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
@@ -150,7 +150,7 @@ struct TodaysActivitySummaryView: View {
 #Preview {
     TodaysActivitySummaryView(
         viewModel: RecentActivityViewModel(),
-        selectedDate: Date()
+        selectedDate: Date.now
     )
     .environmentObject(AppRouter.shared)
     .environmentObject(PreviewAuthService())

--- a/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
@@ -11,7 +11,7 @@ struct WeekSelector: View {
 
     private var weekDates: [Date] {
         // Center today (or the navigated day) in the week: 3 days before, center, 3 days after
-        let baseDate = calendar.date(byAdding: .day, value: weekOffset * 7, to: Date()) ?? Date()
+        let baseDate = calendar.date(byAdding: .day, value: weekOffset * 7, to: Date.now) ?? Date.now
         let startDate = calendar.date(byAdding: .day, value: -3, to: baseDate) ?? baseDate
         return (0..<daysInWeek).compactMap { offset in
             calendar.date(byAdding: .day, value: offset, to: startDate)
@@ -79,7 +79,7 @@ struct WeekSelector: View {
                             Group {
                                 if selectedDate.isSameDay(as: date) {
                                     ColorTheme.accent
-                                } else if date.isSameDay(as: Date()) {
+                                } else if date.isSameDay(as: Date.now) {
                                     ColorTheme.accent.opacity(0.3)
                                 } else {
                                     ColorTheme.cardBackground
@@ -88,7 +88,7 @@ struct WeekSelector: View {
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)
-                                .stroke(date.isSameDay(as: Date()) ? ColorTheme.accent : Color.clear, lineWidth: 2)
+                                .stroke(date.isSameDay(as: Date.now) ? ColorTheme.accent : Color.clear, lineWidth: 2)
                         )
                         .cornerRadius(10)
                         .shadow(color: selectedDate.isSameDay(as: date) ? ColorTheme.shadowColor : .clear, radius: 4, x: 0, y: 2)
@@ -100,7 +100,7 @@ struct WeekSelector: View {
                 updateWeekOffsetForSelectedDate()
             }
             .onChange(of: selectedDate) {
-                if selectedDate.isSameDay(as: Date()) {
+                if selectedDate.isSameDay(as: Date.now) {
                     weekOffset = 0
                 }
             }
@@ -144,14 +144,14 @@ struct WeekSelector: View {
         withAnimation(.easeInOut(duration: 0.3)) {
             weekOffset = 0
             // Update selected date to today
-            selectedDate = Date()
-            onDateSelected?(Date())
+            selectedDate = Date.now
+            onDateSelected?(Date.now)
         }
     }
     
     /// Update week offset to show the week containing the selected date
     private func updateWeekOffsetForSelectedDate() {
-        let today = calendar.startOfDay(for: Date())
+        let today = calendar.startOfDay(for: Date.now)
         let selected = calendar.startOfDay(for: selectedDate)
         let daysDifference = calendar.dateComponents([.day], from: today, to: selected).day ?? 0
         // Convert day difference to week offset (rounds toward zero)

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -280,7 +280,7 @@ struct MealAnalysis {
     NavigationView {
         MealConfirmationView(meal: Meal(
             name: "Lunch",
-            date: Date(),
+            date: Date.now,
             type: .lunch,
             source: .manual,
             foodItems: [

--- a/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
+++ b/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
@@ -87,7 +87,7 @@ struct LogMedicationDoseView: View {
                 DatePicker(
                     "Date & Time",
                     selection: $viewModel.dateTaken,
-                    in: ...Date(),
+                    in: ...Date.now,
                     displayedComponents: [.date, .hourAndMinute]
                 )
                 .datePickerStyle(.compact)

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -328,7 +328,7 @@ struct DoseCalendarRow: View {
 
 @MainActor
 class MedicationCalendarViewModel: ObservableObject {
-    @Published var selectedDate = Date()
+    @Published var selectedDate = Date.now
     @Published var doses: [MedicationDoseLog] = []
     @Published var isLoading = false
 

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -183,7 +183,7 @@ struct MedicationsView: View {
         guard let userId = AuthenticationManager.shared.currentUserId else { return }
         isLoadingDoses = true
         do {
-            todayDoses = try await MedicationDoseRepository.shared.fetchDosesForDate(Date(), userId: userId)
+            todayDoses = try await MedicationDoseRepository.shared.fetchDosesForDate(Date.now, userId: userId)
         } catch {
             print("⚠️ MedicationsView: failed to load today's doses: \(error)")
         }

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
         let date = Date(timeIntervalSince1970: lastHealthKitSyncTimestamp)
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
-        return "Synced \(formatter.localizedString(for: date, relativeTo: Date()))"
+        return "Synced \(formatter.localizedString(for: date, relativeTo: Date.now))"
     }
 
     var body: some View {

--- a/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
@@ -86,7 +86,7 @@ struct HealthKitTestView: View {
                 if success {
                     isAuthorized = true
                     statusMessage = "✅ HealthKit authorized successfully!"
-                    testResults.append("✅ Authorization granted at \(Date().formatted())")
+                    testResults.append("✅ Authorization granted at \(Date.now.formatted())")
                 } else {
                     statusMessage = "❌ HealthKit authorization failed: \(error?.localizedDescription ?? "Unknown error")"
                     testResults.append("❌ Authorization failed: \(error?.localizedDescription ?? "Unknown")")
@@ -117,7 +117,7 @@ struct HealthKitTestView: View {
         
         let testMeal = Meal(
             name: "HealthKit Test Meal",
-            date: Date(),
+            date: Date.now,
             type: .lunch,
             source: .manual,
             foodItems: [testFoodItem],
@@ -146,7 +146,7 @@ struct HealthKitTestView: View {
         
         // Create test symptom
         let testSymptom = Symptom(
-            date: Date(),
+            date: Date.now,
             stoolType: .type4,
             painLevel: .mild,
             urgencyLevel: .mild,

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -21,8 +21,8 @@ struct HealthcareExportView: View {
     @State private var errorMessage = ""
     
     // Date range picker states
-    @State private var startDate = Calendar.current.date(byAdding: .month, value: -3, to: Date()) ?? Date()
-    @State private var endDate = Date()
+    @State private var startDate = Calendar.current.date(byAdding: .month, value: -3, to: Date.now) ?? Date.now
+    @State private var endDate = Date.now
     
     var body: some View {
         NavigationView {


### PR DESCRIPTION
## Summary

- Replaces all 151 instances of `Date()` with `Date.now` across 54 files
- `Date.now` is more expressive and makes intent clear — the code wants the current date/time, not an arbitrary `Date` construction
- Pure rename with no behavioral change

## Files Changed

**Models (7):** DataDeletionRequest, Meal, Symptom, MedicationModels, UserProfile, User, ReminderSettings
**Services (18):** CoreDataStack, CoreDataStorageService, DataSyncService, DataSyncManager, PreviewAuthService, HealthKitManager, HealthKitMedicationService, HealthKitSyncManager, HealthcareExportService, InsightsService, PatternRecognitionService, MealBuilderService, PrivacyPolicyManager, ReminderSettingsService, RemindersKitService, ServerStatusService, LocalProfileImageStrategy, TimeoutManager
**ViewModels (10):** CategoryInsightsViewModel, InsightsViewModel, DashboardDataStore, HealthKitViewModel, MealBuilderModelView, MealDetailViewModel, MedicationViewModel, LogSymptomViewModel, SymptomDetailViewModel
**Views (19):** SymptomDetailView, SymptomEditView, CalendarDetailView, CalendarView, MealSummaryCard, SymptomSummaryCard, UnifiedCalendarView, PaginationComponents, ProfileAvatarButton, SocialSignInButton, CalendarShortcutButton, TodaysActivitySummaryView, WeekSelector, MealConfirmationView, LogMedicationDoseView, MedicationCalendarView, MedicationsView, SettingsView, HealthKitTestView, HealthcareExportView, DashboardView

## Test plan

- [ ] Build succeeds with zero errors (verified)
- [ ] App launches and displays dashboard correctly
- [ ] Dates display correctly throughout the app (meals, symptoms, calendar)
- [ ] New entries are timestamped with the current time

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)