### PR TITLE
fix(#218): replace NavigationView with NavigationStack

### DIFF
--- a/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
@@ -181,7 +181,7 @@ private struct HistoricalInsightRow: View {
 // MARK: - Preview
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CategoryInsightsView(category: .foodTriggers)
     }
 }

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -212,7 +212,7 @@ struct ContributingFactor: Identifiable {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         InsightDetailView(insight: HealthInsight(
             title: "Dairy Sensitivity Pattern",
             summary: "Strong correlation between dairy consumption and bloating",

--- a/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
@@ -26,7 +26,7 @@ struct RegisterView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     // Logo/Welcome Section

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -267,7 +267,7 @@ struct AuthenticationView: View {
     // MARK: - Forgot Password Sheet
     
     private var forgotPasswordSheet: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 24) {
                 VStack(spacing: 8) {
                     Text("Reset Password")

--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -14,7 +14,7 @@ struct PaginatedSymptomHistoryView: View {
     @State private var optionalEndDate: Date? = nil
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 // Filter bar
                 FilterBar(selectedFilter: $viewModel.selectedFilter) { filter in

--- a/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
@@ -5,7 +5,7 @@ struct SymptomExplanationView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     // Overview

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -221,7 +221,7 @@ private struct DateRangePickerView: View {
     @Binding var isPresented: Bool
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 DatePicker("Start Date", selection: $startDate, displayedComponents: [.date])
                 DatePicker("End Date", selection: $endDate, displayedComponents: [.date])
@@ -242,7 +242,7 @@ private struct DateRangePickerView: View {
 // MARK: - Supporting Types
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SymptomHistoryView()
     }
 }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
@@ -89,7 +89,7 @@ struct CalendarDetailView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         CalendarDetailView(date: Date.now)
     }
     .environmentObject(AuthService())

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -9,7 +9,7 @@ struct UnifiedCalendarView: View {
     private let daysInWeek = 7
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 // Month Header
                 monthHeader
@@ -194,7 +194,7 @@ private struct DatePickerView: View {
     @Binding var isPresented: Bool
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             DatePicker(
                 "Select Date",
                 selection: $selectedDate,

--- a/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
+++ b/GutCheck/GutCheck/Views/Components/PaginationComponents.swift
@@ -387,7 +387,7 @@ struct DateRangePickerSheet: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 20) {
                 DatePicker("Start Date", selection: Binding(
                     get: { startDate ?? Date.now },

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -34,7 +34,7 @@ struct InsightsDashboardView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     // Header

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -277,7 +277,7 @@ struct MealAnalysis {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         MealConfirmationView(meal: Meal(
             name: "Lunch",
             date: Date.now,

--- a/GutCheck/GutCheck/Views/PhoneAuthView.swift
+++ b/GutCheck/GutCheck/Views/PhoneAuthView.swift
@@ -18,7 +18,7 @@ struct PhoneAuthView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 24) {
                 if !authService.isPhoneVerificationInProgress {
                     phoneNumberSection

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -14,7 +14,7 @@ struct ServerStatusSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     // Recheck countdown pill

--- a/GutCheck/GutCheck/Views/Settings/DebugView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DebugView.swift
@@ -11,7 +11,7 @@ struct DebugView: View {
     @State private var resetError: Error?
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 // App Info
                 Section("App Information") {

--- a/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
@@ -15,7 +15,7 @@ struct HealthKitTestView: View {
     @State private var testResults: [String] = []
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 20) {
                 Text("HealthKit Integration Test")
                     .font(.title)

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -25,7 +25,7 @@ struct HealthcareExportView: View {
     @State private var endDate = Date.now
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     // Header
@@ -363,7 +363,7 @@ struct ExportOptionsSheet: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section("Date Range") {
                     DatePicker("Start Date", selection: $startDate, displayedComponents: .date)

--- a/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
+++ b/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
@@ -173,7 +173,7 @@ struct LocalStorageSettingsView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         LocalStorageSettingsView()
             .environmentObject(DataSyncService.shared)
             .environmentObject(CoreDataStorageService.shared)

--- a/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
+++ b/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
@@ -7,7 +7,7 @@ struct PrivacyPolicyView: View {
     private let sections = PolicySection.allSections
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 // Introduction Section
                 Section {

--- a/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
@@ -11,7 +11,7 @@ struct ReminderSettingsTestView: View {
     @StateObject private var reminderService = ReminderSettingsService.shared
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 20) {
                 Text("Reminder Settings Test")
                     .font(.title)

--- a/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
+++ b/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
@@ -4,7 +4,7 @@ struct ProfileMenuSheet: View {
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section {
                     NavigationLink(destination: SettingsView()) {


### PR DESCRIPTION
## Summary
- Replaces all 24 deprecated `NavigationView` instances with `NavigationStack` across 21 files
- No column-style navigation was in use, so all replacements are direct substitutions
- Existing `NavigationLink(destination:)` navigation continues to work unchanged within `NavigationStack`

Closes #218

## Test plan
- [x] Verify all navigation flows still work (push/pop transitions)
- [x] Test sheet presentations that contain navigation (ProfileMenuSheet, ServerStatusSheet, etc.)
- [x] Verify authentication flow navigation (RegisterView, PhoneAuthView, AuthenticationView)
- [x] Test calendar, meal, symptom, and insights navigation paths
- [x] Verify settings and debug views navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)