### PR TITLE
fix(#220): replace cornerRadius() with clipShape(.rect(cornerRadius:))

### DIFF
--- a/GutCheck/GutCheck/Extensions/View+Modifiers.swift
+++ b/GutCheck/GutCheck/Extensions/View+Modifiers.swift
@@ -5,7 +5,7 @@ extension View {
         self
             .padding()
             .background(ColorTheme.cardBackground)
-            .cornerRadius(10)
+            .clipShape(.rect(cornerRadius: 10))
             .shadow(radius: 2)
     }
     
@@ -14,7 +14,7 @@ extension View {
             .padding()
             .background(ColorTheme.buttonPrimary)
             .foregroundStyle(.white)
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
     }
     
     func secondaryButton() -> some View {
@@ -22,13 +22,13 @@ extension View {
             .padding()
             .background(ColorTheme.buttonSecondary)
             .foregroundStyle(ColorTheme.text)
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
     }
     
     func inputField() -> some View {
         self
             .padding()
             .background(ColorTheme.inputBackground)
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
     }
 }

--- a/GutCheck/GutCheck/SearchTest.swift
+++ b/GutCheck/GutCheck/SearchTest.swift
@@ -41,7 +41,7 @@ struct SearchTestView: View {
                 }
                 .padding()
                 .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
             }
             
             Spacer()

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
@@ -60,7 +60,7 @@ struct BristolStoolInfoView: View {
                     }
                     .padding()
                     .background(ColorTheme.cardBackground)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     .padding(.horizontal)
                     
                     // Detailed guide
@@ -343,7 +343,7 @@ struct BristolQuickCard: View {
         .frame(maxWidth: .infinity)
         .padding(8)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 
@@ -377,7 +377,7 @@ struct BristolDetailCard: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 
@@ -430,7 +430,7 @@ struct PainRangeCard: View {
         .padding(.horizontal)
         .padding(.vertical, 8)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 
@@ -461,7 +461,7 @@ struct UrgencyCard: View {
         .padding(.horizontal)
         .padding(.vertical, 8)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
@@ -48,7 +48,7 @@ struct CategoryInsightsView: View {
         .padding()
         .frame(maxWidth: .infinity)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var activeInsightsSection: some View {
@@ -97,7 +97,7 @@ struct CategoryInsightsView: View {
         .padding()
         .frame(maxWidth: .infinity)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 
@@ -142,7 +142,7 @@ private struct ActiveInsightRow: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 
@@ -174,7 +174,7 @@ private struct HistoricalInsightRow: View {
         }
         .padding()
         .background(ColorTheme.surface.opacity(0.5))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -182,7 +182,7 @@ struct InsightsView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
     }
 
@@ -221,7 +221,7 @@ struct InsightsView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
     }
 
@@ -264,7 +264,7 @@ struct InsightsView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
     }
 
@@ -303,7 +303,7 @@ private struct WeeklyStatPill: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
     }
 }
@@ -343,7 +343,7 @@ private struct AnalyticsInsightCard: View {
             }
             .padding()
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
         }
     }
@@ -374,7 +374,7 @@ private struct CategoryCard: View {
             .padding()
             .frame(maxWidth: .infinity, minHeight: 140, maxHeight: 140)
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
         }
     }
@@ -407,7 +407,7 @@ private struct PatternRow: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 
@@ -442,7 +442,7 @@ private struct RecommendationCard: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
@@ -35,7 +35,7 @@ struct RegisterView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 80, height: 80)
-                            .cornerRadius(20)
+                            .clipShape(.rect(cornerRadius: 20))
                         
                         Text("Create Your Account")
                             .font(.title2)
