### PR TITLE
fix(#226): replace onTapGesture with Button for accessibility

### DIFF
--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -203,69 +203,70 @@ struct SymptomRowView: View {
     }()
     
     var body: some View {
-        HStack(spacing: 12) {
-            // Time
-            Text(timeFormatter.string(from: symptom.date))
-                .font(.caption)
-                .fontWeight(.medium)
-                .foregroundStyle(ColorTheme.primary)
-                .frame(width: 60, alignment: .leading)
-            
-            // Stool type indicator
-            Circle()
-                .fill(stoolTypeColor)
-                .frame(width: 12, height: 12)
-            
-            // Details
-            VStack(alignment: .leading, spacing: 2) {
-                HStack {
-                    Text("Type \(symptom.stoolType.typeNumber)")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                    
-                    if symptom.painLevel != .none {
-                        SimpleIndicator(
-                            icon: "exclamationmark.triangle.fill",
-                            text: symptom.painLevel.displayName,
-                            color: symptom.painLevel.color
-                        )
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                // Time
+                Text(timeFormatter.string(from: symptom.date))
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(ColorTheme.primary)
+                    .frame(width: 60, alignment: .leading)
+                
+                // Stool type indicator
+                Circle()
+                    .fill(stoolTypeColor)
+                    .frame(width: 12, height: 12)
+                
+                // Details
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Type \(symptom.stoolType.typeNumber)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        
+                        if symptom.painLevel != .none {
+                            SimpleIndicator(
+                                icon: "exclamationmark.triangle.fill",
+                                text: symptom.painLevel.displayName,
+                                color: symptom.painLevel.color
+                            )
+                        }
+                        
+                        if symptom.urgencyLevel != .none {
+                            SimpleIndicator(
+                                icon: "timer",
+                                text: symptom.urgencyLevel.displayName,
+                                color: symptom.urgencyLevel.color
+                            )
+                        }
+                        
+                        Spacer()
                     }
                     
-                    if symptom.urgencyLevel != .none {
-                        SimpleIndicator(
-                            icon: "timer",
-                            text: symptom.urgencyLevel.displayName,
-                            color: symptom.urgencyLevel.color
-                        )
+                    if let notes = symptom.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
                     }
-                    
-                    Spacer()
                 }
                 
-                if let notes = symptom.notes, !notes.isEmpty {
-                    Text(notes)
+                // Delete button
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
+                        .foregroundStyle(.red)
+                        .padding(8)
+                        .background(Circle().fill(Color.red.opacity(0.1)))
                 }
             }
-            
-            // Delete button
-            Button(action: onDelete) {
-                Image(systemName: "trash")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .padding(8)
-                    .background(Circle().fill(Color.red.opacity(0.1)))
-            }
         }
+        .buttonStyle(.plain)
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color(.secondarySystemBackground))
         )
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
     }
     
     private var stoolTypeColor: Color {

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -20,13 +20,15 @@ struct UnifiedCalendarView: View {
                 // Calendar Grid
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: daysInWeek), spacing: 0) {
                     ForEach(viewModel.calendarDays) { day in
-                        DayCell(
-                            day: day,
-                            isSelected: calendar.isDate(day.date, inSameDayAs: selectedDate)
-                        )
-                        .onTapGesture {
+                        Button {
                             selectedDate = day.date
+                        } label: {
+                            DayCell(
+                                day: day,
+                                isSelected: calendar.isDate(day.date, inSameDayAs: selectedDate)
+                            )
                         }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(.horizontal)

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -608,27 +608,29 @@ struct HealthIndicatorBadge: View {
     @State private var showingDetail = false
     
     var body: some View {
-        VStack(spacing: 4) {
-            HStack(spacing: 4) {
-                Text(indicator.icon)
-                    .font(.caption)
-                Text(indicator.text)
-                    .font(.caption)
-                    .fontWeight(.medium)
-            }
-            .foregroundStyle(indicator.color)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(indicator.color.opacity(0.1))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(indicator.severity.borderColor.opacity(0.3), lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 8))
-        .onTapGesture {
+        Button {
             showingDetail = true
+        } label: {
+            VStack(spacing: 4) {
+                HStack(spacing: 4) {
+                    Text(indicator.icon)
+                        .font(.caption)
+                    Text(indicator.text)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+                .foregroundStyle(indicator.color)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(indicator.color.opacity(0.1))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(indicator.severity.borderColor.opacity(0.3), lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 8))
         }
+        .buttonStyle(.plain)
         .alert(indicator.text, isPresented: $showingDetail) {
             Button("Got it") { }
         } message: {

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -275,21 +275,23 @@ struct LanguageSelectionView: View {
     var body: some View {
         List {
             ForEach(AppLanguage.allCases, id: \ .self) { lang in
-                HStack {
-                    Text(lang.displayName)
-                        .typography(Typography.body)
-                    Spacer()
-                    if lang == settingsVM.language {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(Color.accentColor)
-                            .accessibleDecorative()
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
+                Button {
                     HapticManager.shared.selection()
                     settingsVM.language = lang
+                } label: {
+                    HStack {
+                        Text(lang.displayName)
+                            .typography(Typography.body)
+                        Spacer()
+                        if lang == settingsVM.language {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                                .accessibleDecorative()
+                        }
+                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .accessibleSelectable(
                     label: lang.displayName,
                     isSelected: lang == settingsVM.language
@@ -306,21 +308,23 @@ struct UnitSelectionView: View {
     var body: some View {
         List {
             ForEach(UnitSystem.allCases, id: \ .self) { unit in
-                HStack {
-                    Text(unit.displayName)
-                        .typography(Typography.body)
-                    Spacer()
-                    if unit == settingsVM.unitOfMeasure {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(Color.accentColor)
-                            .accessibleDecorative()
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
+                Button {
                     HapticManager.shared.selection()
                     settingsVM.unitOfMeasure = unit
+                } label: {
+                    HStack {
+                        Text(unit.displayName)
+                            .typography(Typography.body)
+                        Spacer()
+                        if unit == settingsVM.unitOfMeasure {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                                .accessibleDecorative()
+                        }
+                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .accessibleSelectable(
                     label: unit.displayName,
                     isSelected: unit == settingsVM.unitOfMeasure
@@ -337,21 +341,23 @@ struct AppearanceSelectionView: View {
     var body: some View {
         List {
             ForEach(AppColorScheme.allCases, id: \ .self) { scheme in
-                HStack {
-                    Text(scheme.displayName)
-                        .typography(Typography.body)
-                    Spacer()
-                    if scheme == settingsVM.colorScheme {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(Color.accentColor)
-                            .accessibleDecorative()
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
+                Button {
                     HapticManager.shared.selection()
                     settingsVM.colorScheme = scheme
+                } label: {
+                    HStack {
+                        Text(scheme.displayName)
+                            .typography(Typography.body)
+                        Spacer()
+                        if scheme == settingsVM.colorScheme {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                                .accessibleDecorative()
+                        }
+                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .accessibleSelectable(
                     label: scheme.displayName,
                     isSelected: scheme == settingsVM.colorScheme


### PR DESCRIPTION
## Summary
- Replaces 6 `onTapGesture` instances across 4 files with proper `Button` views
- Uses `.buttonStyle(.plain)` to preserve existing visual appearance
- Improves VoiceOver accessibility by making interactive elements properly focusable and activatable

Files changed:
- `PaginatedSymptomHistoryView.swift` — symptom row tap handler
- `UnifiedCalendarView.swift` — calendar day cell selection
- `UnifiedFoodDetailView.swift` — health indicator badge detail tap
- `SettingsView.swift` — language, unit, and appearance selection rows (3 instances)

Closes #226

## Test plan
- [x] Verify symptom history rows still navigate on tap
- [x] Verify calendar day cells still select dates correctly
- [x] Verify health indicator badges still show detail alerts
- [x] Verify settings selection rows (language, units, appearance) still toggle correctly
- [ ] Test with VoiceOver enabled to confirm all elements are properly announced and activatable

🤖 Generated with [Claude Code](https://claude.com/claude-code)