### PR TITLE
fix(#224): replace Task.sleep(nanoseconds:) with Task.sleep(for:)

### DIFF
--- a/GutCheck/GutCheck/Navigation/RefreshManager.swift
+++ b/GutCheck/GutCheck/Navigation/RefreshManager.swift
@@ -16,7 +16,7 @@ class RefreshManager: ObservableObject {
     func triggerRefreshAfterSave() {
         // Wait a short moment to allow database operations to complete
         Task {
-            try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+            try? await Task.sleep(for: .milliseconds(500))
             triggerRefresh()
         }
     }

--- a/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
@@ -300,11 +300,11 @@ class DataSyncService: ObservableObject {
                 do {
                     try await performIncrementalSync()
                     // Wait 15 minutes before next sync
-                    try await Task.sleep(nanoseconds: 15 * 60 * 1_000_000_000)
+                    try await Task.sleep(for: .seconds(15 * 60))
                 } catch {
                     print("Background sync failed: \(error)")
                     // Wait 5 minutes before retry on failure
-                    try await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
+                    try await Task.sleep(for: .seconds(5 * 60))
                 }
             }
         }

--- a/GutCheck/GutCheck/Services/DataSyncManager.swift
+++ b/GutCheck/GutCheck/Services/DataSyncManager.swift
@@ -73,7 +73,7 @@ class DataSyncManager: ObservableObject {
     /// Trigger refresh with delay (useful for UI transitions)
     func triggerRefreshWithDelay(seconds: Double = 0.5, dataType: DataType = .dashboard) {
         Task {
-            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            try? await Task.sleep(for: .seconds(seconds))
             await MainActor.run {
                 triggerRefresh(for: dataType)
             }

--- a/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
+++ b/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
@@ -178,7 +178,7 @@ class BaseFirebaseRepository<T: FirestoreModel & DataClassifiable>: FirebaseRepo
                 if attempt < maxRetries - 1 {
                     let delay = pow(2.0, Double(attempt)) // Exponential backoff
                     print("🔄 Retry attempt \(attempt + 1) after \(delay) seconds")
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    try await Task.sleep(for: .seconds(delay))
                 }
             }
         }

--- a/GutCheck/GutCheck/Services/ServerStatusService.swift
+++ b/GutCheck/GutCheck/Services/ServerStatusService.swift
@@ -67,7 +67,7 @@ class ServerStatusService: ObservableObject {
 
         // Initial Firebase probe after a short delay
         Task {
-            try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s delay
+            try? await Task.sleep(for: .seconds(2))
             await performFirebaseCheck()
             startCountdown()
         }


### PR DESCRIPTION
## Summary
- Replaces all 6 instances of `Task.sleep(nanoseconds:)` with the modern `Task.sleep(for:)` API across 5 files
- Uses appropriate `Duration` values: `.milliseconds(500)`, `.seconds(2)`, `.seconds(delay)`, `.seconds(seconds)`, `.seconds(15 * 60)`, `.seconds(5 * 60)`
- Eliminates manual nanosecond arithmetic and `UInt64` casts

Closes #224

## Test plan
- [x] Verify the project builds successfully
- [x] Verify refresh-after-save delay (~500ms) still works in RefreshManager
- [x] Verify background sync intervals (15min normal, 5min retry) in DataSyncService
- [x] Verify configurable delay in DataSyncManager.triggerRefreshWithDelay
- [x] Verify exponential backoff retry in FirebaseRepository
- [x] Verify 2-second initial probe delay in ServerStatusService

🤖 Generated with [Claude Code](https://claude.com/claude-code)