@@ -128,7 +128,7 @@ struct RegisterView: View {
                     .padding()
                     .background(isFormValid ? ColorTheme.primary : Color.gray)
                     .foregroundStyle(.white)
-                    .cornerRadius(10)
+                    .clipShape(.rect(cornerRadius: 10))
                     .padding(.horizontal)
                     .disabled(!isFormValid || isLoading)
                     

--- a/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
@@ -76,7 +76,7 @@ struct BristolScaleSelectionView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     private func bristolColor(for type: StoolType) -> Color {
         switch type {
@@ -165,7 +165,7 @@ struct PainLevelSliderView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     private func painColor(for level: Int) -> Color {
         switch level {
@@ -239,7 +239,7 @@ struct UrgencyLevelSelectionView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func urgencyColor(for level: UrgencyLevel) -> Color {
@@ -305,7 +305,7 @@ struct TagSelectionView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 
@@ -432,7 +432,7 @@ struct SectionHeader: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.surface)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(ColorTheme.border, lineWidth: 1)
@@ -446,7 +446,7 @@ struct SectionHeader: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var notesSection: some View {
@@ -461,7 +461,7 @@ struct SectionHeader: View {
                 .frame(minHeight: 100)
                 .padding(12)
                 .background(ColorTheme.cardBackground)
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
@@ -472,7 +472,7 @@ struct SectionHeader: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var actionButtonsSection: some View {
@@ -575,7 +575,7 @@ struct SectionHeader: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 
     private var datePickerSheet: some View {

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -144,7 +144,7 @@ struct SymptomDetailView: View {
             .frame(width: 58)
             .padding(.vertical, 10)
             .background(ColorTheme.primary.opacity(0.1))
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(viewModel.entity.date.formatted(.dateTime.weekday(.wide)))
@@ -167,7 +167,7 @@ struct SymptomDetailView: View {
         }
         .padding(16)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 
@@ -209,7 +209,7 @@ struct SymptomDetailView: View {
             )
         }
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 
@@ -228,7 +228,7 @@ struct SymptomDetailView: View {
             }
         }
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 
@@ -246,7 +246,7 @@ struct SymptomDetailView: View {
                 .foregroundStyle(iconColor)
                 .frame(width: 28, height: 28)
                 .background(iconColor.opacity(0.12))
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
 
             Text(label)
                 .font(.subheadline)
@@ -268,7 +268,7 @@ struct SymptomDetailView: View {
                     .foregroundStyle(ColorTheme.info)
                     .frame(width: 28, height: 28)
                     .background(ColorTheme.info.opacity(0.12))
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
 
                 Text("Notes")
                     .font(.subheadline)
@@ -293,7 +293,7 @@ struct SymptomDetailView: View {
                     .foregroundStyle(ColorTheme.secondary)
                     .frame(width: 28, height: 28)
                     .background(ColorTheme.secondary.opacity(0.12))
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
 
                 Text("Tags")
                     .font(.subheadline)
@@ -310,7 +310,7 @@ struct SymptomDetailView: View {
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
                             .background(ColorTheme.primary.opacity(0.12))
-                            .cornerRadius(20)
+                            .clipShape(.rect(cornerRadius: 20))
                     }
                 }
                 .padding(.leading, 40)
@@ -336,7 +336,7 @@ struct SymptomDetailView: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(color.opacity(0.15))
-            .cornerRadius(20)
+            .clipShape(.rect(cornerRadius: 20))
     }
 
     // MARK: - Color Helpers

--- a/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
@@ -102,7 +102,7 @@ struct SymptomEditView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var notesSection: some View {
@@ -116,7 +116,7 @@ struct SymptomEditView: View {
                 .frame(minHeight: 100)
                 .padding(12)
                 .background(ColorTheme.cardBackground)
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
@@ -124,7 +124,7 @@ struct SymptomEditView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var actionButtonsSection: some View {
@@ -179,7 +179,7 @@ struct SymptomEditView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var isFormValid: Bool {

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -887,7 +887,7 @@ private struct MacroPill: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(color.opacity(0.12))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 
@@ -977,7 +977,7 @@ private struct SymptomStatPill: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(color.opacity(0.12))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -20,7 +20,7 @@ struct MealSummaryCard: View {
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/PatternSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/PatternSummaryCard.swift
@@ -16,7 +16,7 @@ struct PatternSummaryCard: View {
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/SymptomSummaryCard.swift
@@ -28,7 +28,7 @@ struct SymptomSummaryCard: View {
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/TriggerSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/TriggerSummaryCard.swift
@@ -16,7 +16,7 @@ struct TriggerSummaryCard: View {
         }
         .padding()
         .background(Color(UIColor.secondarySystemBackground))
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
@@ -51,7 +51,7 @@ struct CameraPermissionView: View {
         }
         .padding(24)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(16)
+        .clipShape(.rect(cornerRadius: 16))
         .onAppear {
             permissionManager.updateAllPermissionStates()
         }
@@ -120,7 +120,7 @@ struct CameraPermissionView: View {
         }
         .padding(16)
         .background(permissionManager.cameraStatus.statusColor.opacity(0.1))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var actionButtons: some View {
@@ -143,7 +143,7 @@ struct CameraPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 .disabled(isRequesting)
             } else if permissionManager.cameraStatus.canOpenSettings {
                 Button("Open Settings") {
@@ -154,7 +154,7 @@ struct CameraPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             } else if permissionManager.cameraStatus.isGranted {
                 Button("Continue") {
                     onPermissionGranted()
@@ -164,7 +164,7 @@ struct CameraPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.success)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             }
             
             // Additional info button

--- a/GutCheck/GutCheck/Views/Components/CustomButton.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomButton.swift
@@ -78,7 +78,7 @@ struct CustomButton: View {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(style.borderColor, lineWidth: style == .outline ? 2 : 0)
             )
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
         }
         .disabled(isDisabled || isLoading)

--- a/GutCheck/GutCheck/Views/Components/FoodItemDetailRow.swift
+++ b/GutCheck/GutCheck/Views/Components/FoodItemDetailRow.swift
@@ -60,7 +60,7 @@ struct FoodItemDetailRow: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 }

--- a/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
@@ -54,7 +54,7 @@ struct NotificationPermissionView: View {
         }
         .padding(24)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(16)
+        .clipShape(.rect(cornerRadius: 16))
         .onAppear {
             permissionManager.updateAllPermissionStates()
         }
@@ -78,7 +78,7 @@ struct NotificationPermissionView: View {
         }
         .padding(16)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func reminderBenefit(_ icon: String, _ title: String, _ description: String) -> some View {
@@ -143,7 +143,7 @@ struct NotificationPermissionView: View {
         }
         .padding(16)
         .background(permissionManager.notificationStatus.statusColor.opacity(0.1))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var actionButtons: some View {
@@ -166,7 +166,7 @@ struct NotificationPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 .disabled(isRequesting)
                 
                 Button("Maybe Later") {
@@ -184,7 +184,7 @@ struct NotificationPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 
                 Button("Continue Without Notifications") {
                     onPermissionResult(false)
@@ -201,7 +201,7 @@ struct NotificationPermissionView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.success)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
@@ -71,7 +71,7 @@ struct UnifiedNutritionBadge: View {
         .padding(style.padding)
         .background(color.opacity(0.2))
         .foregroundStyle(color)
-        .cornerRadius(style == .large ? 6 : 4)
+        .clipShape(.rect(cornerRadius: style == .large ? 6 : 4))
     }
 }
 
@@ -166,7 +166,7 @@ struct UnifiedNutritionSummary: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
     

--- a/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
+++ b/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
@@ -86,7 +86,7 @@ struct ReauthenticationView: View {
                         .padding()
                         .background(Color.red)
                         .foregroundStyle(.white)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                     }
                     .disabled(authService.isLoading || email.isEmpty || password.isEmpty)
                     
@@ -203,7 +203,7 @@ struct PhoneReauthenticationView: View {
                             .padding()
                             .background(Color.blue)
                             .foregroundStyle(.white)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                         }
                         .disabled(authService.isLoading || phoneNumber.isEmpty)
                     } else {
@@ -233,7 +233,7 @@ struct PhoneReauthenticationView: View {
                             .padding()
                             .background(Color.green)
                             .foregroundStyle(.white)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                         }
                         .disabled(authService.isLoading || verificationCode.isEmpty)
                         

--- a/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
+++ b/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
@@ -86,7 +86,7 @@ struct SocialSignInButton: View {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(provider.borderColor, lineWidth: 1)
             )
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
         }
         .disabled(isLoading)

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -71,7 +71,7 @@ struct UnifiedFoodDetailView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
     
@@ -205,7 +205,7 @@ struct UnifiedFoodDetailView: View {
             }
             .padding()
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             
             Text("Per \(customQuantity)")
                 .font(.subheadline)
@@ -257,7 +257,7 @@ struct UnifiedFoodDetailView: View {
             }
             .padding()
             .background(ColorTheme.cardBackground)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
         }
     }
@@ -349,7 +349,7 @@ struct UnifiedFoodDetailView: View {
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color.green.opacity(0.1))
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             } else {
                 LazyVGrid(columns: [
                     GridItem(.flexible()),
@@ -363,7 +363,7 @@ struct UnifiedFoodDetailView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
     }
     
@@ -447,7 +447,7 @@ struct UnifiedFoodDetailView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.accent)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
         }
         .padding(.top)
     }
@@ -625,7 +625,7 @@ struct HealthIndicatorBadge: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(indicator.severity.borderColor.opacity(0.3), lineWidth: 1)
         )
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
         .onTapGesture {
             showingDetail = true
         }
@@ -680,7 +680,7 @@ struct DetailSectionRow: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
     }
 }
@@ -740,7 +740,7 @@ struct NutritionDetailsView: View {
                     }
                     .padding()
                     .background(ColorTheme.cardBackground)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     
                     // Additional nutrition details (remaining items)
                     if !remainingNutritionDetails.isEmpty {
@@ -760,7 +760,7 @@ struct NutritionDetailsView: View {
                         }
                         .padding()
                         .background(ColorTheme.cardBackground)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                     }
                 }
                 .padding()
@@ -881,7 +881,7 @@ struct NutritionDetailsView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
         .background(ColorTheme.surface)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 
@@ -910,7 +910,7 @@ struct NutritionDetailItem: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
         .background(ColorTheme.surface)
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
     
     private var formattedLabel: String {
@@ -1126,7 +1126,7 @@ struct AllergensView: View {
                                 }
                                 .padding()
                                 .background(ColorTheme.error.opacity(0.1))
-                                .cornerRadius(12)
+                                .clipShape(.rect(cornerRadius: 12))
                                 .padding(.horizontal)
                             }
                         }
@@ -1187,7 +1187,7 @@ struct AllergensView: View {
                                 }
                                 .padding()
                                 .background(indicator.color.opacity(0.1))
-                                .cornerRadius(12)
+                                .clipShape(.rect(cornerRadius: 12))
                                 .padding(.horizontal)
                             }
                         }

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
@@ -73,7 +73,7 @@ struct UnifiedFoodItemRow: View {
         }
         .padding(config.padding)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(config.cornerRadius)
+        .clipShape(.rect(cornerRadius: config.cornerRadius))
         .shadow(color: ColorTheme.shadowColor, radius: config.shadowRadius, x: 0, y: 1)
     }
     
@@ -193,7 +193,7 @@ struct UnifiedFoodItemRow: View {
                     .padding(.vertical, 2)
                     .background(ColorTheme.error.opacity(0.2))
                     .foregroundStyle(ColorTheme.error)
-                    .cornerRadius(4)
+                    .clipShape(.rect(cornerRadius: 4))
             }
             if item.allergens.count > config.maxAllergens {
                 Text("+\(item.allergens.count - config.maxAllergens)")
@@ -254,7 +254,7 @@ struct NutritionBadge: View {
             .padding(.vertical, size.verticalPadding)
             .background(color.opacity(0.2))
             .foregroundStyle(color)
-            .cornerRadius(size.cornerRadius)
+            .clipShape(.rect(cornerRadius: size.cornerRadius))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
@@ -228,12 +228,12 @@ struct HealthScoreCard: View {
                     Rectangle()
                         .fill(ColorTheme.border.opacity(0.3))
                         .frame(height: 6)
-                        .cornerRadius(3)
+                        .clipShape(.rect(cornerRadius: 3))
                     
                     Rectangle()
                         .fill(scoreColor)
                         .frame(width: geometry.size.width * CGFloat(score) / 10.0, height: 6)
-                        .cornerRadius(3)
+                        .clipShape(.rect(cornerRadius: 3))
                         .animation(.spring(response: 0.6, dampingFraction: 0.8), value: score)
                 }
             }
@@ -267,7 +267,7 @@ struct DashboardInsightCard: View {
                     .foregroundStyle(iconColor)
                     .frame(width: 32, height: 32)
                     .background(iconColor.opacity(0.15))
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
                     .accessibleDecorative()
                 
                 Text(title)
@@ -401,13 +401,13 @@ struct DashboardInsightsView: View {
                         Rectangle()
                             .fill(index <= healthScore ? healthScoreColor : ColorTheme.border)
                             .frame(height: 8)
-                            .cornerRadius(4)
+                            .clipShape(.rect(cornerRadius: 4))
                     }
                 }
             }
             .padding()
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             
             // Today's Focus Section
             // Provides actionable health advice based on current symptoms
@@ -428,7 +428,7 @@ struct DashboardInsightsView: View {
             }
             .padding()
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             
             // Avoidance Tip Section
             // Warns about potential food triggers based on recent patterns
@@ -449,7 +449,7 @@ struct DashboardInsightsView: View {
             }
             .padding()
             .background(ColorTheme.surface)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
         }
     }
     

--- a/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
@@ -26,7 +26,7 @@ struct GreetingHeaderView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 }

--- a/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
@@ -43,7 +43,7 @@ struct RecentActivityListView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
         .onAppear {
             viewModel.loadRecentActivity(for: selectedDate, authService: authService)
@@ -117,7 +117,7 @@ struct ActivityRowView: View {
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
             .background(ColorTheme.surface)
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
         }
         .buttonStyle(PlainButtonStyle())
     }
@@ -181,7 +181,7 @@ struct LoadingStateView: View {
                 .padding(.vertical, 8)
                 .padding(.horizontal, 12)
                 .background(ColorTheme.surface)
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
             }
         }
         .redacted(reason: .placeholder)

