### PR TITLE
fix(#228): replace deprecated overlay(_:) with overlay { } trailing closure

### DIFF
--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -25,7 +25,7 @@ struct ProfileAvatarButton: View {
                         .scaledToFill()
                         .frame(width: size, height: size)
                         .clipShape(Circle())
-                        .overlay(Circle().stroke(ColorTheme.accent, lineWidth: 2))
+                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
                 } else if isLoadingImage {
                     // Loading state
                     Circle()
@@ -36,7 +36,7 @@ struct ProfileAvatarButton: View {
                                 .progressViewStyle(CircularProgressViewStyle(tint: ColorTheme.accent))
                                 .scaleEffect(0.7)
                         )
-                        .overlay(Circle().stroke(ColorTheme.accent, lineWidth: 2))
+                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
                 } else {
                     // Default avatar with initials or fallback icon
                     Circle()
@@ -55,7 +55,7 @@ struct ProfileAvatarButton: View {
                                 }
                             }
                         )
-                        .overlay(Circle().stroke(ColorTheme.accent, lineWidth: 2))
+                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
                 }
             }
         }

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -77,7 +77,7 @@ struct ProfileImageView: View {
                     .scaledToFill()
                     .frame(width: 110, height: 110)
                     .clipShape(Circle())
-                    .overlay(Circle().stroke(ColorTheme.accent, lineWidth: 5))
+                    .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 5) }
             } else {
                 Circle()
                     .strokeBorder(ColorTheme.accent, lineWidth: 5)

--- a/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
+++ b/GutCheck/GutCheck/Views/Shared/GraphPreviewView.swift
@@ -15,7 +15,7 @@ struct GraphPreviewView: View {
                 .fill(Color.gray.opacity(0.1))
                 .frame(height: 120)
                 .clipShape(.rect(cornerRadius: 8))
-                .overlay(Text("Graph Placeholder"))
+                .overlay { Text("Graph Placeholder") }
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Shared/InsightsCardView.swift
+++ b/GutCheck/GutCheck/Views/Shared/InsightsCardView.swift
@@ -13,7 +13,7 @@ struct InsightsCardView: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(RoundedRectangle(cornerRadius: 12).fill(Color.yellow.opacity(0.1)))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.yellow, lineWidth: 1))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(Color.yellow, lineWidth: 1) }
 
     }
 }

--- a/GutCheck/GutCheck/Views/Shared/TriggerAlertBanner.swift
+++ b/GutCheck/GutCheck/Views/Shared/TriggerAlertBanner.swift
@@ -16,7 +16,7 @@ struct TriggerAlertBanner: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.1)))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.red, lineWidth: 1))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(Color.red, lineWidth: 1) }
 
     }
 }

--- a/GutCheck/GutCheck/Views/Shared/TriggerAlertView.swift
+++ b/GutCheck/GutCheck/Views/Shared/TriggerAlertView.swift
@@ -16,7 +16,7 @@ struct TriggerAlertView: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.1)))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.red, lineWidth: 1))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(Color.red, lineWidth: 1) }
 
     }
 }


### PR DESCRIPTION
## Summary
- Replaces 8 instances of the deprecated `overlay(_:alignment:)` single-argument form with the modern `overlay { }` trailing closure syntax
- Affected files: ProfileAvatarButton (3), UserProfileView (1), GraphPreviewView (1), InsightsCardView (1), TriggerAlertBanner (1), TriggerAlertView (1)

Closes #228

## Test plan
- [x] Verify the project builds successfully
- [x] Verify profile avatar circle stroke overlay renders correctly
- [x] Verify trigger alert and insights card border overlays render correctly
- [x] Verify graph placeholder text overlay renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)