### PR TITLE
fix(#227): replace .onAppear with .task for async work

### DIFF
--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -25,14 +25,9 @@ struct SymptomDetailView: View {
                 contentView
             }
         }
-        .onAppear {
-            #if DEBUG
-            #endif
-
+        .task {
             if viewModel.symptomId != nil && viewModel.entity.id.isEmpty {
-                Task {
-                    await viewModel.loadEntity()
-                }
+                await viewModel.loadEntity()
             }
         }
         .onChange(of: viewModel.entity) { _, newEntity in

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -56,10 +56,8 @@ struct InsightsDashboardView: View {
             .refreshable {
                 await refreshInsights()
             }
-            .onAppear {
-                Task {
-                    await refreshInsights()
-                }
+            .task {
+                await refreshInsights()
             }
             .onChange(of: selectedTimeRange) { _, _ in
                 Task {

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -25,11 +25,9 @@ struct MealDetailView: View {
                 mealContentView
             }
         }
-        .onAppear {
+        .task {
             if viewModel.mealId != nil {
-                Task {
-                    await viewModel.loadMeal()
-                }
+                await viewModel.loadMeal()
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -106,8 +106,8 @@ struct MedicationCalendarView: View {
                 }
             }
         }
-        .onAppear {
-            Task { await viewModel.loadDoses() }
+        .task {
+            await viewModel.loadDoses()
         }
         .onChange(of: viewModel.selectedDate) { _, _ in
             Task { await viewModel.loadDoses() }

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -237,8 +237,10 @@ struct HealthDataIntegrationView: View {
             }
             .onAppear {
                 healthKitVM.updateDependencies(settingsViewModel: settingsVM, authService: authService)
-                Task { await healthKitVM.fetchHealthData() }
                 healthKitVM.refreshWriteStatuses()
+            }
+            .task {
+                await healthKitVM.fetchHealthData()
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
@@ -83,10 +83,8 @@ struct ReminderSettingsTestView: View {
                 .padding()
             }
             .navigationTitle("Test View")
-            .onAppear {
-                Task {
-                    await reminderService.loadReminderSettings()
-                }
+            .task {
+                await reminderService.loadReminderSettings()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Converts 6 `.onAppear` blocks containing `Task {}` to use `.task` modifier instead
- Provides automatic task cancellation on view disappearance
- Eliminates manual `Task` creation boilerplate
- 17 synchronous-only `.onAppear` blocks left unchanged (not candidates for conversion)

Files changed:
- `SymptomDetailView.swift` — conditional entity loading
- `InsightsDashboardView.swift` — insights refresh
- `MealDetailView.swift` — conditional meal loading
- `MedicationCalendarView.swift` — dose loading
- `HealthDataIntegrationView.swift` — split into `.onAppear` (sync) + `.task` (async)
- `ReminderSettingsTestView.swift` — reminder settings loading

Closes #227

## Test plan
- [x] Verify symptom detail view loads data correctly when navigated to
- [x] Verify insights dashboard refreshes on appearance
- [x] Verify meal detail view loads meal data correctly
- [x] Verify medication calendar loads doses on appearance
- [x] Verify health data integration view fetches data and updates dependencies
- [x] Verify reminder settings test view loads settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)