--- a/GutCheck/GutCheck/Views/Dashboard/TodaySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaySummaryView.swift
@@ -20,7 +20,7 @@ struct TodaySummaryView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
     }
 }

--- a/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
@@ -119,7 +119,7 @@ struct TodaysActivitySummaryView: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
         .refreshable {
             print("🔄 TodaysActivitySummaryView: Manual refresh triggered")

--- a/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/WeekSelector.swift
@@ -44,7 +44,7 @@ struct WeekSelector: View {
                             .padding(.horizontal, 8)
                             .padding(.vertical, 2)
                             .background(ColorTheme.accent.opacity(0.1))
-                            .cornerRadius(8)
+                            .clipShape(.rect(cornerRadius: 8))
                     }
                 }
                 
@@ -90,7 +90,7 @@ struct WeekSelector: View {
                             RoundedRectangle(cornerRadius: 10)
                                 .stroke(date.isSameDay(as: Date.now) ? ColorTheme.accent : Color.clear, lineWidth: 2)
                         )
-                        .cornerRadius(10)
+                        .clipShape(.rect(cornerRadius: 10))
                         .shadow(color: selectedDate.isSameDay(as: date) ? ColorTheme.shadowColor : .clear, radius: 4, x: 0, y: 2)
                     }
                 }

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -349,7 +349,7 @@ struct StatCard: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(Color(.systemBackground))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
     }
 }
