### PR TITLE
fix(#221): replace .navigationBarLeading/.navigationBarTrailing with .topBarLeading/.topBarTrailing

### DIFF
--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomInfoViews.swift
@@ -82,7 +82,7 @@ struct BristolStoolInfoView: View {
             .navigationTitle("Bristol Stool Scale")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }
@@ -193,7 +193,7 @@ struct PainLevelInfoView: View {
             .navigationTitle("Pain Assessment")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }
@@ -285,7 +285,7 @@ struct UrgencyLevelInfoView: View {
             .navigationTitle("Urgency Assessment")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
+++ b/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
@@ -275,7 +275,7 @@ struct DeletionRequestDetailView: View {
             .navigationTitle("Request Details")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -46,7 +46,7 @@ struct InsightsView: View {
             }
             .navigationTitle("Insights")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     ProfileAvatarButton(user: authService.currentUser) {
                         router.presentSheet(.profile)
                     }

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -302,7 +302,7 @@ struct AuthenticationView: View {
             .background(ColorTheme.background)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         viewModel.isShowingForgotPassword = false
                     }

--- a/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
@@ -613,7 +613,7 @@ struct SectionHeader: View {
             .navigationTitle("Symptom Time")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         HapticManager.shared.light()
                         showingDatePicker = false

--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -54,7 +54,7 @@ struct PaginatedSymptomHistoryView: View {
             .navigationTitle("Symptom History")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Export") {
                         Task {
                             await viewModel.exportSymptoms()

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -86,10 +86,10 @@ struct SymptomDetailView: View {
         .navigationTitle("Symptom Details")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 trailingToolbarContent
             }
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 leadingToolbarContent
             }
         }

--- a/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
@@ -85,7 +85,7 @@ struct SymptomExplanationView: View {
             .navigationTitle(symptomType.rawValue)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -50,7 +50,7 @@ struct SymptomHistoryView: View {
         .navigationTitle("Symptom History")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 Menu {
                     Button(action: { showingDatePicker = true }) {
                         Label("Select Date Range", systemImage: "calendar")
@@ -64,7 +64,7 @@ struct SymptomHistoryView: View {
                 }
             }
             
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 ProfileAvatarButton(user: authService.currentUser) {
                     router.showProfile()
                 }
@@ -229,7 +229,7 @@ private struct DateRangePickerView: View {
             .navigationTitle("Select Date Range")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         isPresented = false
                     }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -196,7 +196,7 @@ struct CalendarView: View {
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 ProfileAvatarButton(user: authService.currentUser) {
                     router.showProfile()
                 }
@@ -1163,7 +1163,7 @@ struct DailyNutritionDetailView: View {
             .navigationTitle(dateTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -43,7 +43,7 @@ struct UnifiedCalendarView: View {
             }
             .navigationTitle("Calendar")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button(action: { showingDatePicker = true }) {
                         Image(systemName: "calendar")
                     }
@@ -202,7 +202,7 @@ private struct DatePickerView: View {
             .navigationTitle("Choose Date")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         isPresented = false
                     }

--- a/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
@@ -406,13 +406,13 @@ struct DateRangePickerSheet: View {
             .navigationTitle("Select Date Range")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         dismiss()
                     }
                 }
                 
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         onRangeChange()
                         dismiss()

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -103,7 +103,7 @@ struct UnifiedFoodDetailView: View {
         .navigationTitle("Food Details")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 Button("Cancel") {
                     dismiss()
                 }
@@ -768,7 +768,7 @@ struct NutritionDetailsView: View {
             .navigationTitle("Nutrition Details")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }
@@ -1059,7 +1059,7 @@ struct IngredientsView: View {
             .navigationTitle("Ingredients")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }
@@ -1198,7 +1198,7 @@ struct AllergensView: View {
             .navigationTitle("Allergens & Warnings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
@@ -109,7 +109,7 @@ struct DashboardView: View {
         .navigationTitle("Dashboard")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 ProfileAvatarButton(user: authService.currentUser) {
                     router.showProfile()
                 }

--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -121,7 +121,7 @@ struct FoodSearchView: View {
             .navigationBarTitleDisplayMode(.inline)
             // Remove navigationDestination - will use sheet instead
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         HapticManager.shared.light()
                         dismiss()

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -462,7 +462,7 @@ struct DateTimePickerView: View {
             .navigationTitle("Select Date & Time")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         HapticManager.shared.light()
                         dismiss()

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -81,7 +81,7 @@ struct MealDetailView: View {
         .navigationTitle("Meal Details")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 editMenuButton
             }
         }

--- a/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealTypeSelectionView.swift
@@ -145,7 +145,7 @@ struct MealTypeSelectionView: View {
             .padding()
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
+++ b/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
@@ -139,10 +139,10 @@ struct AddMedicationView: View {
 
     @ToolbarContentBuilder
     private var toolbarItems: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
+        ToolbarItem(placement: .topBarLeading) {
             Button("Cancel") { dismiss() }
         }
-        ToolbarItem(placement: .navigationBarTrailing) {
+        ToolbarItem(placement: .topBarTrailing) {
             Group {
                 if viewModel.isSaving {
                     ProgressView()

--- a/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
+++ b/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
@@ -145,10 +145,10 @@ struct LogMedicationDoseView: View {
 
     @ToolbarContentBuilder
     private var toolbarItems: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
+        ToolbarItem(placement: .topBarLeading) {
             Button("Cancel") { dismiss() }
         }
-        ToolbarItem(placement: .navigationBarTrailing) {
+        ToolbarItem(placement: .topBarTrailing) {
             Group {
                 if viewModel.isSaving {
                     ProgressView()

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -94,12 +94,12 @@ struct MedicationCalendarView: View {
         .navigationTitle("Meds")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 ProfileAvatarButton(user: authService.currentUser) {
                     router.showProfile()
                 }
             }
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 NavigationLink(destination: MedicationListView()) {
                     Image(systemName: "list.bullet")
                         .accessibilityLabel("Manage medications")

--- a/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
@@ -26,7 +26,7 @@ struct MedicationListView: View {
         .navigationTitle("My Medications")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     viewModel.showingAddMedication = true
                 } label: {

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -31,7 +31,7 @@ struct MedicationsView: View {
         .navigationTitle("Medications")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     showingAddMed = true
                 } label: {

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
@@ -217,7 +217,7 @@ struct HealthKitPermissionExplanationView: View {
             .navigationTitle("HealthKit Integration")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/PhoneAuthView.swift
+++ b/GutCheck/GutCheck/Views/PhoneAuthView.swift
@@ -33,7 +33,7 @@ struct PhoneAuthView: View {
             .navigationTitle("Phone Sign In")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -225,7 +225,7 @@ struct HealthDataIntegrationView: View {
             }
             .navigationTitle("Apple Health")
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Close") { dismiss() }
                 }
             }
@@ -329,7 +329,7 @@ struct HealthKitPermissionsGuideView: View {
             .navigationTitle("Health App Settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button {
                         dismiss()
                     } label: {

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -250,7 +250,7 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Close") {
                         HapticManager.shared.light()
                         dismiss()

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -281,7 +281,7 @@ struct UserProfileView: View {
             .navigationTitle("Profile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Close") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -44,11 +44,11 @@ struct ServerStatusSheet: View {
             .navigationTitle("Server Status")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Image(systemName: "icloud.slash")
                         .foregroundStyle(ColorTheme.warning)
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button(action: { dismiss() }) {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(ColorTheme.secondaryText)

--- a/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
@@ -106,7 +106,7 @@ struct DataDeletionRequestView: View {
             .navigationTitle("Data Deletion")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") { dismiss() }
                 }
             }

--- a/GutCheck/GutCheck/Views/Settings/DebugView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DebugView.swift
@@ -72,7 +72,7 @@ struct DebugView: View {
             .navigationTitle("Debug Menu")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -48,7 +48,7 @@ struct HealthcareExportView: View {
             .navigationTitle("Healthcare Export")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Export") {
                         showingExportOptions = true
                     }
@@ -397,13 +397,13 @@ struct ExportOptionsSheet: View {
             .navigationTitle("Export Options")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") {
                         dismiss()
                     }
                 }
                 
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }

--- a/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
+++ b/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
@@ -48,7 +48,7 @@ struct PrivacyPolicyView: View {
             .navigationTitle("Privacy Policy")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }


### PR DESCRIPTION
## Summary
- Replaces all 51 instances of deprecated toolbar placement APIs across 33 files
- `.navigationBarTrailing` → `.topBarTrailing` (31 occurrences)
- `.navigationBarLeading` → `.topBarLeading` (20 occurrences)

Closes #221

## Test plan
- [x] Verify the project builds successfully
- [x] Verify toolbar buttons appear correctly in navigation bars across all screens
- [x] Spot-check leading/trailing placement on Dashboard, Symptom, Meal, and Settings screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)