### PR TITLE
fix(#225): replace String(format:) with FormatStyle APIs

### DIFF
--- a/GutCheck/GutCheck/Services/HealthcareExportService.swift
+++ b/GutCheck/GutCheck/Services/HealthcareExportService.swift
@@ -399,7 +399,7 @@ class HealthcareExportService: ObservableObject {
             
             if let avgInterval = intervals.isEmpty ? nil : intervals.reduce(0, +) / Double(intervals.count) {
                 if avgInterval < 2 {
-                    recommendations.append("Consider spacing meals further apart (current average: \(String(format: "%.1f", avgInterval)) hours)")
+                    recommendations.append("Consider spacing meals further apart (current average: \(avgInterval.formatted(.number.precision(.fractionLength(1)))) hours)")
                 }
             }
         }

--- a/GutCheck/GutCheck/Services/Insights/InsightsService.swift
+++ b/GutCheck/GutCheck/Services/Insights/InsightsService.swift
@@ -252,7 +252,7 @@ class InsightsService: ObservableObject {
         
         description += trend.description + " "
         
-        description += "Your current intake is \(String(format: "%.1f", trend.currentValue)) \(trend.unit), while the recommended target is \(String(format: "%.1f", trend.targetValue)) \(trend.unit). "
+        description += "Your current intake is \(trend.currentValue.formatted(.number.precision(.fractionLength(1)))) \(trend.unit), while the recommended target is \(trend.targetValue.formatted(.number.precision(.fractionLength(1)))) \(trend.unit). "
         
         if trend.currentValue < trend.targetValue {
             description += "This represents a \(Int(((trend.targetValue - trend.currentValue) / trend.targetValue) * 100))% shortfall from your target. "

--- a/GutCheck/GutCheck/Services/Insights/PatternRecognitionService.swift
+++ b/GutCheck/GutCheck/Services/Insights/PatternRecognitionService.swift
@@ -345,9 +345,9 @@ class PatternRecognitionService {
                     impact: .negative,
                     confidence: 0.8,
                     title: "Sleep Deprivation Impact",
-                    description: "Short sleep (\(String(format: "%.1f", sleepHours))h) correlates with symptoms",
+                    description: "Short sleep (\(sleepHours.formatted(.number.precision(.fractionLength(1))))h) correlates with symptoms",
                     evidence: [
-                        "Sleep duration: \(String(format: "%.1f", sleepHours)) hours",
+                        "Sleep duration: \(sleepHours.formatted(.number.precision(.fractionLength(1)))) hours",
                         "Symptoms: \(symptomsOnDay.count)"
                     ],
                     recommendations: [
@@ -440,7 +440,7 @@ class PatternRecognitionService {
                 targetValue: 25,
                 unit: "g",
                 evidence: [
-                    "Average daily fiber: \(String(format: "%.1f", averageDailyFiber))g",
+                    "Average daily fiber: \(averageDailyFiber.formatted(.number.precision(.fractionLength(1))))g",
                     "Recommended: 25g+ daily"
                 ],
                 recommendations: [

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -77,7 +77,7 @@ class FoodSearchViewModel: ObservableObject {
         let servingWeightGrams = nfood.servingWeight
         
         // Create quantity string
-        let quantityString = "\(String(format: "%g", servingQty)) \(servingUnit)"
+        let quantityString = "\(servingQty.formatted(.number)) \(servingUnit)"
         
         // Parse ingredients from Nutritionix ingredients string  
         let ingredientList: [String] = parseIngredients(from: nfood.ingredients)
@@ -92,48 +92,48 @@ class FoodSearchViewModel: ObservableObject {
         
         // Add basic nutrition values
         if let calories = nfood.calories {
-            nutritionDict["calories"] = String(format: "%.1f", calories)
+            nutritionDict["calories"] = calories.formatted(.number.precision(.fractionLength(1)))
         }
         if let protein = nfood.protein {
-            nutritionDict["protein"] = String(format: "%.1f", protein)
+            nutritionDict["protein"] = protein.formatted(.number.precision(.fractionLength(1)))
         }
         if let carbs = nfood.carbs {
-            nutritionDict["total_carbohydrate"] = String(format: "%.1f", carbs)
+            nutritionDict["total_carbohydrate"] = carbs.formatted(.number.precision(.fractionLength(1)))
         }
         if let fat = nfood.fat {
-            nutritionDict["total_fat"] = String(format: "%.1f", fat)
+            nutritionDict["total_fat"] = fat.formatted(.number.precision(.fractionLength(1)))
         }
         if let fiber = nfood.fiber {
-            nutritionDict["dietary_fiber"] = String(format: "%.1f", fiber)
+            nutritionDict["dietary_fiber"] = fiber.formatted(.number.precision(.fractionLength(1)))
         }
         if let sugar = nfood.sugar {
-            nutritionDict["sugars"] = String(format: "%.1f", sugar)
+            nutritionDict["sugars"] = sugar.formatted(.number.precision(.fractionLength(1)))
         }
         if let sodium = nfood.sodium {
-            nutritionDict["sodium"] = String(format: "%.1f", sodium)
+            nutritionDict["sodium"] = sodium.formatted(.number.precision(.fractionLength(1)))
         }
         
         // Add detailed nutrition from the specific properties
         if let saturatedFat = nfood.saturatedFat {
-            nutritionDict["saturated_fat"] = String(format: "%.1f", saturatedFat)
+            nutritionDict["saturated_fat"] = saturatedFat.formatted(.number.precision(.fractionLength(1)))
         }
         if let cholesterol = nfood.cholesterol {
-            nutritionDict["cholesterol"] = String(format: "%.1f", cholesterol)
+            nutritionDict["cholesterol"] = cholesterol.formatted(.number.precision(.fractionLength(1)))
         }
         if let potassium = nfood.potassium {
-            nutritionDict["potassium"] = String(format: "%.1f", potassium)
+            nutritionDict["potassium"] = potassium.formatted(.number.precision(.fractionLength(1)))
         }
         if let vitaminA = nfood.vitaminA {
-            nutritionDict["vitamin_a_dv"] = String(format: "%.0f", vitaminA)
+            nutritionDict["vitamin_a_dv"] = vitaminA.formatted(.number.precision(.fractionLength(0)))
         }
         if let vitaminC = nfood.vitaminC {
-            nutritionDict["vitamin_c_dv"] = String(format: "%.0f", vitaminC)
+            nutritionDict["vitamin_c_dv"] = vitaminC.formatted(.number.precision(.fractionLength(0)))
         }
         if let calcium = nfood.calcium {
-            nutritionDict["calcium_dv"] = String(format: "%.0f", calcium)
+            nutritionDict["calcium_dv"] = calcium.formatted(.number.precision(.fractionLength(0)))
         }
         if let iron = nfood.iron {
-            nutritionDict["iron_dv"] = String(format: "%.0f", iron)
+            nutritionDict["iron_dv"] = iron.formatted(.number.precision(.fractionLength(0)))
         }
         
         // Extract allergens with enhanced detection

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -865,7 +865,7 @@ private struct MacroPill: View {
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(color)
-            Text(value.map { String(format: "%.1fg", $0) } ?? "--")
+            Text(value.map { "\($0.formatted(.number.precision(.fractionLength(1))))g" } ?? "--")
                 .font(.caption)
                 .foregroundStyle(ColorTheme.primaryText)
         }
@@ -1167,7 +1167,7 @@ struct NutritionDetailRow: View {
         if unit == "kcal" || unit == "mg" {
             return "\(Int(v)) \(unit)"
         }
-        return String(format: "%.1f %@", v, unit)
+        return "\(v.formatted(.number.precision(.fractionLength(1)))) \(unit)"
     }
 
     var body: some View {

--- a/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/NutritionComponents.swift
@@ -48,15 +48,15 @@ struct UnifiedNutritionBadge: View {
     }
     
     init(protein: Double, style: BadgeStyle = .standard) {
-        self.init(value: String(format: "%.1f", protein), unit: "P", color: .blue, style: style)
+        self.init(value: protein.formatted(.number.precision(.fractionLength(1))), unit: "P", color: .blue, style: style)
     }
     
     init(carbs: Double, style: BadgeStyle = .standard) {
-        self.init(value: String(format: "%.1f", carbs), unit: "C", color: .green, style: style)
+        self.init(value: carbs.formatted(.number.precision(.fractionLength(1))), unit: "C", color: .green, style: style)
     }
     
     init(fat: Double, style: BadgeStyle = .standard) {
-        self.init(value: String(format: "%.1f", fat), unit: "F", color: .red, style: style)
+        self.init(value: fat.formatted(.number.precision(.fractionLength(1))), unit: "F", color: .red, style: style)
     }
     
     var body: some View {
@@ -209,15 +209,15 @@ struct UnifiedNutritionSummary: View {
     private var additionalNutrientsSection: some View {
         VStack(spacing: 8) {
             if let fiber = nutrition.fiber {
-                UnifiedMacroRow(label: "Fiber", value: String(format: "%.1f", fiber), unit: "g", color: .brown)
+                UnifiedMacroRow(label: "Fiber", value: fiber.formatted(.number.precision(.fractionLength(1))), unit: "g", color: .brown)
             }
             
             if let sodium = nutrition.sodium {
-                UnifiedMacroRow(label: "Sodium", value: String(format: "%.0f", sodium), unit: "mg", color: .purple)
+                UnifiedMacroRow(label: "Sodium", value: sodium.formatted(.number.precision(.fractionLength(0))), unit: "mg", color: .purple)
             }
             
             if let sugar = nutrition.sugar {
-                UnifiedMacroRow(label: "Sugar", value: String(format: "%.1f", sugar), unit: "g", color: .pink)
+                UnifiedMacroRow(label: "Sugar", value: sugar.formatted(.number.precision(.fractionLength(1))), unit: "g", color: .pink)
             }
         }
     }
@@ -237,7 +237,7 @@ struct NutrientColumn: View {
                 .font(.caption)
                 .foregroundStyle(ColorTheme.secondaryText)
             
-            Text(String(format: "%.1f", value))
+            Text(value.formatted(.number.precision(.fractionLength(1))))
                 .font(.headline)
                 .foregroundStyle(color)
             
@@ -259,17 +259,17 @@ enum MacroType {
         case .calories:
             return ("Calories", "\(nutrition.calories ?? 0)", "calories", .orange)
         case .protein:
-            return ("Protein", String(format: "%.1f", nutrition.protein ?? 0), "g", .blue)
+            return ("Protein", (nutrition.protein ?? 0).formatted(.number.precision(.fractionLength(1))), "g", .blue)
         case .carbs:
-            return ("Carbs", String(format: "%.1f", nutrition.carbs ?? 0), "g", .green)
+            return ("Carbs", (nutrition.carbs ?? 0).formatted(.number.precision(.fractionLength(1))), "g", .green)
         case .fat:
-            return ("Fat", String(format: "%.1f", nutrition.fat ?? 0), "g", .red)
+            return ("Fat", (nutrition.fat ?? 0).formatted(.number.precision(.fractionLength(1))), "g", .red)
         case .fiber:
-            return ("Fiber", String(format: "%.1f", nutrition.fiber ?? 0), "g", .brown)
+            return ("Fiber", (nutrition.fiber ?? 0).formatted(.number.precision(.fractionLength(1))), "g", .brown)
         case .sodium:
-            return ("Sodium", String(format: "%.0f", nutrition.sodium ?? 0), "mg", .purple)
+            return ("Sodium", (nutrition.sodium ?? 0).formatted(.number.precision(.fractionLength(0))), "mg", .purple)
         case .sugar:
-            return ("Sugar", String(format: "%.1f", nutrition.sugar ?? 0), "g", .pink)
+            return ("Sugar", (nutrition.sugar ?? 0).formatted(.number.precision(.fractionLength(1))), "g", .pink)
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -198,7 +198,7 @@ struct UnifiedFoodDetailView: View {
                     .font(.subheadline)
                 
                 Stepper(value: $servingMultiplier, in: 0.1...10.0, step: 0.1) {
-                    Text(String(format: "%.1f", servingMultiplier))
+                    Text(servingMultiplier.formatted(.number.precision(.fractionLength(1))))
                         .font(.headline)
                         .foregroundStyle(ColorTheme.primary)
                 }
@@ -310,17 +310,17 @@ struct UnifiedFoodDetailView: View {
             // Macros in a compact row
             HStack(spacing: 12) {
                 if let protein = foodItem.nutrition.protein {
-                    Text("P: \(String(format: "%.1f", protein))g")
+                    Text("P: \(protein.formatted(.number.precision(.fractionLength(1))))g")
                         .font(.caption)
                         .foregroundStyle(ColorTheme.secondaryText)
                 }
                 if let carbs = foodItem.nutrition.carbs {
-                    Text("C: \(String(format: "%.1f", carbs))g")
+                    Text("C: \(carbs.formatted(.number.precision(.fractionLength(1))))g")
                         .font(.caption)
                         .foregroundStyle(ColorTheme.secondaryText)
                 }
                 if let fat = foodItem.nutrition.fat {
-                    Text("F: \(String(format: "%.1f", fat))g")
+                    Text("F: \(fat.formatted(.number.precision(.fractionLength(1))))g")
                         .font(.caption)
                         .foregroundStyle(ColorTheme.secondaryText)
                 }
@@ -468,7 +468,7 @@ struct UnifiedFoodDetailView: View {
         if multiplier == 1.0 {
             customQuantity = baseQuantity
         } else {
-            customQuantity = "\(String(format: "%.1f", multiplier)) × \(baseQuantity)"
+            customQuantity = "\(multiplier.formatted(.number.precision(.fractionLength(1)))) × \(baseQuantity)"
         }
         foodItem.quantity = customQuantity
     }
@@ -869,7 +869,7 @@ struct NutritionDetailsView: View {
                 .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
             
-            Text(String(format: "%.1f", value))
+            Text(value.formatted(.number.precision(.fractionLength(1))))
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundStyle(ColorTheme.primaryText)
@@ -919,7 +919,7 @@ struct NutritionDetailItem: View {
     
     private var formattedValue: String {
         if let doubleValue = Double(value) {
-            return String(format: "%.1f", doubleValue)
+            return doubleValue.formatted(.number.precision(.fractionLength(1)))
         }
         return value
     }

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodItemRow.swift
@@ -159,7 +159,7 @@ struct UnifiedFoodItemRow: View {
             if config.showMacros {
                 if let protein = item.nutrition.protein {
                     NutritionBadge(
-                        text: config.compactMacros ? "\(String(format: "%.1f", protein)) P" : "P: \(String(format: "%.1f", protein))g",
+                        text: config.compactMacros ? "\(protein.formatted(.number.precision(.fractionLength(1)))) P" : "P: \(protein.formatted(.number.precision(.fractionLength(1))))g",
                         color: .blue,
                         size: config.badgeSize
                     )
@@ -167,7 +167,7 @@ struct UnifiedFoodItemRow: View {
                 
                 if let carbs = item.nutrition.carbs {
                     NutritionBadge(
-                        text: config.compactMacros ? "\(String(format: "%.1f", carbs)) C" : "C: \(String(format: "%.1f", carbs))g",
+                        text: config.compactMacros ? "\(carbs.formatted(.number.precision(.fractionLength(1)))) C" : "C: \(carbs.formatted(.number.precision(.fractionLength(1))))g",
                         color: .green,
                         size: config.badgeSize
                     )
@@ -175,7 +175,7 @@ struct UnifiedFoodItemRow: View {
                 
                 if let fat = item.nutrition.fat {
                     NutritionBadge(
-                        text: config.compactMacros ? "\(String(format: "%.1f", fat)) F" : "F: \(String(format: "%.1f", fat))g",
+                        text: config.compactMacros ? "\(fat.formatted(.number.precision(.fractionLength(1)))) F" : "F: \(fat.formatted(.number.precision(.fractionLength(1))))g",
                         color: .red,
                         size: config.badgeSize
                     )

--- a/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
+++ b/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
@@ -62,12 +62,12 @@ struct AddWaterView: View {
     
     private var fluidOunces: String {
         let oz = cups * 8.0
-        return String(format: "%.1f", oz)
+        return oz.formatted(.number.precision(.fractionLength(1)))
     }
     
     private var milliliters: String {
         let ml = cups * 236.6 // 1 cup ≈ 236.6 mL
-        return String(format: "%.0f", ml)
+        return ml.formatted(.number.precision(.fractionLength(0)))
     }
     
     // MARK: - Actions

--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -543,7 +543,7 @@ struct SimpleRecentFoodRow: View {
                         }
                         
                         if let protein = item.nutrition.protein {
-                            Text("\(String(format: "%.1f", protein)) P")
+                            Text("\(protein.formatted(.number.precision(.fractionLength(1)))) P")
                                 .typography(Typography.caption)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
@@ -553,7 +553,7 @@ struct SimpleRecentFoodRow: View {
                         }
                         
                         if let carbs = item.nutrition.carbs {
-                            Text("\(String(format: "%.1f", carbs)) C")
+                            Text("\(carbs.formatted(.number.precision(.fractionLength(1)))) C")
                                 .typography(Typography.caption)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
@@ -563,7 +563,7 @@ struct SimpleRecentFoodRow: View {
                         }
                         
                         if let fat = item.nutrition.fat {
-                            Text("\(String(format: "%.1f", fat)) F")
+                            Text("\(fat.formatted(.number.precision(.fractionLength(1)))) F")
                                 .typography(Typography.caption)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
@@ -627,15 +627,15 @@ struct SimpleRecentFoodRow: View {
         }
         
         if let protein = item.nutrition.protein {
-            label += ", \(String(format: "%.1f", protein)) grams protein"
+            label += ", \(protein.formatted(.number.precision(.fractionLength(1)))) grams protein"
         }
         
         if let carbs = item.nutrition.carbs {
-            label += ", \(String(format: "%.1f", carbs)) grams carbohydrates"
+            label += ", \(carbs.formatted(.number.precision(.fractionLength(1)))) grams carbohydrates"
         }
         
         if let fat = item.nutrition.fat {
-            label += ", \(String(format: "%.1f", fat)) grams fat"
+            label += ", \(fat.formatted(.number.precision(.fractionLength(1)))) grams fat"
         }
         
         if !item.allergens.isEmpty {

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -419,13 +419,13 @@ struct NutrientLabel: View {
                 .typography(Typography.caption)
                 .foregroundStyle(ColorTheme.secondaryText)
             
-            Text("\(String(format: "%.1f", value ?? 0)) \(unit)")
+            Text("\((value ?? 0).formatted(.number.precision(.fractionLength(1)))) \(unit)")
                 .typography(Typography.headline)
                 .foregroundStyle(color)
         }
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(name): \(String(format: "%.1f", value ?? 0)) \(unit)")
+        .accessibilityLabel("\(name): \((value ?? 0).formatted(.number.precision(.fractionLength(1)))) \(unit)")
     }
 }
 

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -170,19 +170,19 @@ private struct NutritionSummaryView: View {
                 Divider()
                 NutritionValueView(
                     label: "Protein",
-                    value: String(format: "%.1f", nutrition.protein ?? 0),
+                    value: (nutrition.protein ?? 0).formatted(.number.precision(.fractionLength(1))),
                     unit: "g"
                 )
                 Divider()
                 NutritionValueView(
                     label: "Carbs",
-                    value: String(format: "%.1f", nutrition.carbs ?? 0),
+                    value: (nutrition.carbs ?? 0).formatted(.number.precision(.fractionLength(1))),
                     unit: "g"
                 )
                 Divider()
                 NutritionValueView(
                     label: "Fat",
-                    value: String(format: "%.1f", nutrition.fat ?? 0),
+                    value: (nutrition.fat ?? 0).formatted(.number.precision(.fractionLength(1))),
                     unit: "g"
                 )
             }
@@ -191,7 +191,7 @@ private struct NutritionSummaryView: View {
                 HStack {
                     Label("Fiber", systemImage: "leaf")
                     Spacer()
-                    Text("\(String(format: "%.1f", fiber))g")
+                    Text("\(fiber.formatted(.number.precision(.fractionLength(1))))g")
                 }
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -201,7 +201,7 @@ private struct NutritionSummaryView: View {
                 HStack {
                     Label("Sugar", systemImage: "cube")
                     Spacer()
-                    Text("\(String(format: "%.1f", sugar))g")
+                    Text("\(sugar.formatted(.number.precision(.fractionLength(1))))g")
                 }
                 .font(.subheadline)
                 .foregroundStyle(.secondary)

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -268,7 +268,7 @@ struct MealDetailView: View {
                 .font(.caption)
                 .foregroundStyle(ColorTheme.secondaryText)
             
-            Text("\(String(format: "%.1f", value ?? 0))\(unit)")
+            Text("\((value ?? 0).formatted(.number.precision(.fractionLength(1))))\(unit)")
                 .font(.subheadline.bold())
                 .foregroundStyle(color)
         }

--- a/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
+++ b/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
@@ -164,7 +164,7 @@ struct LogMedicationDoseView: View {
     // MARK: - Helpers
 
     private func formattedAmount(_ amount: Double) -> String {
-        amount == amount.rounded() ? "\(Int(amount))" : String(format: "%.1f", amount)
+        amount == amount.rounded() ? "\(Int(amount))" : amount.formatted(.number.precision(.fractionLength(1)))
     }
 }
 
@@ -191,7 +191,7 @@ private struct MedicationPickerRow: View {
     }
 
     private func formattedAmount(_ amount: Double) -> String {
-        amount == amount.rounded() ? "\(Int(amount))" : String(format: "%.1f", amount)
+        amount == amount.rounded() ? "\(Int(amount))" : amount.formatted(.number.precision(.fractionLength(1)))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -271,7 +271,7 @@ struct DoseCalendarRow: View {
         if dose.dosageAmount > 0 {
             let amtStr = dose.dosageAmount.truncatingRemainder(dividingBy: 1) == 0
                 ? String(Int(dose.dosageAmount))
-                : String(format: "%.1f", dose.dosageAmount)
+                : dose.dosageAmount.formatted(.number.precision(.fractionLength(1)))
             return "\(amtStr) \(dose.dosageUnit)"
         }
         return dose.dosageUnit

--- a/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
@@ -199,7 +199,7 @@ private struct MedicationRowView: View {
         if amt == amt.rounded() {
             return "\(Int(amt)) \(medication.dosage.unit)"
         } else {
-            return "\(String(format: "%.1f", amt)) \(medication.dosage.unit)"
+            return "\(amt.formatted(.number.precision(.fractionLength(1)))) \(medication.dosage.unit)"
         }
     }
 

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -251,7 +251,7 @@ private struct DoseRowView: View {
 
     private func formattedDose(_ dose: MedicationDoseLog) -> String {
         let amt = dose.dosageAmount
-        let formatted = amt == amt.rounded() ? "\(Int(amt))" : String(format: "%.1f", amt)
+        let formatted = amt == amt.rounded() ? "\(Int(amt))" : amt.formatted(.number.precision(.fractionLength(1)))
         return "\(formatted) \(dose.dosageUnit)"
     }
 }
@@ -289,7 +289,7 @@ private struct MedCatalogRow: View {
 
     private var formattedDosage: String {
         let amt = medication.dosage.amount
-        let n   = amt == amt.rounded() ? "\(Int(amt))" : String(format: "%.1f", amt)
+        let n   = amt == amt.rounded() ? "\(Int(amt))" : amt.formatted(.number.precision(.fractionLength(1)))
         return "\(n) \(medication.dosage.unit)"
     }
 }

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -104,7 +104,7 @@ struct HealthDataIntegrationView: View {
                         }
                         if let glucose = healthKitVM.healthData?.bloodGlucose {
                             HealthDataRow(label: "Blood Glucose",
-                                         value: String(format: "%.1f mg/dL", glucose))
+                                         value: "\(glucose.formatted(.number.precision(.fractionLength(1)))) mg/dL")
                         }
                         if let hr = healthKitVM.healthData?.heartRate {
                             HealthDataRow(label: "Heart Rate", value: "\(Int(hr)) BPM")


### PR DESCRIPTION
## Summary
- Replaces 72 `String(format:)` calls across 18 files with modern Swift `FormatStyle` APIs
- Uses `.formatted(.number.precision(.fractionLength(N)))` for `%.Nf` patterns and `.formatted(.number)` for `%g` patterns
- Skips 1 `%02x` hex format in `AuthService.swift` (SHA256 hash, not user-visible text)

Closes #225

## Test plan
- [x] Verify numeric values display correctly throughout the app (meal nutrition, medication doses, calendar entries, health data)
- [x] Check edge cases: nil/optional values default to 0, decimal precision matches original formatting
- [x] Confirm water intake, food search results, and insights display proper formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)