@@ -395,7 +395,7 @@ struct CategoryFilterButton: View {
                 .padding(.vertical, 8)
                 .background(isSelected ? Color.accentColor : Color(.systemGray6))
                 .foregroundStyle(isSelected ? .white : .primary)
-                .cornerRadius(20)
+                .clipShape(.rect(cornerRadius: 20))
         }
     }
 }
@@ -544,7 +544,7 @@ struct InsightCard: View {
         }
         .padding()
         .background(Color(.systemBackground))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
     }
 }

--- a/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
+++ b/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
@@ -55,7 +55,7 @@ struct LogOptionButton: View {
             }
             .frame(width: 120, height: 120)
             .background(color.opacity(0.1))
-            .cornerRadius(20)
+            .clipShape(.rect(cornerRadius: 20))
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
+++ b/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
@@ -23,7 +23,7 @@ struct AddWaterView: View {
                     .keyboardType(.decimalPad)
                     .padding()
                     .background(ColorTheme.surface)
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
                             .stroke(ColorTheme.primary.opacity(0.3), lineWidth: 1)
@@ -45,7 +45,7 @@ struct AddWaterView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.blue)
-                    .cornerRadius(8)
+                    .clipShape(.rect(cornerRadius: 8))
             }
             .disabled(cups <= 0)
             .opacity(cups <= 0 ? 0.6 : 1)

