### PR TITLE
fix(#230): replace PreviewProvider with #Preview macro

### DIFF
--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -364,11 +364,7 @@ extension StoolType {
 
 // MARK: - Preview
 
-#if DEBUG
-struct PaginatedSymptomHistoryView_Previews: PreviewProvider {
-    static var previews: some View {
-        PaginatedSymptomHistoryView()
-            .environmentObject(AuthService())
-    }
+#Preview {
+    PaginatedSymptomHistoryView()
+        .environmentObject(AuthService())
 }
-#endif

--- a/GutCheck/GutCheck/Views/ContentView.swift
+++ b/GutCheck/GutCheck/Views/ContentView.swift
@@ -1,13 +1,8 @@
-// MARK: - Preview
-#if DEBUG
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-            .environmentObject(AuthService())
-            .environmentObject(AppRouter.shared)
-    }
+#Preview {
+    ContentView()
+        .environmentObject(AuthService())
+        .environmentObject(AppRouter.shared)
 }
-#endif
 //
 //  ContentView.swift
 //  GutCheck

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -368,17 +368,13 @@ struct ProfileActionRow: View {
     }
 }
 
-#if DEBUG
-struct UserProfileView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            UserProfileView(user: User(
-                id: "1",
-                email: "jenny@email.com",
-                firstName: "Jenny",
-                lastName: "Wilson"
-            ))
-        }
+#Preview {
+    NavigationStack {
+        UserProfileView(user: User(
+            id: "1",
+            email: "jenny@email.com",
+            firstName: "Jenny",
+            lastName: "Wilson"
+        ))
     }
 }
-#endif

--- a/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
@@ -280,12 +280,8 @@ struct ReminderSection<Content: View>: View {
     }
 }
 
-#if DEBUG
-struct UserRemindersView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            UserRemindersView()
-        }
+#Preview {
+    NavigationStack {
+        UserRemindersView()
     }
 }
-#endif

--- a/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
@@ -190,10 +190,6 @@ struct HealthKitTestView: View {
     }
 }
 
-#if DEBUG
-struct HealthKitTestView_Previews: PreviewProvider {
-    static var previews: some View {
-        HealthKitTestView()
-    }
+#Preview {
+    HealthKitTestView()
 }
-#endif

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -444,10 +444,6 @@ extension ExportFormat {
     }
 }
 
-// MARK: - Preview
-
-struct HealthcareExportView_Previews: PreviewProvider {
-    static var previews: some View {
-        HealthcareExportView()
-    }
+#Preview {
+    HealthcareExportView()
 }

--- a/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
@@ -92,10 +92,6 @@ struct ReminderSettingsTestView: View {
     }
 }
 
-#if DEBUG
-struct ReminderSettingsTestView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReminderSettingsTestView()
-    }
+#Preview {
+    ReminderSettingsTestView()
 }
-#endif


### PR DESCRIPTION
## Summary
- Replaces 7 legacy `PreviewProvider` structs with the modern `#Preview` macro across 7 files
- Removes unnecessary `#if DEBUG` wrappers (the `#Preview` macro handles debug-only compilation)
- Also updates `NavigationView` → `NavigationStack` in UserRemindersView preview

Closes #230

## Test plan
- [x] Verify the project builds successfully
- [ ] Verify Xcode previews render correctly for ContentView, PaginatedSymptomHistoryView, UserRemindersView, UserProfileView, HealthKitTestView, ReminderSettingsTestView, and HealthcareExportView

🤖 Generated with [Claude Code](https://claude.com/claude-code)