### PR TITLE
fix: resolve unused value warnings across 12 files

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -23,7 +23,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         // Configure Firebase - try automatic configuration first
         if FirebaseApp.app() == nil {
             // Check if GoogleService-Info.plist exists
-            if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") {
+            if Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
                 FirebaseApp.configure()
             } else {
                 // TEMPORARY: Manual configuration if plist is missing

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitAsyncWrapper.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitAsyncWrapper.swift
@@ -51,37 +51,21 @@ class HealthKitAsyncWrapper {
         }
     }
     
-    // MARK: - Convenience Methods with Logging
+    // MARK: - Convenience Methods
     func writeMealWithLogging(_ meal: Meal) async {
-        let (success, error) = await writeMeal(meal)
-        if success {
-        } else if let error = error {
-        }
+        _ = await writeMeal(meal)
     }
     
     func writeSymptomWithLogging(_ symptom: Symptom) async {
-        let (success, error) = await writeSymptom(symptom)
-        if success {
-        } else if let error = error {
-        }
+        _ = await writeSymptom(symptom)
     }
     
     func requestAuthorizationWithLogging() async -> Bool {
-        let (granted, error) = await requestAuthorization()
-        if granted {
-        } else {
-            if let error = error {
-            } else {
-            }
-        }
+        let (granted, _) = await requestAuthorization()
         return granted
     }
     
     func fetchUserHealthDataWithLogging() async -> UserHealthData? {
-        let healthData = await fetchUserHealthData()
-        if healthData != nil {
-        } else {
-        }
-        return healthData
+        return await fetchUserHealthData()
     }
 }

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
@@ -98,7 +98,7 @@ class HealthKitMedicationService: ObservableObject {
         
         // Create observer query that triggers on any medication record change
         let query = HKObserverQuery(sampleType: medicationType, predicate: nil) { [weak self] _, completion, error in
-            if let error = error {
+            if error != nil {
                 completion()
                 return
             }

--- a/GutCheck/GutCheck/Services/LocalStorageService.swift
+++ b/GutCheck/GutCheck/Services/LocalStorageService.swift
@@ -146,8 +146,6 @@ class LocalStorageService {
             throw error
         } catch {
             #if DEBUG
-            if let cryptoError = error as? CryptoKitError {
-            }
             #endif
             throw LocalStorageError.encryptionFailed
         }
@@ -199,8 +197,6 @@ class LocalStorageService {
             throw error
         } catch {
             #if DEBUG
-            if let cryptoError = error as? CryptoKitError {
-            }
             #endif
             throw LocalStorageError.decryptionFailed
         }

--- a/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
+++ b/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
@@ -397,9 +397,7 @@ class SymptomRepository: BaseFirebaseRepository<Symptom> {
             }
             allSymptoms.append(contentsOf: filteredLocalSymptoms)
             
-            // Debug: Print details of each local symptom
-            for symptom in filteredLocalSymptoms {
-            }
+            
         } catch {
         }
         
@@ -413,9 +411,7 @@ class SymptomRepository: BaseFirebaseRepository<Symptom> {
         }
         allSymptoms.append(contentsOf: firestoreSymptoms)
         
-        // Debug: Print details of each Firestore symptom
-        for symptom in firestoreSymptoms {
-        }
+        
         
         // Sort all symptoms by date
         let sortedSymptoms = allSymptoms.sorted { $0.date < $1.date }
@@ -424,12 +420,6 @@ class SymptomRepository: BaseFirebaseRepository<Symptom> {
         let symptomIds = sortedSymptoms.map { $0.id }
         let uniqueIds = Set(symptomIds)
         if symptomIds.count != uniqueIds.count {
-            
-            // Find duplicates
-            let duplicateIds = symptomIds.filter { id in
-                symptomIds.filter { $0 == id }.count > 1
-            }
-            
             // Remove duplicates by keeping only the first occurrence of each ID
             var deduplicatedSymptoms: [Symptom] = []
             var seenIds = Set<String>()

--- a/GutCheck/GutCheck/Services/Strategies/LocalProfileImageStrategy.swift
+++ b/GutCheck/GutCheck/Services/Strategies/LocalProfileImageStrategy.swift
@@ -127,12 +127,6 @@ class LocalProfileImageStrategy: ProfileImageStrategy {
             "profileImageURL": imageURL,
             "updatedAt": Timestamp(date: Date.now)
         ])
-        
-        
-        let document = try await userRef.getDocument()
-        if let data = document.data(), let savedURL = data["profileImageURL"] as? String {
-        } else {
-        }
     }
     
     private func removeProfileImageURL(for userId: String) async throws {

--- a/GutCheck/GutCheck/ViewModels/Base/BaseViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Base/BaseViewModel.swift
@@ -69,8 +69,6 @@ open class BaseViewModel: ObservableObject {
     /// Handle success consistently
     func handleSuccess(message: String? = nil) {
         errorMessage = nil
-        if let message = message {
-        }
     }
     
     /// Reset all state

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -175,11 +175,7 @@ class LogSymptomViewModel: ObservableObject, HasLoadingState {
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(interval * 60), repeats: false)
         let request = UNNotificationRequest(identifier: "symptomReminder_\(UUID().uuidString)", content: content, trigger: trigger)
         
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-            } else {
-            }
-        }
+        UNUserNotificationCenter.current().add(request)
     }
     
     func resetForm() {

--- a/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
+++ b/GutCheck/GutCheck/Views/Components/SocialSignInButton.swift
@@ -158,14 +158,7 @@ struct AppleSignInButtonView: UIViewRepresentable {
         func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
             NSLog("🍎 [SocialSignInButton] Apple Sign-In succeeded")
             
-            // Examine the authorization details (DEBUG only — user identifiers are PII)
-            #if DEBUG
-            if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-                if let identityToken = appleIDCredential.identityToken {
-                } else {
-                }
-            }
-            #endif
+            
             
             parent.onCompletion(.success(authorization))
         }

--- a/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
@@ -133,7 +133,7 @@ struct TodaysActivitySummaryView: View {
             router.viewMealDetails(id: meal.id)
         case .symptom(let symptom):
             router.viewSymptomDetails(id: symptom.id)
-        case .medication(let medication):
+        case .medication:
             // For now, we'll just show a simple alert since we don't have a medication detail view yet
             // In the future, this could navigate to a medication detail view
             break

--- a/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
+++ b/GutCheck/GutCheck/Views/Meal/AddWaterView.swift
@@ -87,10 +87,7 @@ struct AddWaterView: View {
         
         // Write water intake to HealthKit
         let millilitersAmount = cups * 236.6
-        HealthKitManager.shared.writeWaterIntakeToHealthKit(amount: millilitersAmount) { success, error in
-            if success {
-            } else if let error = error {
-            }
+        HealthKitManager.shared.writeWaterIntakeToHealthKit(amount: millilitersAmount) { _, _ in
         }
         
         // Provide haptic feedback

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -146,7 +146,7 @@ struct ProfileImageView: View {
     private func uploadProfileImage(_ image: UIImage) {
         Task {
             do {
-                let imageURL = try await profileImageService.uploadProfileImage(image, for: user.id)
+                _ = try await profileImageService.uploadProfileImage(image, for: user.id)
                 await MainActor.run {
                     // Update the local profile image immediately
                     self.profileImage = image


### PR DESCRIPTION
## Summary
- Resolves 17 compiler warnings for unused values across 12 files
- Cleans up empty conditional blocks left behind after debug `print()` removal (#237)
- Simplifies dead `WithLogging` methods in `HealthKitAsyncWrapper`
- Removes unused debug verification code in `LocalProfileImageStrategy`
- Replaces unused bindings with `_` wildcards or boolean tests

Files changed:
- `HealthKitAsyncWrapper.swift` — 3 warnings (simplified empty logging methods)
- `HealthKitMedicationService.swift` — 1 warning (`error` → `error != nil`)
- `FirebaseRepository.swift` — 3 warnings (removed empty `for` loops, unused `duplicateIds`)
- `LocalProfileImageStrategy.swift` — 1 warning (removed dead debug verification)
- `LocalStorageService.swift` — 2 warnings (removed empty `CryptoKitError` checks)
- `BaseViewModel.swift` — 1 warning (removed empty `if let message` block)
- `LogSymptomViewModel.swift` — 1 warning (simplified notification add call)
- `SocialSignInButton.swift` — 1 warning (removed empty `#if DEBUG` credential check)
- `TodaysActivitySummaryView.swift` — 1 warning (`let medication` → wildcard pattern)
- `AddWaterView.swift` — 1 warning (simplified HealthKit callback)
- `UserProfileView.swift` — 1 warning (`let imageURL` → `_`)
- `GutCheckApp.swift` — 1 warning (`let plistPath` → `!= nil` check)

## Test plan
- [x] Verify project builds with zero warnings for these patterns
- [x] Verify HealthKit write operations still function correctly
- [x] Verify Firebase symptom fetching and deduplication works
- [x] Verify profile image upload still works
- [x] Verify notification scheduling still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)