--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -52,7 +52,7 @@ struct FoodSearchView: View {
                             .padding(.horizontal, 16)
                             .padding(.vertical, 8)
                             .background(ColorTheme.accent)
-                            .cornerRadius(8)
+                            .clipShape(.rect(cornerRadius: 8))
                         }
                         .disabled(viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || serverStatus.isOffline)
                         .accessibleButton(
@@ -187,7 +187,7 @@ struct FoodSearchView: View {
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
                 .background(ColorTheme.primary)
-                .cornerRadius(10)
+                .clipShape(.rect(cornerRadius: 10))
             }
             .accessibleButton(
                 label: "Add Custom Food",
@@ -341,7 +341,7 @@ struct FoodSearchView: View {
                                 .padding()
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .background(ColorTheme.surface)
-                                .cornerRadius(12)
+                                .clipShape(.rect(cornerRadius: 12))
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 12)
                                         .stroke(ColorTheme.border, lineWidth: 1)
@@ -444,7 +444,7 @@ struct FoodItemResultRow: View {
                                     .padding(.vertical, 2)
                                     .background(ColorTheme.error.opacity(0.2))
                                     .foregroundStyle(ColorTheme.error)
-                                    .cornerRadius(4)
+                                    .clipShape(.rect(cornerRadius: 4))
                             }
                             if item.allergens.count > 3 {
                                 Text("+\(item.allergens.count - 3)")
@@ -476,7 +476,7 @@ struct FoodItemResultRow: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
         .padding(.horizontal)
     }
@@ -539,7 +539,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.vertical, 2)
                                 .background(ColorTheme.accent.opacity(0.2))
                                 .foregroundStyle(ColorTheme.accent)
-                                .cornerRadius(4)
+                                .clipShape(.rect(cornerRadius: 4))
                         }
                         
                         if let protein = item.nutrition.protein {
@@ -549,7 +549,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.vertical, 2)
                                 .background(Color.blue.opacity(0.2))
                                 .foregroundStyle(.blue)
-                                .cornerRadius(4)
+                                .clipShape(.rect(cornerRadius: 4))
                         }
                         
                         if let carbs = item.nutrition.carbs {
@@ -559,7 +559,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.vertical, 2)
                                 .background(Color.green.opacity(0.2))
                                 .foregroundStyle(.green)
