### PR TITLE
fix(#229): replace showsIndicators: false with .scrollIndicators(.hidden)

### DIFF
--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -69,7 +69,7 @@ struct InsightsView: View {
                 .font(.title2.bold())
                 .foregroundStyle(ColorTheme.primaryText)
             
-            ScrollView(.horizontal, showsIndicators: false) {
+            ScrollView(.horizontal) {
                 HStack(spacing: 16) {
                     ForEach(viewModel.recentInsights) { insight in
                         AnalyticsInsightCard(insight: insight)
@@ -77,6 +77,7 @@ struct InsightsView: View {
                     }
                 }
             }
+            .scrollIndicators(.hidden)
         }
     }
     

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -300,7 +300,7 @@ struct SymptomDetailView: View {
                     .foregroundStyle(ColorTheme.primaryText)
             }
 
-            ScrollView(.horizontal, showsIndicators: false) {
+            ScrollView(.horizontal) {
                 HStack(spacing: 8) {
                     ForEach(viewModel.entity.tags, id: \.self) { tag in
                         Text(tag)
@@ -316,6 +316,7 @@ struct SymptomDetailView: View {
                 .padding(.leading, 40)
                 .padding(.trailing, 4)
             }
+            .scrollIndicators(.hidden)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)

--- a/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
@@ -262,7 +262,7 @@ struct FilterBar<FilterType: RawRepresentable & CaseIterable & Equatable>: View 
     let onFilterChange: (FilterType) -> Void
     
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        ScrollView(.horizontal) {
             HStack(spacing: 12) {
                 ForEach(Array(FilterType.allCases), id: \.rawValue) { filter in
                     FilterChip(
@@ -276,6 +276,7 @@ struct FilterBar<FilterType: RawRepresentable & CaseIterable & Equatable>: View 
             }
             .padding(.horizontal)
         }
+        .scrollIndicators(.hidden)
         .padding(.vertical, 8)
     }
 }

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -156,7 +156,7 @@ struct InsightsDashboardView: View {
     }
     
     private var categoryFilterSection: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        ScrollView(.horizontal) {
             HStack(spacing: 12) {
                 CategoryFilterButton(
                     title: "All",
@@ -174,6 +174,7 @@ struct InsightsDashboardView: View {
             }
             .padding(.horizontal)
         }
+        .scrollIndicators(.hidden)
     }
     
     // MARK: - Food Triggers Section

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -42,7 +42,7 @@ struct MealBuilderView: View {
                 
                 VStack(spacing: 12) {
                     // Meal type pills
-                    ScrollView(.horizontal, showsIndicators: false) {
+                    ScrollView(.horizontal) {
                         HStack(spacing: 8) {
                             ForEach(MealType.allCases, id: \.self) { type in
                                 let isSelected = mealService.mealType == type
@@ -70,6 +70,7 @@ struct MealBuilderView: View {
                         .padding(.horizontal)
                         .padding(.vertical, 8)
                     }
+                    .scrollIndicators(.hidden)
                     .background(ColorTheme.surface)
                     .clipShape(.rect(cornerRadius: 12))
                     .overlay(

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -212,13 +212,14 @@ struct DailyMedicationCard: View {
 
                 // Medication name pills
                 if !uniqueMedNames.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
+                    ScrollView(.horizontal) {
                         HStack(spacing: 8) {
                             ForEach(uniqueMedNames, id: \.self) { name in
                                 MedNamePill(name: name)
                             }
                         }
                     }
+                    .scrollIndicators(.hidden)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replaces 6 instances of the deprecated `showsIndicators: false` parameter in `ScrollView` initializers with the modern `.scrollIndicators(.hidden)` modifier
- All occurrences were horizontal scroll views

Closes #229

## Test plan
- [x] Verify the project builds successfully
- [x] Verify horizontal scroll views hide indicators in InsightsView, SymptomDetailView, PaginationComponents, MealBuilderView, InsightsDashboardView, and MedicationCalendarView

🤖 Generated with [Claude Code](https://claude.com/claude-code)