### PR TITLE
fix(#219): replace foregroundColor() with foregroundStyle() across codebase

### DIFF
--- a/GutCheck/GutCheck/Extensions/View+Modifiers.swift
+++ b/GutCheck/GutCheck/Extensions/View+Modifiers.swift
@@ -13,7 +13,7 @@ extension View {
         self
             .padding()
             .background(ColorTheme.buttonPrimary)
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .cornerRadius(8)
     }
     
@@ -21,7 +21,7 @@ extension View {
         self
             .padding()
             .background(ColorTheme.buttonSecondary)
-            .foregroundColor(ColorTheme.text)
+            .foregroundStyle(ColorTheme.text)
             .cornerRadius(8)
     }
     

--- a/GutCheck/GutCheck/SearchTest.swift
+++ b/GutCheck/GutCheck/SearchTest.swift
@@ -27,7 +27,7 @@ struct SearchTestView: View {
             
             if !errorMessage.isEmpty {
                 Text("Error: \(errorMessage)")
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
             }
             
             Text("Results: \(testResults.count)")

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
@@ -42,11 +42,11 @@ struct BristolStoolInfoView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Medical Classification System")
                             .font(.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text("Select the type that best matches your bowel movement consistency.")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
@@ -86,7 +86,7 @@ struct BristolStoolInfoView: View {
                     Button("Done") {
                         dismiss()
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }
@@ -143,11 +143,11 @@ struct PainLevelInfoView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("0-10 Numeric Pain Scale")
                             .font(.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text("Rate your abdominal pain, cramping, or discomfort.")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
@@ -162,14 +162,14 @@ struct PainLevelInfoView: View {
                                     Text("\(level)")
                                         .font(.title2)
                                         .fontWeight(.bold)
-                                        .foregroundColor(.white)
+                                        .foregroundStyle(.white)
                                         .frame(width: 40, height: 40)
                                         .background(Circle().fill(painColor(for: level)))
                                     
                                     Text(painLabel(for: level))
                                         .font(.caption)
                                         .fontWeight(.medium)
-                                        .foregroundColor(ColorTheme.secondaryText)
+                                        .foregroundStyle(ColorTheme.secondaryText)
                                         .multilineTextAlignment(.center)
                                 }
                                 .frame(maxWidth: .infinity)
@@ -197,7 +197,7 @@ struct PainLevelInfoView: View {
                     Button("Done") {
                         dismiss()
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }
@@ -239,11 +239,11 @@ struct UrgencyLevelInfoView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Urgency Classification")
                             .font(.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text("How urgently did you need to use the bathroom?")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
@@ -262,7 +262,7 @@ struct UrgencyLevelInfoView: View {
                                     Text(urgencyLabel(for: level))
                                         .font(.caption)
                                         .fontWeight(.medium)
-                                        .foregroundColor(ColorTheme.secondaryText)
+                                        .foregroundStyle(ColorTheme.secondaryText)
                                 }
                                 .frame(maxWidth: .infinity)
                             }
@@ -289,7 +289,7 @@ struct UrgencyLevelInfoView: View {
                     Button("Done") {
                         dismiss()
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }
@@ -328,14 +328,14 @@ struct BristolQuickCard: View {
             Text("\(type)")
                 .font(.title2)
                 .fontWeight(.bold)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(color))
             
             Text(title)
                 .font(.caption)
                 .fontWeight(.medium)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
         }
@@ -358,7 +358,7 @@ struct BristolDetailCard: View {
             Text("\(type)")
                 .font(.title3)
                 .fontWeight(.bold)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(width: 28, height: 28)
                 .background(Circle().fill(color))
             
@@ -366,11 +366,11 @@ struct BristolDetailCard: View {
                 Text(title)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -394,7 +394,7 @@ struct LegendItem: View {
             Text(text)
                 .font(.caption)
                 .fontWeight(.medium)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
     }
 }
@@ -410,7 +410,7 @@ struct PainRangeCard: View {
             Text(range)
                 .font(.subheadline)
                 .fontWeight(.bold)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(width: 36, height: 28)
                 .background(RoundedRectangle(cornerRadius: 6).fill(color))
             
@@ -418,11 +418,11 @@ struct PainRangeCard: View {
                 Text(title)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -449,11 +449,11 @@ struct UrgencyCard: View {
                 Text(level)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()

--- a/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
+++ b/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
@@ -102,7 +102,7 @@ struct DeletionRequestRow: View {
                         
                         Text(request.userEmail)
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                     
                     Spacer()
@@ -112,21 +112,21 @@ struct DeletionRequestRow: View {
                         
                         Text(request.formattedRequestDate)
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 
                 if let reason = request.reason, !reason.isEmpty {
                     Text("Reason: \(reason)")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
                 
                 HStack {
                     Text("Data to delete:")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     
                     Spacer()
                     
@@ -170,7 +170,7 @@ struct StatusBadge: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(Color(status.color).opacity(0.2))
-            .foregroundColor(Color(status.color))
+            .foregroundStyle(Color(status.color))
             .clipShape(Capsule())
     }
 }
@@ -188,7 +188,7 @@ struct DataTypeBadge: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.2))
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .clipShape(Capsule())
     }
 }
@@ -296,10 +296,10 @@ struct DataScopeRow: View {
             Spacer()
             if isSelected {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
             } else {
                 Image(systemName: "circle")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
@@ -38,11 +38,11 @@ struct CategoryInsightsView: View {
         VStack(spacing: 16) {
             Image(systemName: category.iconName)
                 .font(.system(size: 48))
-                .foregroundColor(category.accentColor)
+                .foregroundStyle(category.accentColor)
             
             Text(category.description)
                 .font(.body)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
         }
         .padding()
@@ -55,7 +55,7 @@ struct CategoryInsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Active Insights")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.activeInsights) { insight in
                 NavigationLink(destination: InsightDetailView(insight: insight)) {
@@ -69,7 +69,7 @@ struct CategoryInsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Historical Insights")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.historicalInsights) { insight in
                 NavigationLink(destination: InsightDetailView(insight: insight)) {
@@ -83,15 +83,15 @@ struct CategoryInsightsView: View {
         VStack(spacing: 16) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 48))
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("No Insights Yet")
                 .font(.title3.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             Text("Keep logging your meals and symptoms. We'll analyze your data to provide insights in this category.")
                 .font(.body)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
         }
         .padding()
@@ -111,33 +111,33 @@ private struct ActiveInsightRow: View {
             HStack {
                 Image(systemName: insight.iconName)
                     .font(.title2)
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 
                 Text(insight.title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
                 Text("\(insight.confidenceLevel)%")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Text(insight.summary)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .lineLimit(2)
             
             HStack {
                 Text(insight.dateRange)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 
                 Spacer()
                 
                 Image(systemName: "chevron.right")
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding()
@@ -154,22 +154,22 @@ private struct HistoricalInsightRow: View {
             HStack {
                 Image(systemName: insight.iconName)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 
                 Text(insight.title)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 
                 Spacer()
                 
                 Text(insight.dateRange)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Text(insight.summary)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .lineLimit(1)
         }
         .padding()

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -15,7 +15,7 @@ struct InsightDetailView: View {
                     if let description = insight.detailedDescription {
                         Text(description)
                             .font(.body)
-                            .foregroundColor(ColorTheme.text.opacity(0.8))
+                            .foregroundStyle(ColorTheme.text.opacity(0.8))
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -35,7 +35,7 @@ struct InsightDetailView: View {
                             .frame(height: 200)
                             .overlay(
                                 Text("Chart Visualization")
-                                    .foregroundColor(ColorTheme.accent)
+                                    .foregroundStyle(ColorTheme.accent)
                                     .font(.headline)
                             )
                     }
@@ -112,7 +112,7 @@ private struct InsightHeaderView: View {
             Label(insight.title, systemImage: insight.iconName)
                 .font(.title2)
                 .bold()
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             
             Text(insight.summary)
                 .font(.headline)
@@ -124,7 +124,7 @@ private struct InsightHeaderView: View {
                 Label(insight.dateRange, systemImage: "calendar")
             }
             .font(.subheadline)
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
         }
     }
 }
@@ -139,14 +139,14 @@ private struct ContributingFactorRow: View {
                     .font(.headline)
                 Text(factor.description)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Spacer()
             
             Text("\(Int(factor.impact * 100))%")
                 .font(.headline)
-                .foregroundColor(impactColor)
+                .foregroundStyle(impactColor)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 8)
@@ -183,7 +183,7 @@ private struct RelatedInsightRow: View {
                     .font(.subheadline)
                 Spacer()
                 Image(systemName: "chevron.right")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -67,7 +67,7 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Recent Insights")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
@@ -84,7 +84,7 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Categories")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             LazyVGrid(columns: [
                 GridItem(.flexible()),
@@ -101,7 +101,7 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Patterns")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.patterns) { pattern in
                 PatternRow(pattern: pattern)
@@ -113,7 +113,7 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Recommendations")
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.recommendations) { recommendation in
                 RecommendationCard(recommendation: recommendation)
@@ -150,12 +150,12 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 12) {
             Label("Most Frequent Symptoms", systemImage: "chart.bar.fill")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             if viewModel.topSymptoms.isEmpty {
                 Text("No symptoms logged this week")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 4)
             } else {
@@ -163,19 +163,19 @@ struct InsightsView: View {
                     HStack(spacing: 12) {
                         Text("\(index + 1)")
                             .font(.caption.bold())
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .frame(width: 22, height: 22)
                             .background(Circle().fill(rankColor(index)))
 
                         Text(item.name)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
 
                         Spacer()
 
                         Text("\(item.count)×")
                             .font(.subheadline.bold())
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 }
             }
@@ -190,12 +190,12 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 12) {
             Label("Top Triggering Foods", systemImage: "exclamationmark.triangle.fill")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             if viewModel.topTriggerFoods.isEmpty {
                 Text("Not enough data to identify triggers yet")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 4)
             } else {
@@ -203,18 +203,18 @@ struct InsightsView: View {
                     HStack(spacing: 12) {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.caption)
-                            .foregroundColor(rankColor(index))
+                            .foregroundStyle(rankColor(index))
 
                         Text(item.name)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                             .lineLimit(1)
 
                         Spacer()
 
                         Text("\(item.count) correlation\(item.count == 1 ? "" : "s")")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 }
             }
@@ -229,34 +229,34 @@ struct InsightsView: View {
         VStack(alignment: .leading, spacing: 12) {
             Label("Best Days", systemImage: "checkmark.seal.fill")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             if viewModel.bestDays.isEmpty {
                 Text("Log symptoms for a week to see your best days")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 4)
             } else {
                 ForEach(Array(viewModel.bestDays.enumerated()), id: \.element.id) { index, item in
                     HStack(spacing: 12) {
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(ColorTheme.success)
+                            .foregroundStyle(ColorTheme.success)
 
                         Text(item.name)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
 
                         Spacer()
 
                         if item.count == 0 {
                             Text("Symptom-free")
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.success)
+                                .foregroundStyle(ColorTheme.success)
                         } else {
                             Text("Low symptoms")
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                         }
                     }
                 }
@@ -290,15 +290,15 @@ private struct WeeklyStatPill: View {
         VStack(spacing: 6) {
             Image(systemName: icon)
                 .font(.title3)
-                .foregroundColor(color)
+                .foregroundStyle(color)
 
             Text(value)
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             Text(label)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
@@ -317,29 +317,29 @@ private struct AnalyticsInsightCard: View {
                 HStack {
                     Image(systemName: insight.iconName)
                         .font(.title2)
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                     
                     Spacer()
                     
                     Text("\(insight.confidenceLevel)%")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
                 
                 Text(insight.title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 
                 Text(insight.summary)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(2)
                 
                 Text(insight.dateRange)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
             }
             .padding()
             .background(ColorTheme.surface)
@@ -357,17 +357,17 @@ private struct CategoryCard: View {
             VStack(spacing: 12) {
                 Image(systemName: category.iconName)
                     .font(.title)
-                    .foregroundColor(category.accentColor)
+                    .foregroundStyle(category.accentColor)
                 
                 Text(category.title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 
                 Text(category.description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
             }
@@ -387,23 +387,23 @@ private struct PatternRow: View {
         HStack(spacing: 16) {
             Image(systemName: pattern.iconName)
                 .font(.title2)
-                .foregroundColor(ColorTheme.accent)
+                .foregroundStyle(ColorTheme.accent)
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(pattern.title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(pattern.description)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(2)
             }
             
             Spacer()
             
             Image(systemName: "chevron.right")
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .padding()
         .background(ColorTheme.surface)
@@ -419,23 +419,23 @@ private struct RecommendationCard: View {
             HStack {
                 Image(systemName: recommendation.iconName)
                     .font(.title2)
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 
                 Text(recommendation.title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
             
             Text(recommendation.description)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             if !recommendation.actionItems.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(recommendation.actionItems, id: \.self) { action in
                         Label(action, systemImage: "checkmark.circle")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                     }
                 }
             }

--- a/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
@@ -18,18 +18,18 @@ struct EmailVerificationView: View {
             // Icon
             Image(systemName: "envelope.badge")
                 .font(.system(size: 60))
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             
             // Title
             VStack(spacing: 12) {
                 Text("Verify Your Email")
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                 
                 Text("We sent a verification link to your email address. Please check your inbox and tap the link to continue.")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 16)
             }
@@ -71,7 +71,7 @@ struct EmailVerificationView: View {
                 } label: {
                     Text("Back to Sign In")
                         .font(.footnote)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                 }
             }
             .padding(.horizontal, 24)

--- a/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
@@ -43,7 +43,7 @@ struct RegisterView: View {
                         
                         Text("Track your digestive health journey with GutCheck")
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
                     }
                     .padding(.top)
@@ -80,13 +80,13 @@ struct RegisterView: View {
                         if !password.isEmpty && password.count < 8 {
                             Text("Password must be at least 8 characters")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                         }
                         
                         if !confirmPassword.isEmpty && password != confirmPassword {
                             Text("Passwords do not match")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                         }
                     }
                     .padding(.horizontal)
@@ -109,7 +109,7 @@ struct RegisterView: View {
                     if let error = errorMessage {
                         Text(error)
                             .font(.subheadline)
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal)
                     }
@@ -127,7 +127,7 @@ struct RegisterView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(isFormValid ? ColorTheme.primary : Color.gray)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .cornerRadius(10)
                     .padding(.horizontal)
                     .disabled(!isFormValid || isLoading)

--- a/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
@@ -84,16 +84,16 @@ private struct WelcomePageView: View {
                 Text(page.title)
                     .font(.largeTitle)
                     .bold()
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                 
                 Text(page.subtitle)
                     .font(.title2)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 Text(page.description)
                     .font(.body)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                     .padding(.horizontal)
             }
         }

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -78,11 +78,11 @@ struct AuthenticationView: View {
                 Text("GutCheck")
                     .font(.largeTitle)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                 
                 Text(viewModel.isShowingSignUp ? "Create your account" : "Welcome back")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding(.top, 40)
@@ -113,7 +113,7 @@ struct AuthenticationView: View {
                     viewModel.isShowingForgotPassword = true
                 }
                 .font(.footnote)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             }
             
             // Sign In Button
@@ -193,12 +193,12 @@ struct AuthenticationView: View {
             HStack {
                 Text("Password Strength:")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 
                 Text(viewModel.passwordStrength.text)
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(viewModel.passwordStrength.color)
+                    .foregroundStyle(viewModel.passwordStrength.color)
                 
                 Spacer()
             }
@@ -214,11 +214,11 @@ struct AuthenticationView: View {
     private var passwordMatchIndicator: some View {
         HStack {
             Image(systemName: viewModel.password == viewModel.confirmPassword ? "checkmark.circle.fill" : "xmark.circle.fill")
-                .foregroundColor(viewModel.password == viewModel.confirmPassword ? ColorTheme.success : ColorTheme.error)
+                .foregroundStyle(viewModel.password == viewModel.confirmPassword ? ColorTheme.success : ColorTheme.error)
             
             Text(viewModel.password == viewModel.confirmPassword ? "Passwords match" : "Passwords don't match")
                 .font(.caption)
-                .foregroundColor(viewModel.password == viewModel.confirmPassword ? ColorTheme.success : ColorTheme.error)
+                .foregroundStyle(viewModel.password == viewModel.confirmPassword ? ColorTheme.success : ColorTheme.error)
             
             Spacer()
         }
@@ -234,7 +234,7 @@ struct AuthenticationView: View {
             Button(action: viewModel.toggleAuthMode) {
                 Text(viewModel.isShowingSignUp ? "Already have an account? Sign In" : "Don't have an account? Sign Up")
                     .font(.footnote)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
         }
     }
@@ -273,11 +273,11 @@ struct AuthenticationView: View {
                     Text("Reset Password")
                         .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundColor(ColorTheme.text)
+                        .foregroundStyle(ColorTheme.text)
                     
                     Text("Enter your email address and we'll send you a link to reset your password.")
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .multilineTextAlignment(.center)
                 }
                 
@@ -306,7 +306,7 @@ struct AuthenticationView: View {
                     Button("Cancel") {
                         viewModel.isShowingForgotPassword = false
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }

--- a/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
@@ -35,16 +35,16 @@ struct BristolScaleSelectionView: View {
                             Text("\(info.type.rawValue)")
                                 .typography(Typography.title2)
                                 .fontWeight(.bold)
-                                .foregroundColor(selectedStoolType == info.type ? .white : bristolTextColor(for: info.type))
+                                .foregroundStyle(selectedStoolType == info.type ? .white : bristolTextColor(for: info.type))
                             Text(info.summary)
                                 .typography(Typography.caption)
-                                .foregroundColor(selectedStoolType == info.type ? .white.opacity(0.9) : ColorTheme.secondaryText)
+                                .foregroundStyle(selectedStoolType == info.type ? .white.opacity(0.9) : ColorTheme.secondaryText)
                                 .multilineTextAlignment(.center)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.8)
                             Text(info.description)
                                 .font(.caption)
-                                .foregroundColor(selectedStoolType == info.type ? .white.opacity(0.8) : ColorTheme.secondaryText)
+                                .foregroundStyle(selectedStoolType == info.type ? .white.opacity(0.8) : ColorTheme.secondaryText)
                                 .multilineTextAlignment(.center)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.7)
@@ -124,7 +124,7 @@ struct PainLevelSliderView: View {
                                 Text("\(i)")
                                     .typography(Typography.title2)
                                     .fontWeight(.semibold)
-                                    .foregroundColor(selectedPainLevel == i ? .white : painColor(for: i))
+                                    .foregroundStyle(selectedPainLevel == i ? .white : painColor(for: i))
                                     .frame(width: 40, height: 40)
                                     .background(
                                         Circle()
@@ -137,7 +137,7 @@ struct PainLevelSliderView: View {
                                 Text(labels[i])
                                     .typography(Typography.caption)
                                     .fontWeight(.medium)
-                                    .foregroundColor(selectedPainLevel == i ? ColorTheme.primaryText : ColorTheme.secondaryText)
+                                    .foregroundStyle(selectedPainLevel == i ? ColorTheme.primaryText : ColorTheme.secondaryText)
                             }
                         }
                         .frame(maxWidth: .infinity)
@@ -157,7 +157,7 @@ struct PainLevelSliderView: View {
                 if selectedPainLevel < descriptions.count {
                     Text(descriptions[selectedPainLevel])
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.top, 4)
                 }
@@ -218,7 +218,7 @@ struct UrgencyLevelSelectionView: View {
                             Text(label)
                                 .typography(Typography.caption)
                                 .fontWeight(.medium)
-                                .foregroundColor(selectedUrgencyLevel == level ? ColorTheme.primaryText : ColorTheme.secondaryText)
+                                .foregroundStyle(selectedUrgencyLevel == level ? ColorTheme.primaryText : ColorTheme.secondaryText)
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
@@ -266,7 +266,7 @@ struct TagSelectionView: View {
             Text("Tags")
                 .typography(Typography.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 8)], spacing: 8) {
                 ForEach(allTags, id: \.self) { tag in
@@ -283,7 +283,7 @@ struct TagSelectionView: View {
                             .fontWeight(.medium)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 8)
-                            .foregroundColor(selectedTags.contains(tag) ? .white : ColorTheme.secondaryText)
+                            .foregroundStyle(selectedTags.contains(tag) ? .white : ColorTheme.secondaryText)
                             .background(
                                 RoundedRectangle(cornerRadius: 16)
                                     .fill(selectedTags.contains(tag) ? ColorTheme.accent : ColorTheme.cardBackground)
@@ -388,7 +388,7 @@ struct SectionHeader: View {
             Text(title)
                 .typography(Typography.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
                 .accessibleHeader(title)
             Button(action: {
                 HapticManager.shared.light()
@@ -396,7 +396,7 @@ struct SectionHeader: View {
             }) {
                 Image(systemName: "info.circle")
                     .font(.title3)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
             .accessibleButton(
                 label: "Information about \(title)",
@@ -416,18 +416,18 @@ struct SectionHeader: View {
             Text("Symptom Time")
                 .typography(Typography.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             Button(action: {
                 HapticManager.shared.light()
                 showingDatePicker = true
             }) {
                 HStack {
                     Image(systemName: "calendar")
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                         .accessibleDecorative()
                     Text(coordinator.symptomDate.formattedDateTime)
                         .typography(Typography.body)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
@@ -454,7 +454,7 @@ struct SectionHeader: View {
             Text("Notes")
                 .typography(Typography.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             TextEditor(text: $coordinator.notes)
                 .typography(Typography.body)
@@ -499,7 +499,7 @@ struct SectionHeader: View {
                         .typography(Typography.button)
                         .fontWeight(.semibold)
                 }
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
@@ -526,7 +526,7 @@ struct SectionHeader: View {
                     Text("Clear")
                         .typography(Typography.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
                         .background(
@@ -555,7 +555,7 @@ struct SectionHeader: View {
                     Text("Remind Later")
                         .typography(Typography.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
                         .background(

--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -103,7 +103,7 @@ struct PaginatedSymptomHistoryView: View {
                 } else if !viewModel.groupedSymptoms.isEmpty {
                     Text("No more symptoms")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .padding()
                 }
             }
@@ -144,11 +144,11 @@ struct SymptomDaySection: View {
                     Text(dayFormatter.string(from: date))
                         .font(.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                     
                     Text(dateFormatter.string(from: date))
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 
                 Spacer()
@@ -157,7 +157,7 @@ struct SymptomDaySection: View {
                 Text("\(symptoms.count)")
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(ColorTheme.accent)
@@ -208,7 +208,7 @@ struct SymptomRowView: View {
             Text(timeFormatter.string(from: symptom.date))
                 .font(.caption)
                 .fontWeight(.medium)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
                 .frame(width: 60, alignment: .leading)
             
             // Stool type indicator
@@ -245,7 +245,7 @@ struct SymptomRowView: View {
                 if let notes = symptom.notes, !notes.isEmpty {
                     Text(notes)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
             }
@@ -254,7 +254,7 @@ struct SymptomRowView: View {
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .font(.caption)
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
                     .padding(8)
                     .background(Circle().fill(Color.red.opacity(0.1)))
             }
@@ -291,11 +291,11 @@ struct SimpleIndicator: View {
         HStack(spacing: 2) {
             Image(systemName: icon)
                 .font(.caption)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             
             Text(text)
                 .font(.caption)
-                .foregroundColor(color)
+                .foregroundStyle(color)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -61,7 +61,7 @@ struct SymptomDetailView: View {
                 .scaleEffect(1.2)
             Text("Loading symptom details...")
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(ColorTheme.background)
@@ -135,11 +135,11 @@ struct SymptomDetailView: View {
                 Text(viewModel.entity.date.formatted(.dateTime.month(.abbreviated)).uppercased())
                     .font(.caption)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                     .kerning(0.5)
                 Text(viewModel.entity.date.formatted(.dateTime.day()))
                     .font(.system(size: 30, weight: .bold, design: .rounded))
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
             .frame(width: 58)
             .padding(.vertical, 10)
@@ -149,17 +149,17 @@ struct SymptomDetailView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(viewModel.entity.date.formatted(.dateTime.weekday(.wide)))
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Text(viewModel.entity.date.formatted(.dateTime.month(.wide).day().year()))
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 HStack(spacing: 4) {
                     Image(systemName: "clock")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.tertiaryText)
+                        .foregroundStyle(ColorTheme.tertiaryText)
                     Text(viewModel.entity.date.formatted(.dateTime.hour().minute()))
                         .font(.caption)
-                        .foregroundColor(ColorTheme.tertiaryText)
+                        .foregroundStyle(ColorTheme.tertiaryText)
                 }
             }
 
@@ -188,7 +188,7 @@ struct SymptomDetailView: View {
                             Text("Type \(viewModel.entity.stoolType.rawValue)")
                                 .font(.subheadline)
                                 .fontWeight(.semibold)
-                                .foregroundColor(stoolTypeColor)
+                                .foregroundStyle(stoolTypeColor)
                         }
                     )
                 }
@@ -243,14 +243,14 @@ struct SymptomDetailView: View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 16, weight: .medium))
-                .foregroundColor(iconColor)
+                .foregroundStyle(iconColor)
                 .frame(width: 28, height: 28)
                 .background(iconColor.opacity(0.12))
                 .cornerRadius(8)
 
             Text(label)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             Spacer()
 
@@ -265,19 +265,19 @@ struct SymptomDetailView: View {
             HStack(spacing: 12) {
                 Image(systemName: "note.text")
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(ColorTheme.info)
+                    .foregroundStyle(ColorTheme.info)
                     .frame(width: 28, height: 28)
                     .background(ColorTheme.info.opacity(0.12))
                     .cornerRadius(8)
 
                 Text("Notes")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
 
             Text(notes)
                 .font(.body)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.leading, 40)
         }
@@ -290,14 +290,14 @@ struct SymptomDetailView: View {
             HStack(spacing: 12) {
                 Image(systemName: "tag.fill")
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(ColorTheme.secondary)
+                    .foregroundStyle(ColorTheme.secondary)
                     .frame(width: 28, height: 28)
                     .background(ColorTheme.secondary.opacity(0.12))
                     .cornerRadius(8)
 
                 Text("Tags")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
 
             ScrollView(.horizontal, showsIndicators: false) {
@@ -306,7 +306,7 @@ struct SymptomDetailView: View {
                         Text(tag)
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(ColorTheme.primary)
+                            .foregroundStyle(ColorTheme.primary)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
                             .background(ColorTheme.primary.opacity(0.12))
@@ -332,7 +332,7 @@ struct SymptomDetailView: View {
         Text(label)
             .font(.caption)
             .fontWeight(.semibold)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(color.opacity(0.15))

--- a/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
@@ -38,7 +38,7 @@ struct SymptomEditView: View {
                     Text("Bristol Stool Scale")
                         .font(.title3)
                         .fontWeight(.semibold)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .padding(.bottom, 2)
                     BristolScaleSelectionView(selectedStoolType: $selectedStoolType)
 
@@ -46,7 +46,7 @@ struct SymptomEditView: View {
                     Text("Pain Level")
                         .font(.title3)
                         .fontWeight(.semibold)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .padding(.bottom, 2)
                     PainLevelSliderView(selectedPainLevel: $selectedPainLevel)
 
@@ -54,7 +54,7 @@ struct SymptomEditView: View {
                     Text("Urgency Level")
                         .font(.title3)
                         .fontWeight(.semibold)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .padding(.bottom, 2)
                     UrgencyLevelSelectionView(selectedUrgencyLevel: $selectedUrgencyLevel)
 
@@ -91,7 +91,7 @@ struct SymptomEditView: View {
             Text("Symptom Time")
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             DatePicker(
                 "",
                 selection: $symptomDate,
@@ -110,7 +110,7 @@ struct SymptomEditView: View {
             Text("Notes")
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             TextEditor(text: $notes)
                 .frame(minHeight: 100)
@@ -147,7 +147,7 @@ struct SymptomEditView: View {
                         .font(.headline)
                         .fontWeight(.semibold)
                 }
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
@@ -164,7 +164,7 @@ struct SymptomEditView: View {
                 Text("Cancel")
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                     .background(

--- a/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
@@ -15,7 +15,7 @@ struct SymptomExplanationView: View {
                             .bold()
                         
                         Text(symptomType.description)
-                            .foregroundColor(ColorTheme.text.opacity(0.8))
+                            .foregroundStyle(ColorTheme.text.opacity(0.8))
                     }
                     .padding()
                     .roundedCard()
@@ -42,7 +42,7 @@ struct SymptomExplanationView: View {
                             
                             ForEach(symptomType.commonTriggers, id: \.self) { trigger in
                                 Label(trigger, systemImage: "exclamationmark.triangle")
-                                    .foregroundColor(ColorTheme.text.opacity(0.8))
+                                    .foregroundStyle(ColorTheme.text.opacity(0.8))
                                     .padding(.vertical, 4)
                             }
                         }
@@ -58,7 +58,7 @@ struct SymptomExplanationView: View {
                         
                         ForEach(symptomType.managementTips, id: \.self) { tip in
                             Label(tip, systemImage: "checkmark.circle")
-                                .foregroundColor(ColorTheme.text.opacity(0.8))
+                                .foregroundStyle(ColorTheme.text.opacity(0.8))
                                 .padding(.vertical, 4)
                         }
                     }
@@ -73,7 +73,7 @@ struct SymptomExplanationView: View {
                         
                         ForEach(symptomType.warningSignals, id: \.self) { warning in
                             Label(warning, systemImage: "exclamationmark.shield")
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                                 .padding(.vertical, 4)
                         }
                     }
@@ -102,7 +102,7 @@ private struct SeverityRow: View {
         HStack(spacing: 16) {
             Text("\(level.range)")
                 .font(.headline)
-                .foregroundColor(level.color)
+                .foregroundStyle(level.color)
                 .frame(width: 60, alignment: .leading)
             
             VStack(alignment: .leading) {
@@ -110,7 +110,7 @@ private struct SeverityRow: View {
                     .font(.headline)
                 Text(level.description)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.text.opacity(0.8))
+                    .foregroundStyle(ColorTheme.text.opacity(0.8))
             }
         }
         .padding(.vertical, 8)

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -195,7 +195,7 @@ private struct SymptomRow: View {
                     .font(.headline)
                 Spacer()
                 Text(symptom.date.formatted(.dateTime.hour().minute()))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             HStack {
@@ -204,7 +204,7 @@ private struct SymptomRow: View {
                 if let notes = symptom.notes, !notes.isEmpty {
                     Text(notes)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -262,7 +262,7 @@ struct CalendarMealsSectionHeader: View {
                 Text("Meals")
                     .font(.title3)
                     .fontWeight(.semibold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
                 Button {
                     HapticManager.shared.medium()
@@ -278,7 +278,7 @@ struct CalendarMealsSectionHeader: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                     .background(Color.orange, in: Capsule())
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                 }
                 .accessibleButton(label: "Log Meal", hint: "Tap to log a new meal")
             }
@@ -309,7 +309,7 @@ struct CalendarSymptomsSectionHeader: View {
                 Text("Symptoms")
                     .font(.title3)
                     .fontWeight(.semibold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
                 Button {
                     HapticManager.shared.medium()
@@ -325,7 +325,7 @@ struct CalendarSymptomsSectionHeader: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                     .background(Color.orange, in: Capsule())
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                 }
                 .accessibleButton(label: "Log Symptom", hint: "Tap to log a new symptom")
                 .accessibilityIdentifier(AccessibilityIdentifiers.Calendar.floatingActionButton)
@@ -347,15 +347,15 @@ struct EmptyStateCard: View {
         VStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 40))
-                .foregroundColor(ColorTheme.secondaryText.opacity(0.5))
+                .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
             
             Text(title)
                 .font(.headline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text(message)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText.opacity(0.8))
+                .foregroundStyle(ColorTheme.secondaryText.opacity(0.8))
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
@@ -597,7 +597,7 @@ struct MealCalendarRow: View {
                     
                     Image(systemName: mealIcon)
                         .font(.system(size: 20, weight: .medium))
-                        .foregroundColor(mealIconColor)
+                        .foregroundStyle(mealIconColor)
                 }
                 
                 // Content
@@ -605,19 +605,19 @@ struct MealCalendarRow: View {
                     HStack {
                         Text(meal.type.rawValue.capitalized)
                             .font(.system(size: 17, weight: .semibold))
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Spacer()
                         
                         Text(formattedTime)
                             .font(.system(size: 15))
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     if !meal.foodItems.isEmpty {
                         Text(foodItemsPreview)
                             .font(.system(size: 15))
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
                     }
@@ -626,7 +626,7 @@ struct MealCalendarRow: View {
                 // Chevron
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(ColorTheme.secondaryText.opacity(0.3))
+                    .foregroundStyle(ColorTheme.secondaryText.opacity(0.3))
             }
             .padding(16)
             .contentShape(Rectangle())
@@ -706,7 +706,7 @@ struct SymptomCalendarRow: View {
                     
                     Image(systemName: "waveform.path.ecg")
                         .font(.system(size: 20, weight: .medium))
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
                 
                 // Content
@@ -714,39 +714,39 @@ struct SymptomCalendarRow: View {
                     HStack {
                         Text("Type \(symptom.stoolType.rawValue)")
                             .font(.system(size: 17, weight: .semibold))
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Spacer()
                         
                         Text(formattedTime)
                             .font(.system(size: 15))
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     HStack(spacing: 16) {
                         HStack(spacing: 6) {
                             Image(systemName: "bolt.fill")
                                 .font(.system(size: 12))
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                             Text(painLevelText)
                                 .font(.system(size: 14))
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                         }
                         
                         HStack(spacing: 6) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .font(.system(size: 12))
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                             Text(urgencyLevelText)
                                 .font(.system(size: 14))
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                         }
                     }
                     
                     if let notes = symptom.notes, !notes.isEmpty {
                         Text(notes)
                             .font(.system(size: 15))
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
                     }
@@ -755,7 +755,7 @@ struct SymptomCalendarRow: View {
                 // Chevron
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(ColorTheme.secondaryText.opacity(0.3))
+                    .foregroundStyle(ColorTheme.secondaryText.opacity(0.3))
             }
             .padding(16)
             .contentShape(Rectangle())
@@ -799,36 +799,36 @@ struct DailyNutritionCard: View {
             HStack {
                 Text("Daily Nutrition")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
                 if mealCount > 0 {
                     Text("See details")
                         .font(.caption)
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                     Image(systemName: "chevron.right")
                         .font(.caption)
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
             }
 
             if mealCount == 0 {
                 Text("Log a meal to see your daily nutrition totals.")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 // Calorie count — prominent
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(nutrition.calories ?? 0)")
                         .font(.system(size: 36, weight: .bold, design: .rounded))
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Text("kcal")
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     Spacer()
                     Text("\(mealCount) meal\(mealCount == 1 ? "" : "s")")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
 
                 // P / C / F pills
@@ -879,10 +879,10 @@ private struct MacroPill: View {
             Text(label)
                 .font(.caption)
                 .fontWeight(.semibold)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             Text(value.map { String(format: "%.1fg", $0) } ?? "--")
                 .font(.caption)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -913,24 +913,24 @@ struct DailySymptomCard: View {
             HStack {
                 Text("Daily Summary")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
             }
 
             if symptoms.isEmpty {
                 Text("Log a symptom to see your daily summary.")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 // Symptom count — prominent
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(symptoms.count)")
                         .font(.system(size: 36, weight: .bold, design: .rounded))
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Text("symptom\(symptoms.count == 1 ? "" : "s")")
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     Spacer()
                 }
 
@@ -969,10 +969,10 @@ private struct SymptomStatPill: View {
             Text(label)
                 .font(.caption)
                 .fontWeight(.semibold)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             Text(value)
                 .font(.caption)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -1134,14 +1134,14 @@ struct DailyNutritionDetailView: View {
                                 Spacer()
                                 Text("\(mealCalories) kcal")
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(.secondary)
                                     .monospacedDigit()
                                     .textCase(nil)
                             }
                         ) {
                             if meal.foodItems.isEmpty {
                                 Text("No food items logged")
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(.secondary)
                                     .font(.subheadline)
                             } else {
                                 ForEach(meal.foodItems) { item in
@@ -1155,7 +1155,7 @@ struct DailyNutritionDetailView: View {
                 if nutrition.calories == nil && details.isEmpty {
                     Section {
                         Text("No nutrition data for this day. Log a meal to see your breakdown.")
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .font(.subheadline)
                     }
                 }
@@ -1191,10 +1191,10 @@ struct NutritionDetailRow: View {
                 .fill(color.opacity(0.2))
                 .frame(width: 8, height: 8)
             Text(label)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
             Spacer()
             Text(formattedValue)
-                .foregroundColor(value != nil ? .primary : .secondary)
+                .foregroundStyle(value != nil ? .primary : .secondary)
                 .monospacedDigit()
         }
         .accessibilityElement(children: .combine)
@@ -1225,11 +1225,11 @@ private struct NutritionDetailFoodRow: View {
                     HStack(alignment: .top, spacing: 8) {
                         Text("Allergens")
                             .font(.subheadline)
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                         Spacer()
                         Text(item.allergens.joined(separator: ", "))
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .multilineTextAlignment(.trailing)
                     }
                     .padding(.top, 6)
@@ -1240,10 +1240,10 @@ private struct NutritionDetailFoodRow: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Ingredients")
                             .font(.subheadline)
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                         Text(item.ingredients.joined(separator: ", "))
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1257,16 +1257,16 @@ private struct NutritionDetailFoodRow: View {
                     Text(item.name)
                         .font(.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                     Text(item.quantity)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 Spacer()
                 if let cal = item.nutrition.calories {
                     Text("\(cal) kcal")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .monospacedDigit()
                 }
             }

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -7,16 +7,16 @@ struct MealSummaryCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(meal.type.rawValue)
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
             
             ForEach(meal.foodItems) { food in
                 Text(food.name)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Text(meal.date.formatted(date: .omitted, time: .shortened))
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))

--- a/GutCheck/GutCheck/Views/Calendar/Components/PatternSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/PatternSummaryCard.swift
@@ -7,11 +7,11 @@ struct PatternSummaryCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Identified Patterns")
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
             
             ForEach(patterns, id: \.self) { pattern in
                 Text(pattern)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding()

--- a/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
@@ -15,16 +15,16 @@ struct SymptomSummaryCard: View {
                 }
             }
             .font(.headline)
-            .foregroundColor(.primary)
+            .foregroundStyle(.primary)
             
             if let notes = symptom.notes, !notes.isEmpty {
                 Text(notes)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Text(symptom.date.formatted(date: .omitted, time: .shortened))
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))

--- a/GutCheck/GutCheck/Views/Calendar/Components/TriggerSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/TriggerSummaryCard.swift
@@ -7,11 +7,11 @@ struct TriggerSummaryCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Identified Triggers")
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
             
             ForEach(triggers, id: \.self) { trigger in
                 Text(trigger)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding()

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -65,7 +65,7 @@ struct UnifiedCalendarView: View {
                     .font(.title2)
                     .bold()
                 Text(selectedDate.formatted(.dateTime.year()))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Spacer()
@@ -88,7 +88,7 @@ struct UnifiedCalendarView: View {
             ForEach(calendar.veryShortWeekdaySymbols, id: \.self) { symbol in
                 Text(symbol)
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity)
             }
         }
@@ -125,7 +125,7 @@ private struct DayCell: View {
         VStack(spacing: 4) {
             Text("\(Calendar.current.component(.day, from: day.date))")
                 .font(.system(.body, design: .rounded))
-                .foregroundColor(isSelected ? .white : day.isCurrentMonth ? .primary : .secondary)
+                .foregroundStyle(isSelected ? .white : day.isCurrentMonth ? .primary : .secondary)
             
             if day.hasMeals || day.hasSymptoms {
                 HStack(spacing: 4) {
@@ -162,7 +162,7 @@ private struct DailySummaryCard: View {
             if day.hasMeals {
                 VStack(alignment: .leading, spacing: 8) {
                     Label("Meals", systemImage: "fork.knife")
-                        .foregroundColor(ColorTheme.mealLogging)
+                        .foregroundStyle(ColorTheme.mealLogging)
                     ForEach(day.meals) { meal in
                         Text(meal.name)
                             .font(.subheadline)
@@ -173,7 +173,7 @@ private struct DailySummaryCard: View {
             if day.hasSymptoms {
                 VStack(alignment: .leading, spacing: 8) {
                     Label("Symptoms", systemImage: "waveform.path.ecg")
-                        .foregroundColor(ColorTheme.bowelTracking)
+                        .foregroundStyle(ColorTheme.bowelTracking)
                     ForEach(day.symptoms) { symptom in
                         Text("Stool: \(symptom.stoolType.rawValue), Pain: \(symptom.painLevel.rawValue)")
                             .font(.subheadline)

--- a/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
@@ -31,15 +31,15 @@ struct CameraPermissionView: View {
             VStack(spacing: 16) {
                 Image(systemName: "camera.metering.none")
                     .font(.system(size: 72))
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 
                 Text(title)
                     .font(.title2.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(message)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(nil)
             }
             
@@ -66,17 +66,17 @@ struct CameraPermissionView: View {
         VStack(spacing: 12) {
             HStack(spacing: 12) {
                 Image(systemName: permissionManager.cameraStatus.statusIcon)
-                    .foregroundColor(permissionManager.cameraStatus.statusColor)
+                    .foregroundStyle(permissionManager.cameraStatus.statusColor)
                     .font(.system(size: 20))
                 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Camera Permission")
                         .font(.subheadline.bold())
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     Text(permissionManager.cameraStatus.statusText)
                         .font(.caption)
-                        .foregroundColor(permissionManager.cameraStatus.statusColor)
+                        .foregroundStyle(permissionManager.cameraStatus.statusColor)
                 }
                 
                 Spacer()
@@ -86,33 +86,33 @@ struct CameraPermissionView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("To enable camera access:")
                         .font(.caption.bold())
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     HStack(spacing: 8) {
                         Text("1.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("Open Settings app")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     HStack(spacing: 8) {
                         Text("2.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("Find 'GutCheck' in the app list")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     HStack(spacing: 8) {
                         Text("3.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("Enable 'Camera' permission")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 }
                 .padding(.top, 8)
@@ -139,7 +139,7 @@ struct CameraPermissionView: View {
                     }
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -150,7 +150,7 @@ struct CameraPermissionView: View {
                     permissionManager.openAppSettings()
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -160,7 +160,7 @@ struct CameraPermissionView: View {
                     onPermissionGranted()
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.success)
@@ -172,7 +172,7 @@ struct CameraPermissionView: View {
                 // Could show an info sheet or modal
             }
             .font(.caption)
-            .foregroundColor(ColorTheme.primary)
+            .foregroundStyle(ColorTheme.primary)
         }
     }
     

--- a/GutCheck/GutCheck/Views/Components/CustomButton.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomButton.swift
@@ -73,7 +73,7 @@ struct CustomButton: View {
             .frame(maxWidth: .infinity)
             .frame(height: 50)
             .background(isDisabled ? ColorTheme.disabled : style.backgroundColor)
-            .foregroundColor(style.foregroundColor)
+            .foregroundStyle(style.foregroundColor)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(style.borderColor, lineWidth: style == .outline ? 2 : 0)

--- a/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
@@ -82,10 +82,10 @@ struct TabBarItem: View {
             VStack(spacing: 2) {
                 Image(systemName: icon)
                     .font(.system(size: 22, weight: .medium))
-                    .foregroundColor(isSelected ? ColorTheme.primary : ColorTheme.secondaryText)
+                    .foregroundStyle(isSelected ? ColorTheme.primary : ColorTheme.secondaryText)
                 Text(label)
                     .font(.caption)
-                    .foregroundColor(isSelected ? ColorTheme.primary : ColorTheme.secondaryText)
+                    .foregroundStyle(isSelected ? ColorTheme.primary : ColorTheme.secondaryText)
             }
             .frame(maxWidth: .infinity)
         }

--- a/GutCheck/GutCheck/Views/Components/CustomTextField.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTextField.swift
@@ -29,7 +29,7 @@ struct CustomTextField: View {
             Text(title)
                 .font(.subheadline)
                 .fontWeight(.medium)
-                .foregroundColor(ColorTheme.text)
+                .foregroundStyle(ColorTheme.text)
             
             ZStack {
                 RoundedRectangle(cornerRadius: 12)

--- a/GutCheck/GutCheck/Views/Components/FoodItemDetailRow.swift
+++ b/GutCheck/GutCheck/Views/Components/FoodItemDetailRow.swift
@@ -11,7 +11,7 @@ struct FoodItemDetailRow: View {
             HStack {
                 Text(foodItem.name)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
@@ -19,7 +19,7 @@ struct FoodItemDetailRow: View {
                     if let onEdit = onEdit {
                         Button(action: onEdit) {
                             Image(systemName: "pencil")
-                                .foregroundColor(ColorTheme.primary)
+                                .foregroundStyle(ColorTheme.primary)
                         }
                         .padding(.horizontal, 4)
                     }
@@ -27,7 +27,7 @@ struct FoodItemDetailRow: View {
                     if let onDelete = onDelete {
                         Button(action: onDelete) {
                             Image(systemName: "trash")
-                                .foregroundColor(ColorTheme.error)
+                                .foregroundStyle(ColorTheme.error)
                         }
                         .padding(.horizontal, 4)
                     }
@@ -37,13 +37,13 @@ struct FoodItemDetailRow: View {
             // Quantity
             Text("\(foodItem.quantity)")
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             // Nutrition details
             if let calories = foodItem.nutrition.calories {
                 Text("\(calories) calories")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
             
             HStack(spacing: 12) {

--- a/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
@@ -31,15 +31,15 @@ struct NotificationPermissionView: View {
             VStack(spacing: 16) {
                 Image(systemName: "bell.badge")
                     .font(.system(size: 64))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 Text(title)
                     .font(.title2.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(message)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(nil)
             }
             
@@ -67,7 +67,7 @@ struct NotificationPermissionView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Helpful reminders for:")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             VStack(alignment: .leading, spacing: 8) {
                 reminderBenefit("🍽️", "Meal logging", "Never miss tracking a meal")
@@ -89,11 +89,11 @@ struct NotificationPermissionView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.subheadline.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -104,17 +104,17 @@ struct NotificationPermissionView: View {
         VStack(spacing: 12) {
             HStack(spacing: 12) {
                 Image(systemName: permissionManager.notificationStatus.statusIcon)
-                    .foregroundColor(permissionManager.notificationStatus.statusColor)
+                    .foregroundStyle(permissionManager.notificationStatus.statusColor)
                     .font(.system(size: 20))
                 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Notification Permission")
                         .font(.subheadline.bold())
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     Text(permissionManager.notificationStatus.statusText)
                         .font(.caption)
-                        .foregroundColor(permissionManager.notificationStatus.statusColor)
+                        .foregroundStyle(permissionManager.notificationStatus.statusColor)
                 }
                 
                 Spacer()
@@ -124,18 +124,18 @@ struct NotificationPermissionView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("To enable notifications:")
                         .font(.caption.bold())
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text("1. Open Settings → Notifications")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("2. Find 'GutCheck' and tap it")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("3. Turn on 'Allow Notifications'")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 }
                 .padding(.top, 8)
@@ -162,7 +162,7 @@ struct NotificationPermissionView: View {
                     }
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -173,14 +173,14 @@ struct NotificationPermissionView: View {
                     onPermissionResult(false)
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 
             } else if permissionManager.notificationStatus.canOpenSettings {
                 Button("Open Settings") {
                     permissionManager.openAppSettings()
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -190,14 +190,14 @@ struct NotificationPermissionView: View {
                     onPermissionResult(false)
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 
             } else if permissionManager.notificationStatus.isGranted {
                 Button("Continue") {
                     onPermissionResult(true)
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.success)

--- a/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
@@ -70,7 +70,7 @@ struct UnifiedNutritionBadge: View {
         }
         .padding(style.padding)
         .background(color.opacity(0.2))
-        .foregroundColor(color)
+        .foregroundStyle(color)
         .cornerRadius(style == .large ? 6 : 4)
     }
 }
@@ -103,7 +103,7 @@ struct UnifiedMacroRow: View {
         HStack {
             Text(label)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             Spacer()
             
@@ -111,11 +111,11 @@ struct UnifiedMacroRow: View {
                 Text(value)
                     .font(.subheadline)
                     .fontWeight(.semibold)
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
                 
                 Text(unit)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
     }
@@ -143,13 +143,13 @@ struct UnifiedNutritionSummary: View {
                 HStack {
                     Text("Nutrition Facts")
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     Spacer()
                     
                     Text("\(calories) calories")
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                 }
             }
             
@@ -235,15 +235,15 @@ struct NutrientColumn: View {
         VStack(spacing: 4) {
             Text(name)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text(String(format: "%.1f", value))
                 .font(.headline)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             
             Text(unit)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .frame(maxWidth: .infinity)
     }

--- a/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
@@ -29,7 +29,7 @@ struct LoadMoreButton: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                 }
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
                 .background(
@@ -93,7 +93,7 @@ struct LoadMoreTrigger: View {
                     .scaleEffect(0.8)
                 Text("Loading more...")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             } else {
                 Spacer()
             }
@@ -120,7 +120,7 @@ struct PaginationStatusBar: View {
             if let totalItems = totalItems {
                 Text("\(totalItems) items")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Spacer()
@@ -133,12 +133,12 @@ struct PaginationStatusBar: View {
                 
                 Text("Page \(currentPage)")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 
                 if hasMoreData {
                     Image(systemName: "ellipsis")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
         }
@@ -228,7 +228,7 @@ struct PaginatedListView<Item: Identifiable, ItemView: View>: View {
                     } else if !items.isEmpty {
                         Text("No more items")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                             .padding()
                     }
                 }
@@ -248,7 +248,7 @@ struct LoadingView: View {
             
             Text("Loading...")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(ColorTheme.background)
@@ -299,7 +299,7 @@ struct FilterChip: View {
                         .fill(isSelected ? ColorTheme.primary : ColorTheme.background)
                         .stroke(ColorTheme.primary, lineWidth: 1)
                 )
-                .foregroundColor(isSelected ? .white : ColorTheme.primary)
+                .foregroundStyle(isSelected ? .white : ColorTheme.primary)
         }
     }
 }
@@ -330,7 +330,7 @@ struct DateRangePicker: View {
                     Text(dateRangeText)
                         .font(.subheadline)
                 }
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .background(
@@ -346,7 +346,7 @@ struct DateRangePicker: View {
                     onRangeChange()
                 }
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             }
             
             Spacer()

--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -47,11 +47,11 @@ struct ProfileAvatarButton: View {
                                 if let user = user {
                                     Text(user.initials)
                                         .font(.system(size: size * 0.4, weight: .semibold))
-                                        .foregroundColor(ColorTheme.accent)
+                                        .foregroundStyle(ColorTheme.accent)
                                 } else {
                                     Image(systemName: "person.circle.fill")
                                         .font(.system(size: size * 0.8))
-                                        .foregroundColor(ColorTheme.accent)
+                                        .foregroundStyle(ColorTheme.accent)
                                 }
                             }
                         )

--- a/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
+++ b/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
@@ -31,14 +31,14 @@ struct ReauthenticationView: View {
                 VStack(spacing: 12) {
                     Image(systemName: "lock.shield")
                         .font(.system(size: 48))
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     
                     Text("Verify Your Identity")
                         .font(.title2.bold())
                     
                     Text("For security reasons, please verify your identity before \(operation.lowercased()).")
                         .font(.body)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
                 }
@@ -85,7 +85,7 @@ struct ReauthenticationView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.red)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .cornerRadius(12)
                     }
                     .disabled(authService.isLoading || email.isEmpty || password.isEmpty)
@@ -93,12 +93,12 @@ struct ReauthenticationView: View {
                     Button("Use Phone Verification") {
                         showPhoneAuth = true
                     }
-                    .foregroundColor(.blue)
+                    .foregroundStyle(.blue)
                     
                     Button("Cancel") {
                         onCancel()
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 }
                 .padding(.horizontal)
                 
@@ -162,14 +162,14 @@ struct PhoneReauthenticationView: View {
                 VStack(spacing: 12) {
                     Image(systemName: "phone.circle")
                         .font(.system(size: 48))
-                        .foregroundColor(.blue)
+                        .foregroundStyle(.blue)
                     
                     Text("Phone Verification")
                         .font(.title2.bold())
                     
                     Text("Verify your identity using your phone number.")
                         .font(.body)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
                 }
@@ -202,7 +202,7 @@ struct PhoneReauthenticationView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(Color.blue)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .cornerRadius(12)
                         }
                         .disabled(authService.isLoading || phoneNumber.isEmpty)
@@ -232,7 +232,7 @@ struct PhoneReauthenticationView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(Color.green)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .cornerRadius(12)
                         }
                         .disabled(authService.isLoading || verificationCode.isEmpty)
@@ -240,7 +240,7 @@ struct PhoneReauthenticationView: View {
                         Button("Resend Code") {
                             sendVerificationCode()
                         }
-                        .foregroundColor(.blue)
+                        .foregroundStyle(.blue)
                     }
                 }
                 .padding(.horizontal)
@@ -251,7 +251,7 @@ struct PhoneReauthenticationView: View {
                 Button("Cancel") {
                     onCancel()
                 }
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .padding(.horizontal)
             }
             .padding()

--- a/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
+++ b/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
@@ -81,7 +81,7 @@ struct SocialSignInButton: View {
             .frame(maxWidth: .infinity)
             .frame(height: 50)
             .background(provider.backgroundColor)
-            .foregroundColor(provider.foregroundColor)
+            .foregroundStyle(provider.foregroundColor)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(provider.borderColor, lineWidth: 1)

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -53,7 +53,7 @@ struct UnifiedFoodDetailView: View {
             HStack {
                 Text(foodItem.name)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
@@ -64,7 +64,7 @@ struct UnifiedFoodDetailView: View {
             
             Text(foodItem.quantity)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             // Unified nutrition display
             unifiedNutritionCompact
@@ -141,10 +141,10 @@ struct UnifiedFoodDetailView: View {
                     VStack {
                         Image(systemName: "fork.knife")
                             .font(.system(size: 48))
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                         Text("Food Image")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 )
             
@@ -152,13 +152,13 @@ struct UnifiedFoodDetailView: View {
                 Text(foodItem.name)
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .multilineTextAlignment(.center)
                 
                 if let brand = foodItem.nutritionDetails["brand"] {
                     Text(brand)
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                 }
                 
                 sourceIndicator
@@ -170,11 +170,11 @@ struct UnifiedFoodDetailView: View {
         HStack {
             Text("Source:")
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text(sourceDescription)
                 .font(.caption)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
         }
     }
     
@@ -191,7 +191,7 @@ struct UnifiedFoodDetailView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Serving Size")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             HStack {
                 Text("Amount:")
@@ -200,7 +200,7 @@ struct UnifiedFoodDetailView: View {
                 Stepper(value: $servingMultiplier, in: 0.1...10.0, step: 0.1) {
                     Text(String(format: "%.1f", servingMultiplier))
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                 }
             }
             .padding()
@@ -209,7 +209,7 @@ struct UnifiedFoodDetailView: View {
             
             Text("Per \(customQuantity)")
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
     }
     
@@ -217,7 +217,7 @@ struct UnifiedFoodDetailView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Nutrition Facts")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             VStack(spacing: 0) {
                 // Macronutrients
@@ -267,7 +267,7 @@ struct UnifiedFoodDetailView: View {
         Text(title)
             .font(.caption)
             .fontWeight(.semibold)
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.bottom, 4)
     }
@@ -304,7 +304,7 @@ struct UnifiedFoodDetailView: View {
             if let calories = foodItem.nutrition.calories {
                 Text("\(calories) calories")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
             
             // Macros in a compact row
@@ -312,17 +312,17 @@ struct UnifiedFoodDetailView: View {
                 if let protein = foodItem.nutrition.protein {
                     Text("P: \(String(format: "%.1f", protein))g")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
                 if let carbs = foodItem.nutrition.carbs {
                     Text("C: \(String(format: "%.1f", carbs))g")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
                 if let fat = foodItem.nutrition.fat {
                     Text("F: \(String(format: "%.1f", fat))g")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
             }
         }
@@ -334,17 +334,17 @@ struct UnifiedFoodDetailView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Health Indicators")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             let indicators = healthIndicators
             
             if indicators.isEmpty {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                     Text("No health concerns detected")
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -443,7 +443,7 @@ struct UnifiedFoodDetailView: View {
         }) {
             Text(onUpdate != nil ? "Update Item" : "Add to Meal")
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.accent)
@@ -616,7 +616,7 @@ struct HealthIndicatorBadge: View {
                     .font(.caption)
                     .fontWeight(.medium)
             }
-            .foregroundColor(indicator.color)
+            .foregroundStyle(indicator.color)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -659,24 +659,24 @@ struct DetailSectionRow: View {
         HStack(spacing: 16) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(iconColor)
+                .foregroundStyle(iconColor)
                 .frame(width: 24)
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(subtitle)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
             
             Image(systemName: "chevron.right")
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .padding()
         .background(ColorTheme.cardBackground)
@@ -700,7 +700,7 @@ struct NutritionDetailsView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Micronutrients & Additional Details")
                             .font(.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         LazyVGrid(columns: [
                             GridItem(.flexible()),
@@ -747,7 +747,7 @@ struct NutritionDetailsView: View {
                         VStack(alignment: .leading, spacing: 16) {
                             Text("Additional Nutrition Information")
                                 .font(.headline)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                             
                             LazyVGrid(columns: [
                                 GridItem(.flexible()),
@@ -866,17 +866,17 @@ struct NutritionDetailsView: View {
         VStack(spacing: 4) {
             Text(label)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
             
             Text(String(format: "%.1f", value))
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             Text(unit)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
@@ -893,18 +893,18 @@ struct NutritionDetailItem: View {
         VStack(spacing: 4) {
             Text(formattedLabel)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
             
             Text(formattedValue)
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             if !unit.isEmpty {
                 Text(unit)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .frame(maxWidth: .infinity)
@@ -1017,15 +1017,15 @@ struct IngredientsView: View {
                         VStack(spacing: 16) {
                             Image(systemName: "list.bullet")
                                 .font(.system(size: 48))
-                                .foregroundColor(ColorTheme.secondaryText.opacity(0.5))
+                                .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
                             
                             Text("No Ingredients Listed")
                                 .font(.headline)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                             
                             Text("Ingredient information is not available for this food item.")
                                 .font(.subheadline)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                                 .multilineTextAlignment(.center)
                         }
                         .frame(maxWidth: .infinity, minHeight: 200)
@@ -1033,19 +1033,19 @@ struct IngredientsView: View {
                     } else {
                         Text("Ingredients are listed in order of predominance by weight.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                             .padding(.horizontal)
                         
                         ForEach(Array(ingredients.enumerated()), id: \.offset) { index, ingredient in
                             HStack {
                                 Text("\(index + 1).")
                                     .font(.caption)
-                                    .foregroundColor(ColorTheme.secondaryText)
+                                    .foregroundStyle(ColorTheme.secondaryText)
                                     .frame(width: 24, alignment: .leading)
                                 
                                 Text(ingredient.capitalized)
                                     .font(.body)
-                                    .foregroundColor(ColorTheme.primaryText)
+                                    .foregroundStyle(ColorTheme.primaryText)
                                 
                                 Spacer()
                             }
@@ -1087,15 +1087,15 @@ struct AllergensView: View {
                         VStack(spacing: 16) {
                             Image(systemName: "checkmark.shield.fill")
                                 .font(.system(size: 48))
-                                .foregroundColor(ColorTheme.success)
+                                .foregroundStyle(ColorTheme.success)
                             
                             Text("No Known Allergens or Warnings")
                                 .font(.headline)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                             
                             Text("No common allergens or health indicators were detected in this food item. However, always check the original packaging for complete allergen information.")
                                 .font(.subheadline)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                                 .multilineTextAlignment(.center)
                         }
                         .frame(maxWidth: .infinity, minHeight: 200)
@@ -1105,22 +1105,22 @@ struct AllergensView: View {
                         if !allergens.isEmpty {
                             Text("Allergens:")
                                 .font(.headline)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                                 .padding(.horizontal)
                             
                             Text("This food contains or may contain the following allergens:")
                                 .font(.subheadline)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                                 .padding(.horizontal)
                             
                             ForEach(allergens, id: \.self) { allergen in
                                 HStack {
                                     Image(systemName: "exclamationmark.triangle.fill")
-                                        .foregroundColor(ColorTheme.error)
+                                        .foregroundStyle(ColorTheme.error)
                                     
                                     Text(allergen)
                                         .font(.body)
-                                        .foregroundColor(ColorTheme.primaryText)
+                                        .foregroundStyle(ColorTheme.primaryText)
                                     
                                     Spacer()
                                 }
@@ -1140,12 +1140,12 @@ struct AllergensView: View {
                             
                             Text("Health Indicators:")
                                 .font(.headline)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                                 .padding(.horizontal)
                             
                             Text("Compounds that may affect your health:")
                                 .font(.subheadline)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                                 .padding(.horizontal)
                             
                             ForEach(healthIndicators, id: \.text) { indicator in
@@ -1153,11 +1153,11 @@ struct AllergensView: View {
                                     // Category header
                                     HStack {
                                         Image(systemName: indicator.icon)
-                                            .foregroundColor(indicator.color)
+                                            .foregroundStyle(indicator.color)
                                         
                                         Text(indicator.text)
                                             .font(.headline)
-                                            .foregroundColor(ColorTheme.primaryText)
+                                            .foregroundStyle(ColorTheme.primaryText)
                                         
                                         Spacer()
                                     }
@@ -1166,12 +1166,12 @@ struct AllergensView: View {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text("Description:")
                                             .font(.subheadline)
-                                            .foregroundColor(ColorTheme.secondaryText)
+                                            .foregroundStyle(ColorTheme.secondaryText)
                                             .padding(.leading, 24) // Indent to align with icon
                                         
                                         Text(getCategoryDescription(indicator.text))
                                             .font(.caption)
-                                            .foregroundColor(ColorTheme.secondaryText)
+                                            .foregroundStyle(ColorTheme.secondaryText)
                                             .padding(.leading, 24) // Indent to align with icon
                                     }
                                     
@@ -1180,7 +1180,7 @@ struct AllergensView: View {
                                         ForEach(getCompoundsFromDescription(indicator.description), id: \.self) { compound in
                                             Text(compound)
                                                 .font(.caption)
-                                                .foregroundColor(ColorTheme.secondaryText)
+                                                .foregroundStyle(ColorTheme.secondaryText)
                                                 .padding(.leading, 24) // Indent to align with icon
                                         }
                                     }

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
@@ -89,7 +89,7 @@ struct UnifiedFoodItemRow: View {
             .frame(width: config.iconSize, height: config.iconSize)
             .overlay(
                 Image(systemName: "fork.knife")
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                     .font(.system(size: config.iconSize * 0.4))
             )
     }
@@ -107,7 +107,7 @@ struct UnifiedFoodItemRow: View {
                     // Food name
                     Text(item.name)
                         .font(config.nameFont)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .multilineTextAlignment(.leading)
                         .lineLimit(config.nameLineLimit)
                     
@@ -115,14 +115,14 @@ struct UnifiedFoodItemRow: View {
                     if config.showBrand, let brand = item.nutritionDetails["brand"] {
                         Text(brand)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                             .lineLimit(1)
                     }
                     
                     // Quantity
                     Text(item.quantity)
                         .font(config.quantityFont)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .lineLimit(1)
                 }
                 
@@ -192,13 +192,13 @@ struct UnifiedFoodItemRow: View {
                     .padding(.horizontal, 4)
                     .padding(.vertical, 2)
                     .background(ColorTheme.error.opacity(0.2))
-                    .foregroundColor(ColorTheme.error)
+                    .foregroundStyle(ColorTheme.error)
                     .cornerRadius(4)
             }
             if item.allergens.count > config.maxAllergens {
                 Text("+\(item.allergens.count - config.maxAllergens)")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
     }
@@ -210,7 +210,7 @@ struct UnifiedFoodItemRow: View {
                 Button(action: onAdd) {
                     Image(systemName: "plus.circle.fill")
                         .font(config.actionButtonFont)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                 }
                 .buttonStyle(PlainButtonStyle())
             }
@@ -220,7 +220,7 @@ struct UnifiedFoodItemRow: View {
                 Button(action: onEdit) {
                     Image(systemName: "pencil")
                         .font(config.actionButtonFont)
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                 }
                 .buttonStyle(PlainButtonStyle())
                 .padding(.horizontal, 4)
@@ -231,7 +231,7 @@ struct UnifiedFoodItemRow: View {
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .font(config.actionButtonFont)
-                        .foregroundColor(ColorTheme.error)
+                        .foregroundStyle(ColorTheme.error)
                 }
                 .buttonStyle(PlainButtonStyle())
                 .padding(.horizontal, 4)
@@ -253,7 +253,7 @@ struct NutritionBadge: View {
             .padding(.horizontal, size.horizontalPadding)
             .padding(.vertical, size.verticalPadding)
             .background(color.opacity(0.2))
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .cornerRadius(size.cornerRadius)
     }
 }

--- a/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
@@ -5,12 +5,12 @@ struct CalendarShortcutButton: View {
         NavigationLink(destination: CalendarView(selectedDate: Date.now)) {
             HStack {
                 Image(systemName: "calendar")
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 Text("View Full Calendar")
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
                 Image(systemName: "chevron.right")
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             .padding()
             .background(RoundedRectangle(cornerRadius: 12).fill(ColorTheme.cardBackground))

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
@@ -182,21 +182,21 @@ struct HealthScoreCard: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Health Score")
                         .typography(Typography.headline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Text("\(score)")
                             .font(.system(size: 52, weight: .bold, design: .rounded))
-                            .foregroundColor(scoreColor)
+                            .foregroundStyle(scoreColor)
                         
                         Text("/10")
                             .typography(Typography.title)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     Text(scoreLabel)
                         .typography(Typography.subheadline)
-                        .foregroundColor(scoreColor)
+                        .foregroundStyle(scoreColor)
                         .fontWeight(.medium)
                 }
                 
@@ -217,7 +217,7 @@ struct HealthScoreCard: View {
                     
                     Image(systemName: score >= 7 ? "checkmark.circle.fill" : "heart.fill")
                         .font(.system(size: 28))
-                        .foregroundColor(scoreColor)
+                        .foregroundStyle(scoreColor)
                 }
                 .accessibleDecorative()
             }
@@ -264,7 +264,7 @@ struct DashboardInsightCard: View {
             HStack(spacing: 8) {
                 Image(systemName: icon)
                     .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(iconColor)
+                    .foregroundStyle(iconColor)
                     .frame(width: 32, height: 32)
                     .background(iconColor.opacity(0.15))
                     .cornerRadius(8)
@@ -273,12 +273,12 @@ struct DashboardInsightCard: View {
                 Text(title)
                     .typography(Typography.subheadline)
                     .fontWeight(.semibold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
             }
             
             Text(content)
                 .typography(Typography.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .lineLimit(4)
                 .multilineTextAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
@@ -308,12 +308,12 @@ struct FloatingActionButton: View {
             HStack(spacing: 12) {
                 Image(systemName: icon)
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .accessibleDecorative()
                 
                 Text(label)
                     .typography(Typography.button)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
@@ -338,11 +338,11 @@ struct TriggerAlertCard: View {
         HStack(spacing: 12) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.title3)
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
             
             Text(alert)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
                 .multilineTextAlignment(.leading)
             
             Spacer()
@@ -386,12 +386,12 @@ struct DashboardInsightsView: View {
                 HStack {
                     Text("Today's Health Score")
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Spacer()
                     Text("\(healthScore)/10")
                         .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundColor(healthScoreColor)
+                        .foregroundStyle(healthScoreColor)
                 }
                 
                 // Health Score Bar
@@ -414,16 +414,16 @@ struct DashboardInsightsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Image(systemName: "target")
-                        .foregroundColor(.blue)
+                        .foregroundStyle(.blue)
                     Text("Today's Focus")
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Text(todaysFocus)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.leading)
             }
             .padding()
@@ -435,16 +435,16 @@ struct DashboardInsightsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Image(systemName: "exclamationmark.triangle")
-                        .foregroundColor(.orange)
+                        .foregroundStyle(.orange)
                     Text("Avoidance Tip")
                         .font(.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Text(avoidanceTip)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.leading)
             }
             .padding()

--- a/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
@@ -17,10 +17,10 @@ struct GreetingHeaderView: View {
                 Text(greeting)
                     .font(.title2)
                     .fontWeight(.semibold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Text("Here's how your day is going so far:")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             Spacer()
         }

--- a/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
@@ -14,7 +14,7 @@ struct RecentActivityListView: View {
             HStack {
                 Text("Today's Activity")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
@@ -23,7 +23,7 @@ struct RecentActivityListView: View {
                     router.selectedTab = .meals
                 }
                 .font(.caption)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             }
             
             if viewModel.isLoading {
@@ -78,7 +78,7 @@ struct ActivityRowView: View {
                 // Icon
                 Image(systemName: entry.icon)
                     .font(.title3)
-                    .foregroundColor(entry.iconColor)
+                    .foregroundStyle(entry.iconColor)
                     .frame(width: 24, height: 24)
                 
                 // Content
@@ -87,7 +87,7 @@ struct ActivityRowView: View {
                         Text(entry.title)
                             .font(.subheadline)
                             .fontWeight(.medium)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         if case .symptom(let symptom) = entry.type {
                             BristolStoolBadge(stoolType: symptom.stoolType)
@@ -99,7 +99,7 @@ struct ActivityRowView: View {
                     if let subtitle = entry.subtitle {
                         Text(subtitle)
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                 }
                 
@@ -107,11 +107,11 @@ struct ActivityRowView: View {
                 VStack(alignment: .trailing) {
                     Text(entry.timestamp, style: .time)
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     
                     Image(systemName: "chevron.right")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
             }
             .padding(.vertical, 8)
@@ -131,7 +131,7 @@ struct BristolStoolBadge: View {
         Text("\(stoolType.rawValue)")
             .font(.caption)
             .fontWeight(.bold)
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .frame(width: 20, height: 20)
             .background(
                 RoundedRectangle(cornerRadius: 4)
@@ -194,15 +194,15 @@ struct RecentActivityEmptyStateView: View {
         VStack(spacing: 8) {
             Image(systemName: "tray")
                 .font(.title2)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("No activity logged today")
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("Start by logging a meal or symptom")
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .padding(.vertical, 20)
         .frame(maxWidth: .infinity)

--- a/GutCheck/GutCheck/Views/Dashboard/TodaySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaySummaryView.swift
@@ -8,13 +8,13 @@ struct TodaySummaryView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Today's Summary")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             HStack(spacing: 16) {
                 Label("\(mealsCount) Meals", systemImage: "fork.knife")
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 Spacer()
                 Label("\(symptomsCount) Symptoms", systemImage: "exclamationmark.triangle")
-                    .foregroundColor(ColorTheme.warning)
+                    .foregroundStyle(ColorTheme.warning)
             }
             .font(.subheadline)
         }

--- a/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
@@ -43,7 +43,7 @@ struct TodaysActivitySummaryView: View {
             HStack {
                 Text("Today's Summary")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
@@ -56,11 +56,11 @@ struct TodaysActivitySummaryView: View {
                         HStack(spacing: 4) {
                             Text(isExpanded ? "See Less" : "See All")
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.primary)
+                                .foregroundStyle(ColorTheme.primary)
                             
                             Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.primary)
+                                .foregroundStyle(ColorTheme.primary)
                         }
                     }
                 }
@@ -70,28 +70,28 @@ struct TodaysActivitySummaryView: View {
             VStack(spacing: 8) {
                 HStack(spacing: 8) {
                     Image(systemName: "fork.knife")
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                         .frame(width: 20)
                     Text("\(mealsCount) \(mealsCount == 1 ? "Meal" : "Meals")")
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                     Spacer()
                 }
                 
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle")
-                        .foregroundColor(ColorTheme.warning)
+                        .foregroundStyle(ColorTheme.warning)
                         .frame(width: 20)
                     Text("\(symptomsCount) \(symptomsCount == 1 ? "Symptom" : "Symptoms")")
-                        .foregroundColor(ColorTheme.warning)
+                        .foregroundStyle(ColorTheme.warning)
                     Spacer()
                 }
                 
                 HStack(spacing: 8) {
                     Image(systemName: "pills")
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                         .frame(width: 20)
                     Text("\(medicationsCount) \(medicationsCount == 1 ? "Medication" : "Medications")")
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                     Spacer()
                 }
             }

--- a/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
@@ -25,7 +25,7 @@ struct WeekSelector: View {
                 Button(action: { navigateToPreviousWeek() }) {
                     Image(systemName: "chevron.left.circle.fill")
                         .font(.title2)
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                 }
                 
                 Spacer()
@@ -34,13 +34,13 @@ struct WeekSelector: View {
                 VStack(spacing: 4) {
                     Text(weekRangeText)
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     
                     Button(action: { resetToCurrentWeek() }) {
                         Text("Today")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 2)
                             .background(ColorTheme.accent.opacity(0.1))
@@ -53,7 +53,7 @@ struct WeekSelector: View {
                 Button(action: { navigateToNextWeek() }) {
                     Image(systemName: "chevron.right.circle.fill")
                         .font(.title2)
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                 }
             }
             .padding(.horizontal)
@@ -68,10 +68,10 @@ struct WeekSelector: View {
                         VStack {
                             Text(shortWeekdayString(for: date))
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                             Text(dayString(for: date))
                                 .font(.headline)
-                                .foregroundColor(selectedDate.isSameDay(as: date) ? .white : ColorTheme.primaryText)
+                                .foregroundStyle(selectedDate.isSameDay(as: date) ? .white : ColorTheme.primaryText)
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 60)

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -79,7 +79,7 @@ struct InsightsDashboardView: View {
             
             Text("Get personalized insights and recommendations based on your symptoms, meals, and daily activities.")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -267,7 +267,7 @@ struct InsightsDashboardView: View {
             ProgressView()
                 .scaleEffect(1.5)
             Text("Analyzing your health data...")
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 60)
@@ -277,14 +277,14 @@ struct InsightsDashboardView: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 48))
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
             
             Text("Unable to load insights")
                 .font(.headline)
             
             Text(error)
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             
             Button("Try Again") {
@@ -302,14 +302,14 @@ struct InsightsDashboardView: View {
         VStack(spacing: 16) {
             Image(systemName: "chart.bar.doc.horizontal")
                 .font(.system(size: 48))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             
             Text("No insights yet")
                 .font(.headline)
             
             Text("Start logging your symptoms and meals to generate personalized insights.")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -335,7 +335,7 @@ struct StatCard: View {
         VStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             
             Text(value)
                 .font(.title2)
@@ -343,7 +343,7 @@ struct StatCard: View {
             
             Text(title)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
@@ -364,7 +364,7 @@ struct SectionHeader: View {
         HStack {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
@@ -373,7 +373,7 @@ struct SectionHeader: View {
                 
                 Text(subtitle)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             Spacer()
@@ -394,7 +394,7 @@ struct CategoryFilterButton: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
                 .background(isSelected ? Color.accentColor : Color(.systemGray6))
-                .foregroundColor(isSelected ? .white : .primary)
+                .foregroundStyle(isSelected ? .white : .primary)
                 .cornerRadius(20)
         }
     }
@@ -449,7 +449,7 @@ struct InsightCard: View {
             HStack {
                 Image(systemName: insight.iconName)
                     .font(.title2)
-                    .foregroundColor(accentColor)
+                    .foregroundStyle(accentColor)
                 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(insight.title)
@@ -458,7 +458,7 @@ struct InsightCard: View {
                     
                     Text(insight.summary)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(isExpanded ? nil : 2)
                 }
                 
@@ -469,13 +469,13 @@ struct InsightCard: View {
             HStack {
                 Text("Confidence")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 
                 Spacer()
                 
                 Text("\(insight.confidenceLevel)%")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             
             // Confidence bar
@@ -490,7 +490,7 @@ struct InsightCard: View {
                     if let detailedDescription = insight.detailedDescription {
                         Text(detailedDescription)
                             .font(.body)
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                     }
                     
                     // Recommendations
@@ -498,17 +498,17 @@ struct InsightCard: View {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Recommendations")
                                 .font(.subheadline.bold())
-                                .foregroundColor(.primary)
+                                .foregroundStyle(.primary)
                             
                             ForEach(insight.recommendations, id: \.self) { recommendation in
                                 HStack(alignment: .top, spacing: 8) {
                                     Image(systemName: "lightbulb.fill")
                                         .font(.caption)
-                                        .foregroundColor(.yellow)
+                                        .foregroundStyle(.yellow)
                                     
                                     Text(recommendation)
                                         .font(.caption)
-                                        .foregroundColor(.secondary)
+                                        .foregroundStyle(.secondary)
                                 }
                             }
                         }
@@ -518,11 +518,11 @@ struct InsightCard: View {
                     HStack {
                         Image(systemName: "calendar")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                         
                         Text(insight.dateRange)
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                         
                         Spacer()
                     }
@@ -539,7 +539,7 @@ struct InsightCard: View {
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.caption)
                 }
-                .foregroundColor(accentColor)
+                .foregroundStyle(accentColor)
             }
         }
         .padding()

--- a/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
+++ b/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
@@ -47,11 +47,11 @@ struct LogOptionButton: View {
             VStack(spacing: 15) {
                 Image(systemName: icon)
                     .font(.system(size: 40))
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
                 
                 Text(title)
                     .font(.headline)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
             }
             .frame(width: 120, height: 120)
             .background(color.opacity(0.1))

--- a/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
+++ b/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
@@ -18,7 +18,7 @@ struct AddWaterView: View {
             HStack {
                 TextField("0", value: $cups, format: .number)
                     .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .multilineTextAlignment(.center)
                     .keyboardType(.decimalPad)
                     .padding()
@@ -31,7 +31,7 @@ struct AddWaterView: View {
                 
                 Text("cup(s)")
                     .font(.title3)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             .padding(.horizontal)
             
@@ -41,7 +41,7 @@ struct AddWaterView: View {
             }) {
                 Text("Add Water")
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.blue)

--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -48,7 +48,7 @@ struct FoodSearchView: View {
                                 Text("Search")
                                     .typography(Typography.button)
                             }
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 8)
                             .background(ColorTheme.accent)
@@ -76,7 +76,7 @@ struct FoodSearchView: View {
                                 AccessibilityAnnouncement.announce("Search cleared")
                             }
                             .typography(Typography.caption)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                             .accessibleButton(
                                 label: "Clear search",
                                 hint: "Clear the search field and results"
@@ -103,15 +103,15 @@ struct FoodSearchView: View {
                     VStack(spacing: 16) {
                         Image(systemName: "magnifyingglass")
                             .font(.system(size: 36))
-                            .foregroundColor(ColorTheme.accent.opacity(0.6))
+                            .foregroundStyle(ColorTheme.accent.opacity(0.6))
 
                         Text("Ready to Search")
                             .font(.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
 
                         Text("Tap the Search button to find foods")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                             .multilineTextAlignment(.center)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -158,15 +158,15 @@ struct FoodSearchView: View {
         VStack(spacing: 16) {
             Image(systemName: "wifi.slash")
                 .font(.system(size: 48))
-                .foregroundColor(ColorTheme.warning)
+                .foregroundStyle(ColorTheme.warning)
 
             Text("You're Offline")
                 .typography(Typography.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             Text("Food search requires an internet connection.\nYou can still add food manually.")
                 .typography(Typography.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
 
             Button {
@@ -183,7 +183,7 @@ struct FoodSearchView: View {
                     Text("Add Custom Food")
                         .typography(Typography.button)
                 }
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
                 .background(ColorTheme.primary)
@@ -204,7 +204,7 @@ struct FoodSearchView: View {
                 .scaleEffect(1.5)
             Text("Searching...")
                 .typography(Typography.body)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)
@@ -216,16 +216,16 @@ struct FoodSearchView: View {
         VStack(spacing: 16) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 48))
-                .foregroundColor(ColorTheme.secondaryText.opacity(0.5))
+                .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
                 .accessibleDecorative()
             
             Text("No Results Found")
                 .typography(Typography.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             Text("Try searching with different keywords")
                 .typography(Typography.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
             
             Button("Add Custom Food") {
@@ -285,7 +285,7 @@ struct FoodSearchView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Recent Searches")
                             .typography(Typography.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                             .accessibleHeader("Recent Searches")
                         ForEach(Array(viewModel.recentSearches.enumerated()), id: \.element) { index, searchTerm in
                             Button(action: {
@@ -295,15 +295,15 @@ struct FoodSearchView: View {
                             }) {
                                 HStack {
                                     Image(systemName: "clock")
-                                        .foregroundColor(ColorTheme.secondaryText)
+                                        .foregroundStyle(ColorTheme.secondaryText)
                                         .accessibleDecorative()
                                     Text(searchTerm)
                                         .typography(Typography.body)
-                                        .foregroundColor(ColorTheme.primaryText)
+                                        .foregroundStyle(ColorTheme.primaryText)
                                     Spacer()
                                     Image(systemName: "arrow.up.left")
                                         .font(.caption)
-                                        .foregroundColor(ColorTheme.secondaryText)
+                                        .foregroundStyle(ColorTheme.secondaryText)
                                         .accessibleDecorative()
                                 }
                                 .padding(.vertical, 8)
@@ -322,7 +322,7 @@ struct FoodSearchView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Common Categories")
                         .typography(Typography.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .accessibleHeader("Common Categories")
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                         ForEach(viewModel.foodCategories, id: \.self) { category in
@@ -334,7 +334,7 @@ struct FoodSearchView: View {
                                 HStack {
                                     Text(category)
                                         .typography(Typography.subheadline)
-                                        .foregroundColor(ColorTheme.primaryText)
+                                        .foregroundStyle(ColorTheme.primaryText)
                                         .multilineTextAlignment(.leading)
                                     Spacer()
                                 }
@@ -364,7 +364,7 @@ struct FoodSearchView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Recent Items")
                             .typography(Typography.headline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                             .accessibleHeader("Recent Items")
                         ForEach(viewModel.recentItems) { item in
                             SimpleRecentFoodRow(
@@ -409,7 +409,7 @@ struct FoodItemResultRow: View {
                 .frame(width: 60, height: 60)
                 .overlay(
                     Image(systemName: "fork.knife")
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                 )
                 .accessibleDecorative()
             
@@ -418,18 +418,18 @@ struct FoodItemResultRow: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(item.name)
                         .typography(Typography.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .multilineTextAlignment(.leading)
                     
                     if let brand = item.nutritionDetails["brand"] {
                         Text(brand)
                             .typography(Typography.subheadline)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                     }
                     
                     Text(item.quantity)
                         .typography(Typography.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     
                     // Much cleaner with convenience initializers
                     item.nutrition.compactPreview()
@@ -443,13 +443,13 @@ struct FoodItemResultRow: View {
                                     .padding(.horizontal, 6)
                                     .padding(.vertical, 2)
                                     .background(ColorTheme.error.opacity(0.2))
-                                    .foregroundColor(ColorTheme.error)
+                                    .foregroundStyle(ColorTheme.error)
                                     .cornerRadius(4)
                             }
                             if item.allergens.count > 3 {
                                 Text("+\(item.allergens.count - 3)")
                                     .font(.caption)
-                                    .foregroundColor(ColorTheme.secondaryText)
+                                    .foregroundStyle(ColorTheme.secondaryText)
                             }
                         }
                     }
@@ -466,7 +466,7 @@ struct FoodItemResultRow: View {
             Button(action: onAdd) {
                 Image(systemName: "plus.circle.fill")
                     .font(.title2)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
             .buttonStyle(PlainButtonStyle())
             .accessibleButton(
@@ -513,7 +513,7 @@ struct SimpleRecentFoodRow: View {
                 .frame(width: 50, height: 50)
                 .overlay(
                     Image(systemName: "fork.knife")
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                         .font(.system(size: 16))
                 )
                 .accessibleDecorative()
@@ -523,12 +523,12 @@ struct SimpleRecentFoodRow: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(item.name)
                         .typography(Typography.headline)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                         .multilineTextAlignment(.leading)
                     
                     Text(item.quantity)
                         .typography(Typography.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     
                     // Nutrition preview - matching screenshot style
                     HStack(spacing: 8) {
@@ -538,7 +538,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(ColorTheme.accent.opacity(0.2))
-                                .foregroundColor(ColorTheme.accent)
+                                .foregroundStyle(ColorTheme.accent)
                                 .cornerRadius(4)
                         }
                         
@@ -548,7 +548,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(Color.blue.opacity(0.2))
-                                .foregroundColor(.blue)
+                                .foregroundStyle(.blue)
                                 .cornerRadius(4)
                         }
                         
@@ -558,7 +558,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(Color.green.opacity(0.2))
-                                .foregroundColor(.green)
+                                .foregroundStyle(.green)
                                 .cornerRadius(4)
                         }
                         
@@ -568,7 +568,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(Color.red.opacity(0.2))
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                                 .cornerRadius(4)
                         }
                     }
@@ -582,13 +582,13 @@ struct SimpleRecentFoodRow: View {
                                     .padding(.horizontal, 4)
                                     .padding(.vertical, 2)
                                     .background(ColorTheme.error.opacity(0.2))
-                                    .foregroundColor(ColorTheme.error)
+                                    .foregroundStyle(ColorTheme.error)
                                     .cornerRadius(4)
                             }
                             if item.allergens.count > 2 {
                                 Text("+\(item.allergens.count - 2)")
                                     .font(.caption)
-                                    .foregroundColor(ColorTheme.secondaryText)
+                                    .foregroundStyle(ColorTheme.secondaryText)
                             }
                         }
                     }
@@ -605,7 +605,7 @@ struct SimpleRecentFoodRow: View {
             Button(action: onAdd) {
                 Image(systemName: "plus.circle.fill")
                     .font(.title3)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
             .buttonStyle(PlainButtonStyle())
             .accessibleButton(

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -55,7 +55,7 @@ struct MealBuilderView: View {
                                         .padding(.horizontal, 16)
                                         .padding(.vertical, 8)
                                         .background(isSelected ? ColorTheme.primary : ColorTheme.surface)
-                                        .foregroundColor(isSelected ? .white : ColorTheme.primaryText)
+                                        .foregroundStyle(isSelected ? .white : ColorTheme.primaryText)
                                         .cornerRadius(20)
                                         .overlay(
                                             RoundedRectangle(cornerRadius: 20)
@@ -85,11 +85,11 @@ struct MealBuilderView: View {
                     }) {
                         HStack {
                             Image(systemName: "calendar")
-                                .foregroundColor(ColorTheme.primary)
+                                .foregroundStyle(ColorTheme.primary)
                                 .accessibleDecorative()
                             Text(mealService.formattedDateTime)
                                 .typography(Typography.body)
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                         }
                         .frame(maxWidth: .infinity)
                         .padding()
@@ -157,7 +157,7 @@ struct MealBuilderView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Notes")
                             .typography(Typography.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         
                         TextEditor(text: $mealService.notes)
                             .typography(Typography.body)
@@ -195,7 +195,7 @@ struct MealBuilderView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary.opacity(0.9))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .cornerRadius(12)
                 }
                 .accessibleButton(
@@ -219,7 +219,7 @@ struct MealBuilderView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(ColorTheme.surface)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                             .cornerRadius(12)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 12)
@@ -257,7 +257,7 @@ struct MealBuilderView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(ColorTheme.accent)
-                            .foregroundColor(ColorTheme.text)
+                            .foregroundStyle(ColorTheme.text)
                             .cornerRadius(12)
                     }
                     .disabled(mealService.currentMeal.isEmpty)
@@ -341,16 +341,16 @@ struct MealBuilderView: View {
         VStack(spacing: 12) {
             Image(systemName: "fork.knife")
                 .font(.system(size: 48))
-                .foregroundColor(ColorTheme.secondaryText.opacity(0.5))
+                .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
                 .accessibleDecorative()
             
             Text("No food items yet")
                 .typography(Typography.headline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("Tap \"Add Food Item\" to start building your meal")
                 .typography(Typography.caption)
-                .foregroundColor(ColorTheme.secondaryText.opacity(0.8))
+                .foregroundStyle(ColorTheme.secondaryText.opacity(0.8))
                 .multilineTextAlignment(.center)
         }
         .padding()
@@ -373,13 +373,13 @@ struct NutritionSummaryCard: View {
             HStack {
                 Text("Nutrition Summary")
                     .typography(Typography.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
                 Text("\(Int(nutrition.calories ?? 0)) calories")
                     .typography(Typography.headline)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
             
             Divider()
@@ -417,11 +417,11 @@ struct NutrientLabel: View {
         VStack(spacing: 4) {
             Text(name)
                 .typography(Typography.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("\(String(format: "%.1f", value ?? 0)) \(unit)")
                 .typography(Typography.headline)
-                .foregroundColor(color)
+                .foregroundStyle(color)
         }
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .combine)

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -18,18 +18,18 @@ struct MealConfirmationView: View {
                             .bold()
                         Spacer()
                         Text(meal.date.formatted(.dateTime.hour().minute()))
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                     
                     if let notes = meal.notes {
                         Text(notes)
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                     
                     Label("\(meal.type.rawValue)", systemImage: "clock")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 .padding()
                 .roundedCard()
@@ -64,10 +64,10 @@ struct MealConfirmationView: View {
                 if serverStatus.isOffline {
                     HStack(spacing: 8) {
                         Image(systemName: "wifi.slash")
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         Text("AI analysis unavailable while offline")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
@@ -90,7 +90,7 @@ struct MealConfirmationView: View {
                             ForEach(analysis.warnings, id: \.self) { warning in
                                 Label(warning, systemImage: "exclamationmark.triangle")
                                     .font(.subheadline)
-                                    .foregroundColor(.orange)
+                                    .foregroundStyle(.orange)
                                     .padding(.vertical, 4)
                             }
                         }
@@ -113,7 +113,7 @@ struct MealConfirmationView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .cornerRadius(10)
                     
                     Button("Edit Meal") {
@@ -122,7 +122,7 @@ struct MealConfirmationView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.background)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                     .cornerRadius(10)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
@@ -194,7 +194,7 @@ private struct NutritionSummaryView: View {
                     Text("\(String(format: "%.1f", fiber))g")
                 }
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             }
             
             if let sugar = nutrition.sugar {
@@ -204,7 +204,7 @@ private struct NutritionSummaryView: View {
                     Text("\(String(format: "%.1f", sugar))g")
                 }
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             }
         }
     }
@@ -219,12 +219,12 @@ private struct NutritionValueView: View {
         VStack(spacing: 4) {
             Text(label)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             Text(value)
                 .font(.headline)
             Text(unit)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
     }
@@ -240,7 +240,7 @@ private struct MealConfirmationFoodItemRow: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 60, height: 60)
-                .foregroundColor(ColorTheme.primary.opacity(0.3))
+                .foregroundStyle(ColorTheme.primary.opacity(0.3))
             
             VStack(alignment: .leading, spacing: 8) {
                 Text(item.name)
@@ -248,12 +248,12 @@ private struct MealConfirmationFoodItemRow: View {
                 
                 Text(item.quantity)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 
                 if let brand = item.nutritionDetails["brand"] {
                     Text(brand)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             
@@ -262,7 +262,7 @@ private struct MealConfirmationFoodItemRow: View {
             if let calories = item.nutrition.calories {
                 Text("\(Int(calories)) cal")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 8)

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -40,7 +40,7 @@ struct MealDetailView: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(mealTypeColor(type).opacity(0.2))
-            .foregroundColor(mealTypeColor(type))
+            .foregroundStyle(mealTypeColor(type))
             .cornerRadius(12)
     }
     
@@ -114,14 +114,14 @@ struct MealDetailView: View {
         VStack(spacing: 8) {
             Text(viewModel.meal.name)
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             HStack {
                 mealBadge(type: viewModel.meal.type)
                 
                 Text(viewModel.formattedDateTime)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding(.horizontal)
@@ -133,7 +133,7 @@ struct MealDetailView: View {
             VStack(alignment: .leading, spacing: 16) {
                 Text("Food Items")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .padding(.horizontal)
                 
                 ForEach(viewModel.meal.foodItems, id: \.id) { foodItem in
@@ -150,7 +150,7 @@ struct MealDetailView: View {
             VStack(alignment: .leading, spacing: 16) {
                 Text("Nutrition Summary")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .padding(.horizontal)
                 
                 nutritionSummaryCard(nutrition: totalNutrition)
@@ -165,7 +165,7 @@ struct MealDetailView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Notes")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                     .padding(.horizontal)
 
                 Text(notes)
@@ -204,11 +204,11 @@ struct MealDetailView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(foodItem.name)
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(foodItem.quantity)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -216,7 +216,7 @@ struct MealDetailView: View {
             if let calories = foodItem.nutrition.calories {
                 Text("\(calories) calories")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding()
@@ -231,13 +231,13 @@ struct MealDetailView: View {
             HStack {
                 Text("Total Nutrition")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
                 
                 Text("\(nutrition.calories ?? 0) calories")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
             }
             
             Divider()
@@ -266,11 +266,11 @@ struct MealDetailView: View {
         VStack(spacing: 4) {
             Text(name)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             
             Text("\(String(format: "%.1f", value ?? 0))\(unit)")
                 .font(.subheadline.bold())
-                .foregroundColor(color)
+                .foregroundStyle(color)
         }
         .frame(maxWidth: .infinity)
     }

--- a/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
@@ -20,17 +20,17 @@ struct MealLoggingOptionsView: View {
                 // Icon
                 Image(systemName: "magnifyingglass.circle.fill")
                     .font(.system(size: 80))
-                    .foregroundColor(ColorTheme.accent)
+                    .foregroundStyle(ColorTheme.accent)
                 
                 // Title
                 Text("Add Food")
                     .font(.title.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 // Description
                 Text("Search our database to find and log your food")
                     .font(.body)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
                 
@@ -49,7 +49,7 @@ struct MealLoggingOptionsView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(ColorTheme.accent)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .cornerRadius(12)
                     }
                     
@@ -61,7 +61,7 @@ struct MealLoggingOptionsView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(ColorTheme.surface)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                             .cornerRadius(12)
                     }
                 }

--- a/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
@@ -39,7 +39,7 @@ struct MealTypeSelectionView: View {
                     
                     Text("Select which meal to add \(foodItem.name) to:")
                         .font(.body)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .multilineTextAlignment(.center)
                 }
                 .padding(.top)
@@ -55,7 +55,7 @@ struct MealTypeSelectionView: View {
                             if let brand = foodItem.nutritionDetails["brand"], !brand.isEmpty {
                                 Text(brand)
                                     .font(.subheadline)
-                                    .foregroundColor(ColorTheme.secondaryText)
+                                    .foregroundStyle(ColorTheme.secondaryText)
                             }
                         }
                         
@@ -99,17 +99,17 @@ struct MealTypeSelectionView: View {
                                         Text(mealTypeInfo.display)
                                             .font(.body)
                                             .fontWeight(.medium)
-                                            .foregroundColor(isSelected ? .white : ColorTheme.primaryText)
+                                            .foregroundStyle(isSelected ? .white : ColorTheme.primaryText)
                                         
                                         Text(mealTypeInfo.description)
                                             .font(.caption)
-                                            .foregroundColor(isSelected ? .white.opacity(0.8) : ColorTheme.secondaryText)
+                                            .foregroundStyle(isSelected ? .white.opacity(0.8) : ColorTheme.secondaryText)
                                     }
                                     
                                     Spacer()
                                     
                                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                                        .foregroundColor(isSelected ? .white : ColorTheme.secondaryText)
+                                        .foregroundStyle(isSelected ? .white : ColorTheme.secondaryText)
                                 }
                                 .padding()
                                 .background(isSelected ? ColorTheme.primary : ColorTheme.cardBackground)
@@ -134,7 +134,7 @@ struct MealTypeSelectionView: View {
                     Text("Add to \(mealTypes.first(where: { $0.type == selectedMealType.rawValue })?.display ?? "Meal")")
                         .font(.headline)
                         .fontWeight(.medium)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(ColorTheme.primary)
@@ -149,7 +149,7 @@ struct MealTypeSelectionView: View {
                     Button("Cancel") {
                         dismiss()
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }

--- a/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
+++ b/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
@@ -123,7 +123,7 @@ struct AddMedicationView: View {
             ZStack(alignment: .topLeading) {
                 if viewModel.notes.isEmpty {
                     Text("e.g. Take with food, prescribed by Dr. Smith…")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .font(.body)
                         .padding(.top, 8)
                         .padding(.leading, 4)

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -148,7 +148,7 @@ struct CalendarMedicationsSectionHeader: View {
                 Text("Medications")
                     .font(.title3)
                     .fontWeight(.semibold)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
                 Button {
                     HapticManager.shared.medium()
@@ -164,7 +164,7 @@ struct CalendarMedicationsSectionHeader: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                     .background(Color.orange, in: Capsule())
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                 }
                 .accessibleButton(label: "Log Dose", hint: "Tap to log a medication dose")
             }
@@ -189,24 +189,24 @@ struct DailyMedicationCard: View {
             HStack {
                 Text("Daily Medications")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 Spacer()
             }
 
             if doses.isEmpty {
                 Text("Log a dose to see your daily medication summary.")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 // Dose count — prominent
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(doses.count)")
                         .font(.system(size: 36, weight: .bold, design: .rounded))
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Text("dose\(doses.count == 1 ? "" : "s") taken")
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     Spacer()
                 }
 
@@ -243,10 +243,10 @@ private struct MedNamePill: View {
         HStack(spacing: 4) {
             Image(systemName: "pills.fill")
                 .font(.caption)
-                .foregroundColor(.purple)
+                .foregroundStyle(.purple)
             Text(name)
                 .font(.caption)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -285,7 +285,7 @@ struct DoseCalendarRow: View {
                     .frame(width: 48, height: 48)
                 Image(systemName: "pills.fill")
                     .font(.system(size: 20, weight: .medium))
-                    .foregroundColor(.purple)
+                    .foregroundStyle(.purple)
             }
 
             // Content
@@ -293,21 +293,21 @@ struct DoseCalendarRow: View {
                 HStack {
                     Text(dose.medicationName)
                         .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Spacer()
                     Text(formattedTime)
                         .font(.system(size: 15))
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
 
                 Text(dosageText)
                     .font(.system(size: 15))
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
 
                 if let notes = dose.notes, !notes.isEmpty {
                     Text(notes)
                         .font(.system(size: 14))
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .lineLimit(2)
                 }
             }
@@ -315,7 +315,7 @@ struct DoseCalendarRow: View {
             // Checkmark
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 20))
-                .foregroundColor(.green)
+                .foregroundStyle(.green)
         }
         .padding(16)
         .contentShape(Rectangle())

--- a/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
@@ -102,7 +102,7 @@ struct MedicationListView: View {
         VStack(spacing: 20) {
             Image(systemName: "pills.circle")
                 .font(.system(size: 64))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
 
             Text("No Medications Yet")
                 .font(.title2)
@@ -110,7 +110,7 @@ struct MedicationListView: View {
 
             Text("Add your current medications to track dosages and timing, and help GutCheck surface insights about how they affect your gut health.")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
@@ -156,7 +156,7 @@ private struct MedicationRowView: View {
                     Text("Active")
                         .font(.caption)
                         .fontWeight(.semibold)
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(Color.green.opacity(0.12), in: Capsule())
@@ -168,13 +168,13 @@ private struct MedicationRowView: View {
                 if medication.dosage.amount > 0 {
                     Text(formattedDosage)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     Text("·")
                         .foregroundStyle(.tertiary)
                 }
                 Text(medication.dosage.frequency.displayName)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
 
             // Source + start date

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -96,7 +96,7 @@ struct MedicationsView: View {
             }
             .padding()
             .background(Color.purple.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
-            .foregroundColor(.purple)
+            .foregroundStyle(.purple)
         }
         .accessibilityLabel("Log a medication dose")
         .accessibilityHint("Tap to record that you took a medication")
@@ -171,7 +171,7 @@ struct MedicationsView: View {
             NavigationLink(destination: MedicationListView()) {
                 Text("Manage all medications…")
                     .font(.subheadline)
-                    .foregroundColor(.purple)
+                    .foregroundStyle(.purple)
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
@@ -199,7 +199,7 @@ private struct SectionTitle: View {
     var body: some View {
         Label(title, systemImage: systemImage)
             .font(.headline)
-            .foregroundColor(.primary)
+            .foregroundStyle(.primary)
     }
 }
 
@@ -225,7 +225,7 @@ private struct DoseRowView: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "checkmark.circle.fill")
-                .foregroundColor(.green)
+                .foregroundStyle(.green)
                 .font(.title3)
             VStack(alignment: .leading, spacing: 2) {
                 Text(dose.medicationName)
@@ -262,7 +262,7 @@ private struct MedCatalogRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "pills.fill")
-                .foregroundColor(.purple)
+                .foregroundStyle(.purple)
                 .font(.title3)
                 .frame(width: 28)
             VStack(alignment: .leading, spacing: 2) {

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
@@ -13,15 +13,15 @@ struct OnboardingHealthKitStep: View {
             VStack(spacing: 16) {
                 Image(systemName: "heart.text.square")
                     .font(.system(size: 64))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 Text("Health Data Integration")
                     .font(.largeTitle.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text("Connect with Apple Health to sync your nutrition and symptom data for comprehensive health tracking.")
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -49,7 +49,7 @@ struct OnboardingHealthKitStep: View {
                     }
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -60,13 +60,13 @@ struct OnboardingHealthKitStep: View {
                     showPermissionExplanation = true
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
                 
                 Button("Skip for Now") {
                     currentStep += 1
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding(.horizontal, 24)
@@ -84,7 +84,7 @@ struct OnboardingHealthKitStep: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("What you'll get:")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             VStack(spacing: 12) {
                 healthKitBenefit("📊", "Comprehensive tracking", "All your health data in one place")
@@ -106,11 +106,11 @@ struct OnboardingHealthKitStep: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.subheadline.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -122,11 +122,11 @@ struct OnboardingHealthKitStep: View {
             HStack(spacing: 12) {
                 Image(systemName: "lock.shield.fill")
                     .font(.system(size: 20))
-                    .foregroundColor(ColorTheme.success)
+                    .foregroundStyle(ColorTheme.success)
                 
                 Text("Your health data stays secure")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
             }
@@ -134,13 +134,13 @@ struct OnboardingHealthKitStep: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("• Data is encrypted and stored securely")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 Text("• You control what data to share")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                 Text("• Can be revoked anytime in Settings")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding(16)
@@ -176,10 +176,10 @@ struct HealthKitPermissionExplanationView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Health Data We'll Access")
                             .font(.title2.bold())
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text("GutCheck will request permission to read and write specific health data types:")
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     VStack(alignment: .leading, spacing: 16) {
@@ -202,10 +202,10 @@ struct HealthKitPermissionExplanationView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Privacy & Control")
                             .font(.title3.bold())
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text("• You can choose which data types to allow or deny\n• Permissions can be changed anytime in Health app settings\n• GutCheck never shares your health data with third parties\n• All data is encrypted and stored securely")
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .padding(16)
                     .background(ColorTheme.cardBackground)
@@ -230,24 +230,24 @@ struct HealthKitPermissionExplanationView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             VStack(spacing: 8) {
                 ForEach(items, id: \.0) { item in
                     HStack(alignment: .top, spacing: 12) {
                         Image(systemName: "circle.fill")
                             .font(.system(size: 6))
-                            .foregroundColor(ColorTheme.primary)
+                            .foregroundStyle(ColorTheme.primary)
                             .padding(.top, 6)
                         
                         VStack(alignment: .leading, spacing: 2) {
                             Text(item.0)
                                 .font(.subheadline.bold())
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                             
                             Text(item.1)
                                 .font(.caption)
-                                .foregroundColor(ColorTheme.secondaryText)
+                                .foregroundStyle(ColorTheme.secondaryText)
                         }
                         
                         Spacer()

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
@@ -20,16 +20,16 @@ struct OnboardingPermissionsStep: View {
             VStack(spacing: 16) {
                 Image(systemName: "lock.shield")
                     .font(.system(size: 64))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 Text("Privacy & Permissions")
                     .font(.largeTitle.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text("GutCheck respects your privacy and only requests permissions for features you choose to use.")
                     .font(.title3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()
@@ -38,7 +38,7 @@ struct OnboardingPermissionsStep: View {
             VStack(spacing: 16) {
                 Text("We may ask for access to:")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 permissionOverviewList
             }
@@ -56,7 +56,7 @@ struct OnboardingPermissionsStep: View {
                     showingPermissionRequest = true
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
@@ -66,7 +66,7 @@ struct OnboardingPermissionsStep: View {
                     currentStep += 1
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             }
         }
         .padding(.horizontal, 24)
@@ -88,17 +88,17 @@ struct OnboardingPermissionsStep: View {
                 HStack(spacing: 16) {
                     Image(systemName: icon)
                         .font(.system(size: 24))
-                        .foregroundColor(ColorTheme.primary)
+                        .foregroundStyle(ColorTheme.primary)
                         .frame(width: 32)
                     
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.subheadline.bold())
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Text(description)
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     
                     Spacer()
@@ -116,11 +116,11 @@ struct OnboardingPermissionsStep: View {
             HStack(spacing: 12) {
                 Image(systemName: "checkmark.shield.fill")
                     .font(.system(size: 20))
-                    .foregroundColor(ColorTheme.success)
+                    .foregroundStyle(ColorTheme.success)
                 
                 Text("Your privacy is protected")
                     .font(.headline)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Spacer()
             }
@@ -141,17 +141,17 @@ struct OnboardingPermissionsStep: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 12))
-                .foregroundColor(ColorTheme.success)
+                .foregroundStyle(ColorTheme.success)
                 .padding(.top, 2)
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.caption.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(description)
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             Spacer()

--- a/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
@@ -61,7 +61,7 @@ struct PermissionRequestView: View {
                     skipToEnd()
                 }
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             }
             
             // Progress indicator
@@ -80,16 +80,16 @@ struct PermissionRequestView: View {
             VStack(spacing: 16) {
                 Image(systemName: permissionType.icon)
                     .font(.system(size: 64))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 Text(permissionType.title)
                     .font(.largeTitle.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text(permissionType.description)
                     .font(.title3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(nil)
             }
             
@@ -108,16 +108,16 @@ struct PermissionRequestView: View {
             VStack(spacing: 12) {
                 Image(systemName: permissionType.icon)
                     .font(.system(size: 64))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 
                 VStack(spacing: 8) {
                     Text(permissionType.title)
                         .font(.largeTitle.bold())
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     
                     Text("Optional")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
                         .background(ColorTheme.surface)
@@ -127,7 +127,7 @@ struct PermissionRequestView: View {
                 Text(permissionType.description)
                     .font(.title3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .lineLimit(nil)
             }
             
@@ -144,18 +144,18 @@ struct PermissionRequestView: View {
         return VStack(alignment: .leading, spacing: 12) {
             Text("This helps you:")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             VStack(alignment: .leading, spacing: 8) {
                 ForEach(getBenefits(for: permissionType), id: \.self) { benefit in
                     HStack(spacing: 12) {
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(ColorTheme.success)
+                            .foregroundStyle(ColorTheme.success)
                             .font(.system(size: 16))
                         
                         Text(benefit)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                         
                         Spacer()
                     }
@@ -173,12 +173,12 @@ struct PermissionRequestView: View {
         
         return HStack(spacing: 12) {
             Image(systemName: status.statusIcon)
-                .foregroundColor(status.statusColor)
+                .foregroundStyle(status.statusColor)
                 .font(.system(size: 16))
             
             Text(status.statusText)
                 .font(.subheadline)
-                .foregroundColor(status.statusColor)
+                .foregroundStyle(status.statusColor)
             
             Spacer()
             
@@ -187,7 +187,7 @@ struct PermissionRequestView: View {
                     permissionManager.openAppSettings()
                 }
                 .font(.caption)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
             }
         }
         .padding(12)
@@ -200,17 +200,17 @@ struct PermissionRequestView: View {
         VStack(spacing: 32) {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 80))
-                .foregroundColor(ColorTheme.success)
+                .foregroundStyle(ColorTheme.success)
             
             VStack(spacing: 16) {
                 Text("All Set!")
                     .font(.largeTitle.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 
                 Text("GutCheck is ready to help you track your digestive health with personalized insights.")
                     .font(.title3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             // Summary of enabled permissions
@@ -222,18 +222,18 @@ struct PermissionRequestView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Enabled Features:")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(PermissionManager.PermissionType.allCases, id: \.self) { type in
                 if permissionManager.isPermissionGranted(type) {
                     HStack(spacing: 12) {
                         Image(systemName: type.icon)
-                            .foregroundColor(ColorTheme.success)
+                            .foregroundStyle(ColorTheme.success)
                             .frame(width: 20)
                         
                         Text(type.title)
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.primaryText)
+                            .foregroundStyle(ColorTheme.primaryText)
                         
                         Spacer()
                     }
@@ -267,7 +267,7 @@ struct PermissionRequestView: View {
                         }
                     }
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary)
@@ -279,14 +279,14 @@ struct PermissionRequestView: View {
                             nextStep()
                         }
                         .font(.subheadline)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                     }
                 } else {
                     Button("Continue") {
                         nextStep()
                     }
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary)
@@ -298,7 +298,7 @@ struct PermissionRequestView: View {
                     dismiss()
                 }
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)

--- a/GutCheck/GutCheck/Views/PhoneAuthView.swift
+++ b/GutCheck/GutCheck/Views/PhoneAuthView.swift
@@ -37,7 +37,7 @@ struct PhoneAuthView: View {
                     Button("Cancel") {
                         dismiss()
                     }
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
         }
@@ -65,11 +65,11 @@ struct PhoneAuthView: View {
                 Text("Enter Phone Number")
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                 
                 Text("We'll send you a verification code to confirm your phone number.")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.center)
             }
             
@@ -89,7 +89,7 @@ struct PhoneAuthView: View {
                 
                 Text("Format: +1 (555) 123-4567")
                     .font(.caption)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
             }
             
             CustomButton(
@@ -111,11 +111,11 @@ struct PhoneAuthView: View {
                 Text("Enter Verification Code")
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundColor(ColorTheme.text)
+                    .foregroundStyle(ColorTheme.text)
                 
                 Text("We sent a 6-digit code to \(viewModel.phoneNumber)")
                     .font(.subheadline)
-                    .foregroundColor(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText)
                     .multilineTextAlignment(.center)
             }
             
@@ -159,7 +159,7 @@ struct PhoneAuthView: View {
                     Task { await viewModel.sendPhoneVerification() }
                 }
                 .font(.footnote)
-                .foregroundColor(ColorTheme.primary)
+                .foregroundStyle(ColorTheme.primary)
                 .disabled(authService.isLoading)
             }
         }

--- a/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
+++ b/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
@@ -27,22 +27,22 @@ struct DeleteAccountView: View {
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 64))
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     
                     Text("Delete Your Account")
                         .font(.title.bold())
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     
                     Text("This action cannot be undone")
                         .font(.headline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 
                 // Consequences Warning
                 VStack(alignment: .leading, spacing: 16) {
                     Text("What will happen:")
                         .font(.headline)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     
                     VStack(alignment: .leading, spacing: 8) {
                         WarningRow(icon: "trash", text: "All your health data will be permanently deleted")
@@ -83,7 +83,7 @@ struct DeleteAccountView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.red)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .cornerRadius(12)
                     }
                     .disabled(isDeleting)
@@ -91,7 +91,7 @@ struct DeleteAccountView: View {
                     Button("Cancel") {
                         dismiss()
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 }
                 .padding(.horizontal)
                 
@@ -161,7 +161,7 @@ struct WarningRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
                 .frame(width: 20)
             
             Text(text)
@@ -179,7 +179,7 @@ struct DataRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
                 .frame(width: 20)
             
             Text(text)

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -16,7 +16,7 @@ struct HealthDataIntegrationView: View {
                 Section(header: Text("Apple Health")) {
                     if healthKitVM.healthData != nil {
                         Label("Connected", systemImage: "checkmark.circle.fill")
-                            .foregroundColor(.green)
+                            .foregroundStyle(.green)
 
                         Button {
                             openHealthApp()
@@ -50,10 +50,10 @@ struct HealthDataIntegrationView: View {
                             Spacer()
                             Image(systemName: "chevron.right")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                 }
 
                 // MARK: - What GutCheck reads
@@ -75,7 +75,7 @@ struct HealthDataIntegrationView: View {
                 ) {
                     NavigationLink(destination: MedicationListView()) {
                         Label("My Medications", systemImage: "pills.fill")
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                     }
                 }
 
@@ -113,7 +113,7 @@ struct HealthDataIntegrationView: View {
                         Button("Refresh Health Data") {
                             Task { await healthKitVM.fetchHealthData() }
                         }
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                     }
                 }
 
@@ -205,7 +205,7 @@ struct HealthDataIntegrationView: View {
                                     Text("Request Write Permissions")
                                 }
                             }
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                         }
 
                         if healthKitVM.hasDeniedWrites {
@@ -218,7 +218,7 @@ struct HealthDataIntegrationView: View {
                                     Text("Enable in Health App Settings")
                                 }
                             }
-                            .foregroundColor(.orange)
+                            .foregroundStyle(.orange)
                         }
                     }
                 }
@@ -249,7 +249,7 @@ struct HealthDataIntegrationView: View {
     private var writesFooter: some View {
         if healthKitVM.hasDeniedWrites {
             Text("Some write permissions are denied. Go to Health App → Privacy → Apps → GutCheck to re-enable them.")
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
         } else if healthKitVM.hasUndeterminedWrites {
             Text("Tap \"Request Write Permissions\" below to grant write access for types not yet authorized.")
         } else {
@@ -275,7 +275,7 @@ struct HealthKitPermissionsGuideView: View {
                 Section {
                     Text("To adjust which data Apple Health and GutCheck share with each other, you'll need to manage permissions directly in the Health app.")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
                 }
 
@@ -334,7 +334,7 @@ struct HealthKitPermissionsGuideView: View {
                         dismiss()
                     } label: {
                         Image(systemName: "xmark")
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                     }
                 }
             }
@@ -360,7 +360,7 @@ private struct GuideStepRow: View {
                     .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
                 Image(systemName: icon)
                     .font(.system(size: 22))
-                    .foregroundColor(iconColor)
+                    .foregroundStyle(iconColor)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -369,7 +369,7 @@ private struct GuideStepRow: View {
                     .fontWeight(.semibold)
                 Text(detail)
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 4)
@@ -402,12 +402,12 @@ private struct WritePermissionRow: View {
 
             Text(name)
                 .font(.subheadline)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
 
             Spacer()
 
             Image(systemName: statusConfig.icon)
-                .foregroundColor(statusConfig.color)
+                .foregroundStyle(statusConfig.color)
                 .font(.system(size: 15))
                 .accessibilityLabel(statusConfig.label)
         }
@@ -426,7 +426,7 @@ private struct HealthTypeRow: View {
             Text(label)
         } icon: {
             Image(systemName: icon)
-                .foregroundColor(color)
+                .foregroundStyle(color)
         }
     }
 }
@@ -442,7 +442,7 @@ private struct HealthDataRow: View {
             Text(label)
             Spacer()
             Text(value)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")

--- a/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
+++ b/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
@@ -12,14 +12,14 @@ struct ProfileSetupView: View {
             VStack(spacing: 24) {
                 Text("Set Up Your Profile")
                     .font(.title.bold())
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
                 TextField("First Name", text: $firstName)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 TextField("Last Name", text: $lastName)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 if let error = errorMessage {
                     Text(error)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
                 Button(action: saveProfile) {
                     if isSaving {
@@ -30,7 +30,7 @@ struct ProfileSetupView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(ColorTheme.accent)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .cornerRadius(10)
                     }
                 }

--- a/GutCheck/GutCheck/Views/Profile/ProfileSheetView.swift
+++ b/GutCheck/GutCheck/Views/Profile/ProfileSheetView.swift
@@ -15,7 +15,7 @@ struct ProfileSheetView: View {
                 VStack(spacing: 20) {
                     ProgressView()
                     Text("Loading profile...")
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(ColorTheme.background)

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -31,7 +31,7 @@ struct SettingsView: View {
                             Spacer()
                             Text(settingsVM.language.displayName)
                                 .typography(Typography.body)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Language: \(settingsVM.language.displayName)")
@@ -44,7 +44,7 @@ struct SettingsView: View {
                             Spacer()
                             Text(settingsVM.unitOfMeasure.displayName)
                                 .typography(Typography.body)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Units: \(settingsVM.unitOfMeasure.displayName)")
@@ -57,7 +57,7 @@ struct SettingsView: View {
                             Spacer()
                             Text(settingsVM.colorScheme.displayName)
                                 .typography(Typography.body)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Appearance: \(settingsVM.colorScheme.displayName)")
@@ -68,7 +68,7 @@ struct SettingsView: View {
                     NavigationLink(destination: UserRemindersView()) {
                         HStack {
                             Image(systemName: "bell.badge")
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                                 .accessibleDecorative()
                             Text("Reminders")
                                 .typography(Typography.body)
@@ -82,14 +82,14 @@ struct SettingsView: View {
                     NavigationLink(destination: MedicationListView()) {
                         HStack {
                             Image(systemName: "pills.fill")
-                                .foregroundColor(.purple)
+                                .foregroundStyle(.purple)
                                 .accessibleDecorative()
                             Text("My Medications")
                                 .typography(Typography.body)
                             Spacer()
                             Text("Manage your list")
                                 .typography(Typography.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("My Medications")
@@ -100,15 +100,15 @@ struct SettingsView: View {
                     Button(action: { showAppleHealth = true }) {
                         HStack {
                             Image(systemName: "heart.fill")
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                                 .accessibleDecorative()
                             Text("Apple Health")
                                 .typography(Typography.body)
-                                .foregroundColor(.primary)
+                                .foregroundStyle(.primary)
                             Spacer()
                             Text(appleHealthStatusText)
                                 .typography(Typography.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Apple Health: \(appleHealthStatusText)")
@@ -117,14 +117,14 @@ struct SettingsView: View {
                     NavigationLink(destination: HealthcareExportView()) {
                         HStack {
                             Image(systemName: "heart.text.square")
-                                .foregroundColor(.blue)
+                                .foregroundStyle(.blue)
                                 .accessibleDecorative()
                             Text("Export Health Data")
                                 .typography(Typography.body)
                             Spacer()
                             Text("For Healthcare Professionals")
                                 .typography(Typography.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Export Health Data for Healthcare Professionals")
@@ -135,7 +135,7 @@ struct SettingsView: View {
                     NavigationLink(destination: PrivacyPolicyView()) {
                         HStack {
                             Image(systemName: "lock.shield")
-                                .foregroundColor(.green)
+                                .foregroundStyle(.green)
                                 .accessibleDecorative()
                             Text("Privacy Policy")
                                 .typography(Typography.body)
@@ -147,14 +147,14 @@ struct SettingsView: View {
                     NavigationLink(destination: DataDeletionRequestView()) {
                         HStack {
                             Image(systemName: "trash.circle")
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                                 .accessibleDecorative()
                             Text("Request Data Deletion")
                                 .typography(Typography.body)
                             Spacer()
                             Text("GDPR Right")
                                 .typography(Typography.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .accessibilityLabel("Request Data Deletion")
@@ -162,18 +162,18 @@ struct SettingsView: View {
 
                     HStack {
                         Image(systemName: "checkmark.shield")
-                            .foregroundColor(.blue)
+                            .foregroundStyle(.blue)
                             .accessibleDecorative()
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Privacy Policy Accepted")
                                 .font(.subheadline)
                             Text("Version 1.0 - August 18, 2025")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                         Spacer()
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
+                            .foregroundStyle(.green)
                             .accessibleDecorative()
                     }
                     .padding(.vertical, 4)
@@ -185,12 +185,12 @@ struct SettingsView: View {
                     NavigationLink(destination: LocalStorageSettingsView()) {
                         HStack {
                             Image(systemName: "internaldrive")
-                                .foregroundColor(.blue)
+                                .foregroundStyle(.blue)
                             Text("Local Storage")
                             Spacer()
                             Text("Core Data")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
@@ -200,7 +200,7 @@ struct SettingsView: View {
                     if let user = authService.currentUser {
                         HStack(spacing: 12) {
                             Image(systemName: user.signInMethod.icon)
-                                .foregroundColor(ColorTheme.primary)
+                                .foregroundStyle(ColorTheme.primary)
                                 .frame(width: 20)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("Signed in with \(user.signInMethod.displayName)")
@@ -208,11 +208,11 @@ struct SettingsView: View {
                                     .fontWeight(.medium)
                                 Text(user.email)
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(.secondary)
                             }
                             Spacer()
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(ColorTheme.success)
+                                .foregroundStyle(ColorTheme.success)
                         }
                         .padding(.vertical, 4)
                         .accessibilityElement(children: .combine)
@@ -226,9 +226,9 @@ struct SettingsView: View {
                     } label: {
                         HStack {
                             Image(systemName: "rectangle.portrait.and.arrow.right")
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                             Text("Sign Out")
-                                .foregroundColor(ColorTheme.primaryText)
+                                .foregroundStyle(ColorTheme.primaryText)
                         }
                     }
                     .accessibilityLabel("Sign Out")
@@ -238,12 +238,12 @@ struct SettingsView: View {
                     NavigationLink(destination: DeleteAccountView()) {
                         HStack {
                             Image(systemName: "trash")
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                             Text("Delete Account")
                             Spacer()
                             Text("Permanent")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                         }
                     }
                 }
@@ -281,7 +281,7 @@ struct LanguageSelectionView: View {
                     Spacer()
                     if lang == settingsVM.language {
                         Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                             .accessibleDecorative()
                     }
                 }
@@ -312,7 +312,7 @@ struct UnitSelectionView: View {
                     Spacer()
                     if unit == settingsVM.unitOfMeasure {
                         Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                             .accessibleDecorative()
                     }
                 }
@@ -343,7 +343,7 @@ struct AppearanceSelectionView: View {
                     Spacer()
                     if scheme == settingsVM.colorScheme {
                         Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                             .accessibleDecorative()
                     }
                 }

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -40,7 +40,7 @@ struct ProfileImageView: View {
                     
                     Text("Uploading...")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.accent)
+                        .foregroundStyle(ColorTheme.accent)
                 }
                 .padding(12)
                 .background(
@@ -53,7 +53,7 @@ struct ProfileImageView: View {
             // Pro badge
             Text("Pro")
                 .font(.caption.bold())
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
                 .background(Capsule().fill(ColorTheme.accent))
@@ -95,7 +95,7 @@ struct ProfileImageView: View {
                             } else {
                                 Text(user.initials)
                                     .font(.system(size: 36, weight: .bold))
-                                    .foregroundColor(ColorTheme.accent)
+                                    .foregroundStyle(ColorTheme.accent)
                             }
                         }
                     )
@@ -109,7 +109,7 @@ struct ProfileImageView: View {
                         Spacer()
                         Image(systemName: "camera.fill")
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .padding(8)
                             .background(Circle().fill(ColorTheme.accent))
                             .offset(x: -8, y: -8)
@@ -305,12 +305,12 @@ struct UserProfileView: View {
             
             Text(user.fullName)
                 .font(.title2.bold())
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
                 .padding(.top, 4)
             
             Text(user.email)
                 .font(.subheadline)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .padding(.bottom, 8)
         }
     }
@@ -324,15 +324,15 @@ struct ProfileInfoCard: View {
         VStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(ColorTheme.accent)
+                .foregroundStyle(ColorTheme.accent)
                 .padding(8)
                 .background(Circle().fill(ColorTheme.accent.opacity(0.08)))
             Text(title)
                 .font(.caption)
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
             Text(value)
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
         }
         .frame(maxWidth: .infinity)
         .padding()
@@ -351,15 +351,15 @@ struct ProfileActionRow: View {
         HStack {
             Image(systemName: icon)
                 .font(.title3)
-                .foregroundColor(ColorTheme.accent)
+                .foregroundStyle(ColorTheme.accent)
                 .frame(width: 36, height: 36)
                 .background(Circle().fill(ColorTheme.accent.opacity(0.08)))
             Text(title)
                 .font(.body)
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
             Spacer()
             Image(systemName: "chevron.right")
-                .foregroundColor(ColorTheme.secondaryText)
+                .foregroundStyle(ColorTheme.secondaryText)
         }
         .padding()
         .background(ColorTheme.cardBackground)

--- a/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
@@ -16,10 +16,10 @@ struct UserRemindersView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "clock.fill")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.accent)
+                            .foregroundStyle(ColorTheme.accent)
                         Text("Set your typical meal time. A reminder fires 15 minutes after to log what you ate.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .padding(.bottom, 4)
 
@@ -100,11 +100,11 @@ struct UserRemindersView: View {
                     HStack(spacing: 12) {
                         Image(systemName: "sparkles")
                             .font(.subheadline)
-                            .foregroundColor(ColorTheme.primary)
+                            .foregroundStyle(ColorTheme.primary)
                             .frame(width: 20)
                         Text("Sent automatically when GutCheck detects new insights or patterns in your data.")
                             .font(.caption)
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .padding(.bottom, 4)
 
@@ -137,7 +137,7 @@ struct UserRemindersView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.accent)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .cornerRadius(12)
                 }
                 .disabled(reminderService.isLoading)
@@ -180,16 +180,16 @@ struct UserRemindersView: View {
             HStack(spacing: 12) {
                 Image(systemName: "checklist")
                     .font(.title3)
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                     .frame(width: 28)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Sync with Apple Reminders")
                         .font(.body)
-                        .foregroundColor(ColorTheme.primaryText)
+                        .foregroundStyle(ColorTheme.primaryText)
                     Text("Add reminders to your Apple Reminders app")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
 
                 Spacer()
@@ -211,18 +211,18 @@ struct UserRemindersView: View {
                         Task { await connectAppleReminders() }
                     }
                     .font(.subheadline.weight(.medium))
-                    .foregroundColor(ColorTheme.primary)
+                    .foregroundStyle(ColorTheme.primary)
                 }
             }
 
             if remindersKit.isEnabled && remindersKit.isAuthorized {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(ColorTheme.success)
+                        .foregroundStyle(ColorTheme.success)
                         .font(.subheadline)
                     Text("Your reminders will appear in the \"GutCheck\" list in Apple Reminders.")
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
             }
         }
@@ -268,7 +268,7 @@ struct ReminderSection<Content: View>: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.headline)
-                .foregroundColor(color)
+                .foregroundStyle(color)
             VStack(spacing: 12) {
                 content()
             }

--- a/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
@@ -25,7 +25,7 @@ struct OfflineBannerView: View {
                         .font(.subheadline)
                         .fontWeight(.semibold)
                 }
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
                 .background(

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusRow.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusRow.swift
@@ -17,19 +17,19 @@ struct ServerStatusRow: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(iconColor)
+                .foregroundStyle(iconColor)
                 .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(ColorTheme.primaryText)
+                    .foregroundStyle(ColorTheme.primaryText)
 
                 if let subtitle {
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundColor(ColorTheme.secondaryText)
+                        .foregroundStyle(ColorTheme.secondaryText)
                 }
             }
 

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -46,12 +46,12 @@ struct ServerStatusSheet: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Image(systemName: "icloud.slash")
-                        .foregroundColor(ColorTheme.warning)
+                        .foregroundStyle(ColorTheme.warning)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { dismiss() }) {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundColor(ColorTheme.secondaryText)
+                            .foregroundStyle(ColorTheme.secondaryText)
                     }
                     .accessibilityId(AccessibilityIdentifiers.ServerStatus.dismissButton)
                 }
@@ -85,7 +85,7 @@ struct ServerStatusSheet: View {
                     .fontWeight(.medium)
             }
         }
-        .foregroundColor(.white)
+        .foregroundStyle(.white)
         .padding(.horizontal, 14)
         .padding(.vertical, 6)
         .background(Capsule().fill(ColorTheme.warning))
@@ -118,11 +118,11 @@ struct ServerStatusSheet: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.caption)
-                .foregroundColor(ColorTheme.warning)
+                .foregroundStyle(ColorTheme.warning)
             Text(message)
                 .font(.caption)
                 .fontWeight(.medium)
-                .foregroundColor(ColorTheme.warning)
+                .foregroundStyle(ColorTheme.warning)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -143,7 +143,7 @@ struct ServerStatusSheet: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("What's happening")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             ServerStatusRow(
                 icon: "exclamationmark.triangle.fill",
@@ -193,7 +193,7 @@ struct ServerStatusSheet: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("What still works")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             ServerStatusRow(
                 icon: "checkmark.circle.fill",
@@ -228,7 +228,7 @@ struct ServerStatusSheet: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Temporarily limited")
                 .font(.headline)
-                .foregroundColor(ColorTheme.primaryText)
+                .foregroundStyle(ColorTheme.primaryText)
 
             ServerStatusRow(
                 icon: "exclamationmark.triangle.fill",
@@ -269,7 +269,7 @@ struct ServerStatusSheet: View {
                         .fontWeight(.medium)
                 }
             }
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)

--- a/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
@@ -32,14 +32,14 @@ struct DataDeletionRequestView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
                             Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                             Text("Data Deletion Request")
                                 .font(.headline)
                         }
                         
                         Text("This will submit a request to delete your data. The request will be reviewed by our team before any data is permanently removed.")
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                     .padding(.vertical, 8)
                 }
@@ -82,7 +82,7 @@ struct DataDeletionRequestView: View {
                         Text("• Some data may be retained for legal compliance")
                     }
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 }
                 
                 Section {

--- a/GutCheck/GutCheck/Views/Settings/DebugView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DebugView.swift
@@ -148,10 +148,10 @@ private struct NetworkDebugger: View {
                     .font(.headline)
                 Text(request.method)
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 if let statusCode = request.statusCode {
                     Text("Status: \(statusCode)")
-                        .foregroundColor(statusCode >= 400 ? .red : .green)
+                        .foregroundStyle(statusCode >= 400 ? .red : .green)
                 }
             }
         }

--- a/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
@@ -22,7 +22,7 @@ struct HealthKitTestView: View {
                     .padding()
                 
                 Text(statusMessage)
-                    .foregroundColor(isAuthorized ? .green : .orange)
+                    .foregroundStyle(isAuthorized ? .green : .orange)
                     .multilineTextAlignment(.center)
                     .padding()
                 
@@ -57,7 +57,7 @@ struct HealthKitTestView: View {
                             testResults.removeAll()
                         }
                         .buttonStyle(.borderless)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     }
                     .padding()
                 }

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -81,7 +81,7 @@ struct HealthcareExportView: View {
         VStack(spacing: 16) {
             Image(systemName: "heart.text.square")
                 .font(.system(size: 48))
-                .foregroundColor(.blue)
+                .foregroundStyle(.blue)
             
             Text("Healthcare Professional Export")
                 .font(.title2)
@@ -90,7 +90,7 @@ struct HealthcareExportView: View {
             
             Text("Generate comprehensive health reports for medical professionals, nutritionists, and healthcare providers.")
                 .font(.body)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         }
         .padding()
@@ -112,7 +112,7 @@ struct HealthcareExportView: View {
                         .fontWeight(.medium)
                     Spacer()
                     Text("\(startDate.formatted(date: .abbreviated, time: .omitted)) - \(endDate.formatted(date: .abbreviated, time: .omitted))")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 
                 HStack {
@@ -120,7 +120,7 @@ struct HealthcareExportView: View {
                         .fontWeight(.medium)
                     Spacer()
                     Text(exportOptions.format.displayName)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 
                 HStack {
@@ -128,7 +128,7 @@ struct HealthcareExportView: View {
                         .fontWeight(.medium)
                     Spacer()
                     Text(exportOptions.includePrivateData ? "Yes" : "No")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             .padding()
@@ -199,7 +199,7 @@ struct HealthcareExportView: View {
                     
                     Text("Generating Report...")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             } else {
                 Button(action: generateExport) {
@@ -208,7 +208,7 @@ struct HealthcareExportView: View {
                         Text("Generate Healthcare Report")
                     }
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.blue)
@@ -320,7 +320,7 @@ struct DataPreviewRow: View {
     var body: some View {
         HStack {
             Image(systemName: icon)
-                .foregroundColor(color)
+                .foregroundStyle(color)
                 .frame(width: 24)
             
             Text(title)
@@ -330,7 +330,7 @@ struct DataPreviewRow: View {
             
             Text(count)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
     }
 }
@@ -344,14 +344,14 @@ struct InstructionRow: View {
             Text(number)
                 .font(.caption)
                 .fontWeight(.bold)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .frame(width: 20, height: 20)
                 .background(Color.blue)
                 .clipShape(Circle())
             
             Text(text)
                 .font(.body)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
         }
     }
 }
@@ -391,7 +391,7 @@ struct ExportOptionsSheet: View {
                 Section("Privacy Note") {
                     Text("Private data includes personal notes, detailed symptoms, and medication information. Only include if required for medical assessment.")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             .navigationTitle("Export Options")

--- a/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
+++ b/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
@@ -24,21 +24,21 @@ struct LocalStorageSettingsView: View {
             Section("Local Storage Status") {
                 HStack {
                     Image(systemName: "internaldrive")
-                        .foregroundColor(.blue)
+                        .foregroundStyle(.blue)
                     Text("Core Data Status")
                     Spacer()
                     Text("Active")
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                         .font(.caption)
                 }
                 
                 HStack {
                     Image(systemName: "lock.shield")
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                     Text("Encryption")
                     Spacer()
                     Text("Enabled")
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                         .font(.caption)
                 }
             }
@@ -46,11 +46,11 @@ struct LocalStorageSettingsView: View {
             Section("Synchronization") {
                 HStack {
                     Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundColor(.orange)
+                        .foregroundStyle(.orange)
                     Text("Sync Status")
                     Spacer()
                     Text(dataSyncService.getSyncStatus().description)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                 }
                 
@@ -72,7 +72,7 @@ struct LocalStorageSettingsView: View {
                             .progressViewStyle(LinearProgressViewStyle())
                         Text("\(Int(dataSyncService.syncProgress * 100))%")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -83,9 +83,9 @@ struct LocalStorageSettingsView: View {
                 }) {
                     HStack {
                         Image(systemName: "trash")
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                         Text("Clear Local Data")
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                     }
                 }
                 
@@ -96,7 +96,7 @@ struct LocalStorageSettingsView: View {
                 }) {
                     HStack {
                         Image(systemName: "clock.arrow.circlepath")
-                            .foregroundColor(.orange)
+                            .foregroundStyle(.orange)
                         Text("Clean Up Old Data")
                     }
                 }
@@ -105,21 +105,21 @@ struct LocalStorageSettingsView: View {
             Section("Storage Information") {
                 HStack {
                     Image(systemName: "info.circle")
-                        .foregroundColor(.blue)
+                        .foregroundStyle(.blue)
                     Text("Local Database Size")
                     Spacer()
                     Text("Calculating...")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                 }
                 
                 HStack {
                     Image(systemName: "clock")
-                        .foregroundColor(.purple)
+                        .foregroundStyle(.purple)
                     Text("Last Cleanup")
                     Spacer()
                     Text("Never")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                 }
             }

--- a/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
+++ b/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
@@ -13,7 +13,7 @@ struct PrivacyPolicyView: View {
                 Section {
                     Text("Last Updated: July 2025")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     
                     Text("This Privacy Policy describes how GutCheck collects, uses, and protects your personal information.")
                         .font(.subheadline)
@@ -27,7 +27,7 @@ struct PrivacyPolicyView: View {
                                 .font(.headline)
                             Text(section.summary)
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                         .padding(.vertical, 4)
                     }
@@ -70,7 +70,7 @@ private struct PolicyDetailView: View {
                     
                     Text(section.summary)
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 
                 // Section Content
@@ -97,7 +97,7 @@ private struct PolicyDetailSection: View {
             
             Text(detail.content)
                 .font(.body)
-                .foregroundColor(ColorTheme.text.opacity(0.8))
+                .foregroundStyle(ColorTheme.text.opacity(0.8))
             
             if !detail.bullets.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
@@ -107,7 +107,7 @@ private struct PolicyDetailSection: View {
                             Text(bullet)
                         }
                         .font(.body)
-                        .foregroundColor(ColorTheme.text.opacity(0.8))
+                        .foregroundStyle(ColorTheme.text.opacity(0.8))
                     }
                 }
                 .padding(.leading, 4)

--- a/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
@@ -23,7 +23,7 @@ struct ReminderSettingsTestView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         if let settings = reminderService.reminderSettings {
                             Text("Settings loaded successfully!")
-                                .foregroundColor(.green)
+                                .foregroundStyle(.green)
                                 .font(.headline)
                             
                             Group {
@@ -39,12 +39,12 @@ struct ReminderSettingsTestView: View {
                             .padding(.horizontal)
                         } else {
                             Text("No settings loaded")
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                         }
                         
                         if let error = reminderService.errorMessage {
                             Text("Error: \(error)")
-                                .foregroundColor(.red)
+                                .foregroundStyle(.red)
                                 .padding()
                         }
                     }

--- a/GutCheck/GutCheck/Views/Shared/EmptyStateView.swift
+++ b/GutCheck/GutCheck/Views/Shared/EmptyStateView.swift
@@ -8,11 +8,11 @@ struct EmptyStateView: View {
         VStack(spacing: 16) {
             Image(systemName: imageName)
                 .font(.system(size: 50))
-                .foregroundColor(.gray)
+                .foregroundStyle(.gray)
             
             Text(message)
                 .font(.body)
-                .foregroundColor(.gray)
+                .foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
         }

--- a/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
+++ b/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
@@ -10,7 +10,7 @@ struct GraphPreviewView: View {
                 .font(.headline)
             Text("AI trend analysis coming soon...")
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             Rectangle()
                 .fill(Color.gray.opacity(0.1))
                 .frame(height: 120)

--- a/GutCheck/GutCheck/Views/Shared/TriggerAlertBanner.swift
+++ b/GutCheck/GutCheck/Views/Shared/TriggerAlertBanner.swift
@@ -7,7 +7,7 @@ struct TriggerAlertBanner: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Trigger Alert", systemImage: "exclamationmark.circle")
                 .font(.headline)
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
             ForEach(alerts, id: \.self) { alert in
                 Text("• \(alert)")
                     .font(.subheadline)

--- a/GutCheck/GutCheck/Views/Shared/TriggerAlertView.swift
+++ b/GutCheck/GutCheck/Views/Shared/TriggerAlertView.swift
@@ -7,7 +7,7 @@ struct TriggerAlertView: View {
         VStack(alignment: .leading, spacing: 8) {
             Label("Trigger Alert", systemImage: "exclamationmark.circle")
                 .font(.headline)
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
             ForEach(alerts, id: \.self) { alert in
                 Text("• \(alert)")
                     .font(.subheadline)


### PR DESCRIPTION
## Summary
- Replaces all 788 instances of the deprecated `foregroundColor()` modifier with `foregroundStyle()` across 81 files
- Fixes 7 instances where `.accentColor` (not a `ShapeStyle` member) needed to be qualified as `Color.accentColor`
- This was the most pervasive deprecated API in the codebase

Closes #219

## Test plan
- [x] Verify the project builds successfully
- [x] Spot-check UI across major screens (Dashboard, Meals, Symptoms, Medications, Insights) for color rendering consistency
- [x] Verify accent-colored elements in CalendarView, HealthDataIntegrationView, and SettingsView render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)