-                                .cornerRadius(4)
+                                .clipShape(.rect(cornerRadius: 4))
                         }
                         
                         if let fat = item.nutrition.fat {
@@ -569,7 +569,7 @@ struct SimpleRecentFoodRow: View {
                                 .padding(.vertical, 2)
                                 .background(Color.red.opacity(0.2))
                                 .foregroundStyle(.red)
-                                .cornerRadius(4)
+                                .clipShape(.rect(cornerRadius: 4))
                         }
                     }
                     
@@ -583,7 +583,7 @@ struct SimpleRecentFoodRow: View {
                                     .padding(.vertical, 2)
                                     .background(ColorTheme.error.opacity(0.2))
                                     .foregroundStyle(ColorTheme.error)
-                                    .cornerRadius(4)
+                                    .clipShape(.rect(cornerRadius: 4))
                             }
                             if item.allergens.count > 2 {
                                 Text("+\(item.allergens.count - 2)")
@@ -615,7 +615,7 @@ struct SimpleRecentFoodRow: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 2, x: 0, y: 1)
     }
     

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -31,7 +31,7 @@ struct MealBuilderView: View {
                     .typography(Typography.headline)
                     .padding()
                     .background(ColorTheme.surface)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(ColorTheme.border, lineWidth: 1)
@@ -56,7 +56,7 @@ struct MealBuilderView: View {
                                         .padding(.vertical, 8)
                                         .background(isSelected ? ColorTheme.primary : ColorTheme.surface)
                                         .foregroundStyle(isSelected ? .white : ColorTheme.primaryText)
-                                        .cornerRadius(20)
+                                        .clipShape(.rect(cornerRadius: 20))
                                         .overlay(
                                             RoundedRectangle(cornerRadius: 20)
                                                 .stroke(isSelected ? Color.clear : ColorTheme.border, lineWidth: 1)
@@ -71,7 +71,7 @@ struct MealBuilderView: View {
                         .padding(.vertical, 8)
                     }
                     .background(ColorTheme.surface)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(ColorTheme.border, lineWidth: 1)
@@ -94,7 +94,7 @@ struct MealBuilderView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(ColorTheme.surface)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
                                 .stroke(ColorTheme.border, lineWidth: 1)
@@ -164,7 +164,7 @@ struct MealBuilderView: View {
                             .frame(minHeight: 100)
                             .padding(8)
                             .background(ColorTheme.surface)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 12)
                                     .stroke(ColorTheme.border, lineWidth: 1)
@@ -196,7 +196,7 @@ struct MealBuilderView: View {
                     .padding()
                     .background(ColorTheme.primary.opacity(0.9))
                     .foregroundStyle(.white)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                 }
                 .accessibleButton(
                     label: "Add Food Item",
@@ -220,7 +220,7 @@ struct MealBuilderView: View {
                             .padding()
                             .background(ColorTheme.surface)
                             .foregroundStyle(ColorTheme.primaryText)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 12)
                                     .stroke(ColorTheme.border, lineWidth: 1)
@@ -258,7 +258,7 @@ struct MealBuilderView: View {
                             .padding()
                             .background(ColorTheme.accent)
                             .foregroundStyle(ColorTheme.text)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                     }
                     .disabled(mealService.currentMeal.isEmpty)
                     .opacity(mealService.currentMeal.isEmpty ? 0.6 : 1)
@@ -356,7 +356,7 @@ struct MealBuilderView: View {
         .padding()
         .frame(maxWidth: .infinity)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .accessibleGroup(
             label: "No food items yet. Tap Add Food Item button to start building your meal",
             hint: nil
@@ -393,7 +393,7 @@ struct NutritionSummaryCard: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
         .accessibleGroup(
             label: AccessibilityText.nutritionSummary(

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -114,7 +114,7 @@ struct MealConfirmationView: View {
                     .padding()
                     .background(ColorTheme.primary)
                     .foregroundStyle(.white)
-                    .cornerRadius(10)
+                    .clipShape(.rect(cornerRadius: 10))
                     
                     Button("Edit Meal") {
                         router.navigateBack()
@@ -123,7 +123,7 @@ struct MealConfirmationView: View {
                     .padding()
                     .background(ColorTheme.background)
                     .foregroundStyle(ColorTheme.primary)
-                    .cornerRadius(10)
+                    .clipShape(.rect(cornerRadius: 10))
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
                             .stroke(ColorTheme.primary, lineWidth: 1)

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -41,7 +41,7 @@ struct MealDetailView: View {
             .padding(.vertical, 4)
             .background(mealTypeColor(type).opacity(0.2))
             .foregroundStyle(mealTypeColor(type))
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
     }
     
     private func mealTypeColor(_ type: MealType) -> Color {
@@ -171,7 +171,7 @@ struct MealDetailView: View {
                 Text(notes)
                     .padding()
                     .background(ColorTheme.surface)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     .padding(.horizontal)
             }
         }
@@ -221,7 +221,7 @@ struct MealDetailView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
         .padding(.horizontal)
     }
     
@@ -259,7 +259,7 @@ struct MealDetailView: View {
         }
         .padding()
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func nutritionItem(name: String, value: Double?, unit: String, color: Color) -> some View {

--- a/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
@@ -50,7 +50,7 @@ struct MealLoggingOptionsView: View {
                         .padding()
                         .background(ColorTheme.accent)
                         .foregroundStyle(.white)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                     }
                     
                     Button(action: {
@@ -62,7 +62,7 @@ struct MealLoggingOptionsView: View {
                             .padding()
                             .background(ColorTheme.surface)
                             .foregroundStyle(ColorTheme.primaryText)
-                            .cornerRadius(12)
+                            .clipShape(.rect(cornerRadius: 12))
                     }
                 }
                 .padding(.horizontal, 24)

--- a/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
@@ -72,7 +72,7 @@ struct MealTypeSelectionView: View {
                 }
                 .padding()
                 .background(ColorTheme.cardBackground)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(ColorTheme.border, lineWidth: 1)
@@ -113,7 +113,7 @@ struct MealTypeSelectionView: View {
                                 }
                                 .padding()
                                 .background(isSelected ? ColorTheme.primary : ColorTheme.cardBackground)
-                                .cornerRadius(12)
+                                .clipShape(.rect(cornerRadius: 12))
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 12)
                                         .stroke(isSelected ? ColorTheme.primary : ColorTheme.border, lineWidth: 1)
@@ -138,7 +138,7 @@ struct MealTypeSelectionView: View {
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(ColorTheme.primary)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                 }
                 .padding(.bottom)
             }

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -251,7 +251,7 @@ private struct MedNamePill: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color.purple.opacity(0.12))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
@@ -53,7 +53,7 @@ struct OnboardingHealthKitStep: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 .disabled(isRequesting)
                 
                 Button("Learn More") {
@@ -95,7 +95,7 @@ struct OnboardingHealthKitStep: View {
         }
         .padding(16)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func healthKitBenefit(_ icon: String, _ title: String, _ description: String) -> some View {
@@ -145,7 +145,7 @@ struct OnboardingHealthKitStep: View {
         }
         .padding(16)
         .background(ColorTheme.success.opacity(0.1))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func requestHealthKitPermission() {
@@ -209,7 +209,7 @@ struct HealthKitPermissionExplanationView: View {
                     }
                     .padding(16)
                     .background(ColorTheme.cardBackground)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 32)
@@ -257,6 +257,6 @@ struct HealthKitPermissionExplanationView: View {
         }
         .padding(16)
         .background(ColorTheme.surface)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
@@ -60,7 +60,7 @@ struct OnboardingPermissionsStep: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 
                 Button("Skip for Now") {
                     currentStep += 1
@@ -108,7 +108,7 @@ struct OnboardingPermissionsStep: View {
         }
         .padding(16)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var privacyCommitmentView: some View {
@@ -134,7 +134,7 @@ struct OnboardingPermissionsStep: View {
         }
         .padding(16)
         .background(ColorTheme.success.opacity(0.1))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     private func privacyPoint(_ title: String, _ description: String) -> some View {

--- a/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
@@ -121,7 +121,7 @@ struct PermissionRequestView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
                         .background(ColorTheme.surface)
-                        .cornerRadius(8)
+                        .clipShape(.rect(cornerRadius: 8))
                 }
                 
                 Text(permissionType.description)
@@ -164,7 +164,7 @@ struct PermissionRequestView: View {
         }
         .padding(16)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     // MARK: - Permission Status View
@@ -192,7 +192,7 @@ struct PermissionRequestView: View {
         }
         .padding(12)
         .background(status.statusColor.opacity(0.1))
-        .cornerRadius(8)
+        .clipShape(.rect(cornerRadius: 8))
     }
     
     // MARK: - Completion View
@@ -242,7 +242,7 @@ struct PermissionRequestView: View {
         }
         .padding(16)
         .background(ColorTheme.cardBackground)
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     // MARK: - Bottom Action View
@@ -271,7 +271,7 @@ struct PermissionRequestView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                     .disabled(isRequestingPermissions)
                     
                     if !permissionType.isRequired {
@@ -290,7 +290,7 @@ struct PermissionRequestView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(ColorTheme.primary)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                 }
             } else {
                 // Completion button
@@ -302,7 +302,7 @@ struct PermissionRequestView: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(ColorTheme.primary)
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
             }
         }
         .padding(.horizontal, 24)

--- a/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
+++ b/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
@@ -54,7 +54,7 @@ struct DeleteAccountView: View {
                 }
                 .padding()
                 .background(Color.red.opacity(0.1))
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 
                 // Data Summary
                 VStack(alignment: .leading, spacing: 16) {
@@ -71,7 +71,7 @@ struct DeleteAccountView: View {
                 }
                 .padding()
                 .background(Color.orange.opacity(0.1))
-                .cornerRadius(12)
+                .clipShape(.rect(cornerRadius: 12))
                 
                 // Action Buttons
                 VStack(spacing: 16) {
@@ -84,7 +84,7 @@ struct DeleteAccountView: View {
                         .padding()
                         .background(Color.red)
                         .foregroundStyle(.white)
-                        .cornerRadius(12)
+                        .clipShape(.rect(cornerRadius: 12))
                     }
                     .disabled(isDeleting)
                     

--- a/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
+++ b/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
@@ -31,7 +31,7 @@ struct ProfileSetupView: View {
                             .padding()
                             .background(ColorTheme.accent)
                             .foregroundStyle(.white)
-                            .cornerRadius(10)
+                            .clipShape(.rect(cornerRadius: 10))
                     }
                 }
                 .disabled(isSaving || firstName.isEmpty || lastName.isEmpty)

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -337,7 +337,7 @@ struct ProfileInfoCard: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(16)
+        .clipShape(.rect(cornerRadius: 16))
         .shadow(color: ColorTheme.shadowColor.opacity(0.08), radius: 4, x: 0, y: 2)
     }
 }
@@ -363,7 +363,7 @@ struct ProfileActionRow: View {
         }
         .padding()
         .background(ColorTheme.cardBackground)
-        .cornerRadius(16)
+        .clipShape(.rect(cornerRadius: 16))
         .shadow(color: ColorTheme.shadowColor.opacity(0.08), radius: 4, x: 0, y: 2)
     }
 }

--- a/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
@@ -138,7 +138,7 @@ struct UserRemindersView: View {
                     .padding()
                     .background(ColorTheme.accent)
                     .foregroundStyle(.white)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                 }
                 .disabled(reminderService.isLoading)
             }
@@ -274,7 +274,7 @@ struct ReminderSection<Content: View>: View {
             }
             .padding()
             .background(ColorTheme.cardBackground)
-            .cornerRadius(12)
+            .clipShape(.rect(cornerRadius: 12))
             .shadow(color: ColorTheme.shadowColor.opacity(0.06), radius: 2, x: 0, y: 1)
         }
     }

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -95,7 +95,7 @@ struct HealthcareExportView: View {
         }
         .padding()
         .background(Color(.systemGray6))
-        .cornerRadius(12)
+        .clipShape(.rect(cornerRadius: 12))
     }
     
     // MARK: - Export Options Section
@@ -133,7 +133,7 @@ struct HealthcareExportView: View {
             }
             .padding()
             .background(Color(.systemBackground))
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color(.systemGray4), lineWidth: 1)
@@ -180,7 +180,7 @@ struct HealthcareExportView: View {
             }
             .padding()
             .background(Color(.systemBackground))
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color(.systemGray4), lineWidth: 1)
@@ -212,7 +212,7 @@ struct HealthcareExportView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.blue)
-                    .cornerRadius(12)
+                    .clipShape(.rect(cornerRadius: 12))
                 }
                 .disabled(exportService.isExporting)
             }
@@ -255,7 +255,7 @@ struct HealthcareExportView: View {
             }
             .padding()
             .background(Color(.systemBackground))
-            .cornerRadius(8)
+            .clipShape(.rect(cornerRadius: 8))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color(.systemGray4), lineWidth: 1)

--- a/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
+++ b/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
@@ -14,7 +14,7 @@ struct GraphPreviewView: View {
             Rectangle()
                 .fill(Color.gray.opacity(0.1))
                 .frame(height: 120)
-                .cornerRadius(8)
+                .clipShape(.rect(cornerRadius: 8))
                 .overlay(Text("Graph Placeholder"))
         }
     }


### PR DESCRIPTION
## Summary
- Replaces all 171 instances of the deprecated `cornerRadius()` modifier with `clipShape(.rect(cornerRadius:))` across 48 files
- Handles numeric literals (12, 8, 10, 4, 20, 16, 3) and dynamic expressions (`config.cornerRadius`, `size.cornerRadius`, ternary)
- Includes 4 fixes in `View+Modifiers.swift` shared modifiers (`roundedCard()`, `primaryButton()`, etc.) that propagate to all consuming views

Closes #220

## Test plan
- [x] Verify the project builds successfully
- [x] Spot-check rounded corners on cards across Dashboard, Meals, Symptoms, Insights screens
- [x] Verify dynamic corner radius in UnifiedFoodItemRow and NutritionComponents renders correctly
- [x] Check shared modifiers (roundedCard, primaryButton) still apply correct corner rounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)