### PR TITLE
fix(#217): replace ObservableObject with @Observable

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -116,12 +116,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 @main
 struct GutCheckApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var authService = AuthService()
-    @StateObject private var settingsVM = SettingsViewModel()
-    @StateObject private var coreDataStack = CoreDataStack.shared
-    @StateObject private var localStorage = CoreDataStorageService.shared
-    @StateObject private var dataSyncService = DataSyncService.shared
-    @StateObject private var serverStatusService = ServerStatusService.shared
+    @State private var authService = AuthService()
+    @State private var settingsVM = SettingsViewModel()
+    @State private var coreDataStack = CoreDataStack.shared
+    @State private var localStorage = CoreDataStorageService.shared
+    @State private var dataSyncService = DataSyncService.shared
+    @State private var serverStatusService = ServerStatusService.shared
     @Environment(\.scenePhase) private var scenePhase
     
     static func testFirebaseConnection() async {
@@ -145,13 +145,13 @@ struct GutCheckApp: App {
                     }
                 } else if authService.isAuthenticated {
                     AppRoot()
-                        .environmentObject(authService)
-                        .environmentObject(settingsVM)
-                        .environmentObject(TimeoutManager.shared)
-                        .environmentObject(coreDataStack)
-                        .environmentObject(localStorage)
-                        .environmentObject(dataSyncService)
-                        .environmentObject(serverStatusService)
+                        .environment(authService)
+                        .environment(settingsVM)
+                        .environment(TimeoutManager.shared)
+                        .environment(coreDataStack)
+                        .environment(localStorage)
+                        .environment(dataSyncService)
+                        .environment(serverStatusService)
                 } else if authService.isAwaitingEmailVerification {
                     EmailVerificationView(authService: authService)
                 } else {

--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -116,14 +116,26 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 @main
 struct GutCheckApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @State private var authService = AuthService()
+    @State private var authService: AuthService
     @State private var settingsVM = SettingsViewModel()
     @State private var coreDataStack = CoreDataStack.shared
     @State private var localStorage = CoreDataStorageService.shared
     @State private var dataSyncService = DataSyncService.shared
     @State private var serverStatusService = ServerStatusService.shared
     @Environment(\.scenePhase) private var scenePhase
-    
+
+    init() {
+        // Firebase must be configured before AuthService is created,
+        // since AuthService.init() calls Auth.auth() which requires
+        // a configured FirebaseApp instance.
+        if FirebaseApp.app() == nil {
+            if Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
+                FirebaseApp.configure()
+            }
+        }
+        _authService = State(wrappedValue: AuthService())
+    }
+
     static func testFirebaseConnection() async {
         do {
             let testDoc = FirebaseManager.shared.testDocument("connection")

--- a/GutCheck/GutCheck/Navigation/AppRouter.swift
+++ b/GutCheck/GutCheck/Navigation/AppRouter.swift
@@ -30,16 +30,16 @@ enum SheetDestination: Identifiable {
 
 
 @MainActor
-class AppRouter: ObservableObject {
+@Observable class AppRouter {
     static let shared = AppRouter()
     
     // Per-tab navigation paths to prevent cross-tab state leakage
-    @Published var dashboardPath = NavigationPath()
-    @Published var mealsPath = NavigationPath()
-    @Published var symptomsPath = NavigationPath()
-    @Published var activeSheet: SheetDestination?
-    @Published var selectedTab: Tab = .dashboard
-    @Published private var isNavigating = false
+    var dashboardPath = NavigationPath()
+    var mealsPath = NavigationPath()
+    var symptomsPath = NavigationPath()
+    var activeSheet: SheetDestination?
+    var selectedTab: Tab = .dashboard
+    private var isNavigating = false
     
     /// The navigation path for the currently selected tab
     private var activePath: NavigationPath {

--- a/GutCheck/GutCheck/Navigation/RefreshManager.swift
+++ b/GutCheck/GutCheck/Navigation/RefreshManager.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 @MainActor
-class RefreshManager: ObservableObject {
+@Observable class RefreshManager {
     static let shared = RefreshManager()
     
-    @Published var refreshToken = UUID()
-    @Published var isRefreshing = false
+    var refreshToken = UUID()
+    var isRefreshing = false
     
     private init() {}
     

--- a/GutCheck/GutCheck/SearchTest.swift
+++ b/GutCheck/GutCheck/SearchTest.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 // Simple test to verify search functionality
 struct SearchTestView: View {
-    @StateObject private var searchService = FoodSearchService()
-    @StateObject private var viewModel = FoodSearchViewModel()
+    @State private var searchService = FoodSearchService()
+    @State private var viewModel = FoodSearchViewModel()
     @State private var testResults: [NutritionixFood] = []
     @State private var isLoading = false
     @State private var errorMessage = ""

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
@@ -13,12 +13,12 @@ import CryptoKit
 import Security
 
 @MainActor
-class CoreDataStack: ObservableObject {
+@Observable class CoreDataStack {
     static let shared = CoreDataStack()
     
     // MARK: - Core Data Stack
     
-    lazy var persistentContainer: NSPersistentContainer = {
+    @ObservationIgnored lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "GutCheck")
         
         // Configure persistent store with encryption

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
@@ -11,7 +11,7 @@ import Foundation
 import CoreData
 
 @MainActor
-class CoreDataStorageService: ObservableObject {
+@Observable class CoreDataStorageService {
     static let shared = CoreDataStorageService()
     
     private let coreDataStack = CoreDataStack.shared

--- a/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/DataSyncService.swift
@@ -13,16 +13,16 @@ import FirebaseFirestore
 import FirebaseAuth
 
 @MainActor
-class DataSyncService: ObservableObject {
+@Observable class DataSyncService {
     static let shared = DataSyncService()
     
     private let localStorage = CoreDataStorageService.shared
     private let coreDataStack = CoreDataStack.shared
-    private lazy var firestore = Firestore.firestore()
+    @ObservationIgnored private lazy var firestore = Firestore.firestore()
     
-    @Published var isSyncing = false
-    @Published var lastSyncDate: Date?
-    @Published var syncProgress: Double = 0.0
+    var isSyncing = false
+    var lastSyncDate: Date?
+    var syncProgress: Double = 0.0
     
     private init() {}
     

--- a/GutCheck/GutCheck/Services/DataDeletionService.swift
+++ b/GutCheck/GutCheck/Services/DataDeletionService.swift
@@ -12,11 +12,11 @@ import FirebaseFirestore
 import FirebaseAuth
 
 @MainActor
-class DataDeletionService: ObservableObject {
+@Observable class DataDeletionService {
     static let shared = DataDeletionService()
     
-    @Published var isLoading = false
-    @Published var errorMessage: String?
+    var isLoading = false
+    var errorMessage: String?
     
     private let firestore = Firestore.firestore()
     private let auth = Auth.auth()

--- a/GutCheck/GutCheck/Services/DataSyncManager.swift
+++ b/GutCheck/GutCheck/Services/DataSyncManager.swift
@@ -8,17 +8,17 @@
 import Foundation
 import SwiftUI
 
-class DataSyncManager: ObservableObject {
+@Observable class DataSyncManager {
     static let shared = DataSyncManager()
     
-    @Published private(set) var lastRefreshTime: Date = Date.now
-    @Published private(set) var isRefreshing: Bool = false
+    private(set) var lastRefreshTime: Date = Date.now
+    private(set) var isRefreshing: Bool = false
     
     // Refresh triggers for different data types
-    @Published var shouldRefreshDashboard: Bool = false
-    @Published var shouldRefreshMeals: Bool = false
-    @Published var shouldRefreshSymptoms: Bool = false
-    @Published var shouldRefreshCalendar: Bool = false
+    var shouldRefreshDashboard: Bool = false
+    var shouldRefreshMeals: Bool = false
+    var shouldRefreshSymptoms: Bool = false
+    var shouldRefreshCalendar: Bool = false
     
     private init() {}
     

--- a/GutCheck/GutCheck/Services/Firebase/AuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthService.swift
@@ -12,26 +12,26 @@ import CryptoKit
 import AuthenticationServices
 
 @MainActor
-class AuthService: AuthenticationProtocol, HasLoadingState {
-    @Published private(set) var authUser: FirebaseAuth.User?
-    @Published private(set) var currentUser: User?
-    @Published private(set) var isAuthStateResolved = false
-    @Published private(set) var isAuthenticated = false
-    @Published private(set) var isAwaitingEmailVerification = false
-    private var verificationId: String?
-    @Published private(set) var isPhoneVerificationInProgress = false
+@Observable class AuthService: AuthenticationProtocol, HasLoadingState {
+    private(set) var authUser: FirebaseAuth.User?
+    private(set) var currentUser: User?
+    private(set) var isAuthStateResolved = false
+    private(set) var isAuthenticated = false
+    private(set) var isAwaitingEmailVerification = false
+    @ObservationIgnored private var verificationId: String?
+    private(set) var isPhoneVerificationInProgress = false
     /// Temporarily holds the email for resending verification when the user is signed out
-    private var pendingVerificationEmail: String?
-    private var pendingVerificationPassword: String?
-    private var currentNonce: String?
+    @ObservationIgnored private var pendingVerificationEmail: String?
+    @ObservationIgnored private var pendingVerificationPassword: String?
+    @ObservationIgnored private var currentNonce: String?
     
     let loadingState = LoadingStateManager()
     
-    private let auth = Auth.auth()
-    private lazy var firestore = Firestore.firestore()
+    @ObservationIgnored private let auth = Auth.auth()
+    @ObservationIgnored private lazy var firestore = Firestore.firestore()
     
     // Auth state listener handle
-    private var authStateListenerHandle: AuthStateDidChangeListenerHandle?
+    @ObservationIgnored private var authStateListenerHandle: AuthStateDidChangeListenerHandle?
     
     init() {
         // Listen for auth state changes

--- a/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @MainActor
-protocol AuthenticationProtocol: ObservableObject {
+protocol AuthenticationProtocol: AnyObject {
     var isAuthStateResolved: Bool { get }
     var isAuthenticated: Bool { get }
     var isLoading: Bool { get }

--- a/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
@@ -2,14 +2,14 @@ import Foundation
 import FirebaseAuth
 
 @MainActor
-class PreviewAuthService: AuthenticationProtocol {
-    @Published private(set) var isAuthStateResolved: Bool = true
-    @Published private(set) var isAuthenticated: Bool = true
-    @Published private(set) var isLoading: Bool = false
-    @Published var errorMessage: String?
-    @Published private(set) var isPhoneVerificationInProgress: Bool = false
-    @Published private(set) var isAwaitingEmailVerification: Bool = false
-    @Published private(set) var currentUser: User? = User(
+@Observable class PreviewAuthService: AuthenticationProtocol {
+    private(set) var isAuthStateResolved: Bool = true
+    private(set) var isAuthenticated: Bool = true
+    private(set) var isLoading: Bool = false
+    var errorMessage: String?
+    private(set) var isPhoneVerificationInProgress: Bool = false
+    private(set) var isAwaitingEmailVerification: Bool = false
+    private(set) var currentUser: User? = User(
         id: "preview",
         email: "preview@example.com",
         firstName: "Preview",

--- a/GutCheck/GutCheck/Services/FoodDetailService.swift
+++ b/GutCheck/GutCheck/Services/FoodDetailService.swift
@@ -8,17 +8,17 @@ import SwiftUI
 
 /// Unified service managing food detail presentation modes and configurations
 @MainActor
-class FoodDetailService: ObservableObject {
+@Observable class FoodDetailService {
     static let shared = FoodDetailService()
     
     /// Current food item being viewed
-    @Published var currentFoodItem: FoodItem?
+    var currentFoodItem: FoodItem?
     
     /// Navigation state for food detail flows
-    @Published var showingFoodDetail = false
-    @Published var showingNutritionDetails = false
-    @Published var showingIngredients = false
-    @Published var showingAllergens = false
+    var showingFoodDetail = false
+    var showingNutritionDetails = false
+    var showingIngredients = false
+    var showingAllergens = false
     
     private init() {}
     

--- a/GutCheck/GutCheck/Services/FoodSearchService.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchService.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 @MainActor
-class FoodSearchService: ObservableObject, HasLoadingState {
-    @Published var results: [FoodSearchResult] = []
+@Observable class FoodSearchService: HasLoadingState {
+    var results: [FoodSearchResult] = []
 
     let loadingState = LoadingStateManager()
 

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitMedicationService.swift
@@ -21,31 +21,31 @@ import UIKit
 /// Provides real-time medication tracking without requiring daily polling.
 /// All medication data is processed locally for privacy compliance.
 @MainActor
-class HealthKitMedicationService: ObservableObject {
+@Observable class HealthKitMedicationService {
     // MARK: - Private Properties
     
     /// HealthKit store for accessing health data
-    private let healthStore = HKHealthStore()
+    @ObservationIgnored private let healthStore = HKHealthStore()
     
     /// Active medication observers for real-time updates
-    private var medicationObservers: [HKObserverQuery] = []
+    @ObservationIgnored private var medicationObservers: [HKObserverQuery] = []
     
     /// Background delivery observers for continuous monitoring
-    private var backgroundDeliveryObservers: [HKObserverQuery] = []
+    @ObservationIgnored private var backgroundDeliveryObservers: [HKObserverQuery] = []
     
     // MARK: - Published Properties
     
     /// Currently active medications from HealthKit
-    @Published var currentMedications: [MedicationRecord] = []
+    var currentMedications: [MedicationRecord] = []
     
     /// Complete medication history for analysis
-    @Published var medicationHistory: [MedicationRecord] = []
+    var medicationHistory: [MedicationRecord] = []
     
     /// Whether HealthKit medication access is authorized
-    @Published var isAuthorized = false
+    var isAuthorized = false
     
     /// Timestamp of last medication data update
-    @Published var lastUpdateTime: Date?
+    var lastUpdateTime: Date?
     
     // MARK: - Authorization
     

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitSyncManager.swift
@@ -11,10 +11,10 @@ import Foundation
 import HealthKit
 
 @MainActor
-class HealthKitSyncManager: ObservableObject {
+@Observable class HealthKitSyncManager {
     static let shared = HealthKitSyncManager()
 
-    @Published var latestHealthData: UserHealthData?
+    var latestHealthData: UserHealthData?
 
     private let syncInterval: TimeInterval = 15 * 60 // 15 minutes
     private let authorizedKey   = "healthKitEverAuthorized"

--- a/GutCheck/GutCheck/Services/HealthcareExportService.swift
+++ b/GutCheck/GutCheck/Services/HealthcareExportService.swift
@@ -50,15 +50,15 @@ struct ExportOptions {
 
 // MARK: - Healthcare Export Service
 
-class HealthcareExportService: ObservableObject {
+@Observable class HealthcareExportService {
     static let shared = HealthcareExportService()
     
     private let mealRepository = MealRepository.shared
     private let symptomRepository = SymptomRepository.shared
     private let localStorageService = LocalStorageService.shared
     
-    @Published var isExporting = false
-    @Published var exportProgress: Double = 0.0
+    var isExporting = false
+    var exportProgress: Double = 0.0
     
     private init() {}
     

--- a/GutCheck/GutCheck/Services/Insights/InsightsService.swift
+++ b/GutCheck/GutCheck/Services/Insights/InsightsService.swift
@@ -2,12 +2,12 @@ import Foundation
 import Combine
 
 /// Service for generating and managing health insights
-class InsightsService: ObservableObject {
+@Observable class InsightsService {
     static let shared = InsightsService()
     
-    @Published var recentInsights: [HealthInsight] = []
-    @Published var isLoading = false
-    @Published var error: String?
+    var recentInsights: [HealthInsight] = []
+    var isLoading = false
+    var error: String?
     
     private let patternService = PatternRecognitionService.shared
     private var cancellables = Set<AnyCancellable>()

--- a/GutCheck/GutCheck/Services/LoadingStateManager.swift
+++ b/GutCheck/GutCheck/Services/LoadingStateManager.swift
@@ -6,11 +6,10 @@
 //
 
 import SwiftUI
-import Combine
 
 // MARK: - LoadingState Protocol
 @MainActor
-protocol LoadingStateManaging: ObservableObject {
+protocol LoadingStateManaging: AnyObject {
     var isLoading: Bool { get set }
     var isSaving: Bool { get set }
     var isLoadingMore: Bool { get set }
@@ -84,12 +83,12 @@ extension LoadingStateManaging {
 
 // MARK: - Concrete Implementation
 @MainActor
-class LoadingStateManager: ObservableObject, LoadingStateManaging {
-    @Published var isLoading: Bool = false
-    @Published var isSaving: Bool = false
-    @Published var isLoadingMore: Bool = false
-    @Published var uploadProgress: Double = 0.0
-    @Published var errorMessage: String? = nil
+@Observable class LoadingStateManager: LoadingStateManaging {
+    var isLoading: Bool = false
+    var isSaving: Bool = false
+    var isLoadingMore: Bool = false
+    var uploadProgress: Double = 0.0
+    var errorMessage: String? = nil
     
     nonisolated init() {}
 }
@@ -97,7 +96,7 @@ class LoadingStateManager: ObservableObject, LoadingStateManaging {
 // MARK: - Specialized Loading States
 @MainActor
 class UploadLoadingStateManager: LoadingStateManager {
-    @Published var isUploading: Bool = false
+    var isUploading: Bool = false
     
     override nonisolated init() {
         super.init()
@@ -120,12 +119,12 @@ class UploadLoadingStateManager: LoadingStateManager {
 }
 
 // MARK: - Loading State Mixins
-protocol HasLoadingState {
+protocol HasLoadingState: AnyObject {
     var loadingState: LoadingStateManager { get }
 }
 
 @MainActor
-extension HasLoadingState where Self: ObservableObject {
+extension HasLoadingState {
     var isLoading: Bool {
         get { loadingState.isLoading }
         set { loadingState.isLoading = newValue }

--- a/GutCheck/GutCheck/Services/MealBuilderService.swift
+++ b/GutCheck/GutCheck/Services/MealBuilderService.swift
@@ -11,23 +11,23 @@ import SwiftUI
 import Combine
 
 @MainActor
-class MealBuilderService: ObservableObject {
+@Observable class MealBuilderService {
     static let shared = MealBuilderService()
     
     // MARK: - Published Properties
-    @Published var currentMeal: [FoodItem] = []
-    @Published var mealType: MealType = .lunch
-    @Published var mealDate: Date = Date.now
-    @Published var mealName: String = ""
-    @Published var notes: String = ""
-    @Published var isBuilding: Bool = false
+    var currentMeal: [FoodItem] = []
+    var mealType: MealType = .lunch
+    var mealDate: Date = Date.now
+    var mealName: String = ""
+    var notes: String = ""
+    var isBuilding: Bool = false
     
     // Navigation state
-    @Published var shouldNavigateToBuilder: Bool = false
-    @Published var shouldDismissModal: Bool = false
+    var shouldNavigateToBuilder: Bool = false
+    var shouldDismissModal: Bool = false
 
     // Edit state — non-nil when editing an existing meal
-    @Published var editingMealId: String? = nil
+    var editingMealId: String? = nil
     
     // MARK: - Dependencies
     

--- a/GutCheck/GutCheck/Services/PaginationService.swift
+++ b/GutCheck/GutCheck/Services/PaginationService.swift
@@ -51,9 +51,9 @@ struct PaginatedResult<T> {
 // MARK: - Pagination Service
 
 @MainActor
-class PaginationService<T: Codable & Identifiable>: ObservableObject {
-    @Published var items: [T] = []
-    @Published var paginationState = PaginationState.initial
+@Observable class PaginationService<T: Codable & Identifiable> {
+    var items: [T] = []
+    var paginationState = PaginationState.initial
     
     internal let collection: String
     internal let config: PaginationConfig

--- a/GutCheck/GutCheck/Services/PhotoSavingService.swift
+++ b/GutCheck/GutCheck/Services/PhotoSavingService.swift
@@ -9,11 +9,11 @@ import UIKit
 import Photos
 
 @MainActor
-class PhotoSavingService: ObservableObject {
+@Observable class PhotoSavingService {
     static let shared = PhotoSavingService()
     
-    @Published var isSaving = false
-    @Published var lastSaveResult: SaveResult?
+    var isSaving = false
+    var lastSaveResult: SaveResult?
     
     enum SaveResult {
         case success

--- a/GutCheck/GutCheck/Services/PrivacyPolicyManager.swift
+++ b/GutCheck/GutCheck/Services/PrivacyPolicyManager.swift
@@ -11,13 +11,13 @@ import Foundation
 import FirebaseFirestore
 
 @MainActor
-class PrivacyPolicyManager: ObservableObject {
+@Observable class PrivacyPolicyManager {
     static let shared = PrivacyPolicyManager()
     
-    @Published var currentVersion = "1.0"
-    @Published var lastUpdated = "August 18, 2025"
-    @Published var isPrivacyPolicyAccepted = false
-    @Published var privacyPolicyAcceptedDate: Date?
+    var currentVersion = "1.0"
+    var lastUpdated = "August 18, 2025"
+    var isPrivacyPolicyAccepted = false
+    var privacyPolicyAcceptedDate: Date?
     
     private let firestore = Firestore.firestore()
     private let userDefaults = UserDefaults.standard

--- a/GutCheck/GutCheck/Services/ReminderSettingsService.swift
+++ b/GutCheck/GutCheck/Services/ReminderSettingsService.swift
@@ -11,12 +11,12 @@ import FirebaseFirestore
 import UserNotifications
 
 @MainActor
-class ReminderSettingsService: ObservableObject {
+@Observable class ReminderSettingsService {
     static let shared = ReminderSettingsService()
     
-    @Published var reminderSettings: ReminderSettings?
-    @Published var isLoading = false
-    @Published var errorMessage: String?
+    var reminderSettings: ReminderSettings?
+    var isLoading = false
+    var errorMessage: String?
     
     private let reminderRepository = ReminderSettingsRepository.shared
     

--- a/GutCheck/GutCheck/Services/RemindersKitService.swift
+++ b/GutCheck/GutCheck/Services/RemindersKitService.swift
@@ -19,7 +19,7 @@ import EventKit
 import Foundation
 
 @MainActor
-final class RemindersKitService: ObservableObject {
+@Observable final class RemindersKitService {
 
     // MARK: - Singleton
 
@@ -28,12 +28,12 @@ final class RemindersKitService: ObservableObject {
     // MARK: - Published State
 
     /// Whether the user has opted in to Apple Reminders sync.
-    @Published var isEnabled: Bool {
+    var isEnabled: Bool {
         didSet { UserDefaults.standard.set(isEnabled, forKey: Keys.isEnabled) }
     }
 
     /// Current EventKit authorization status, kept in sync with the system.
-    @Published var authorizationStatus: EKAuthorizationStatus = .notDetermined
+    var authorizationStatus: EKAuthorizationStatus = .notDetermined
 
     // MARK: - Private
 

--- a/GutCheck/GutCheck/Services/ServerStatusService.swift
+++ b/GutCheck/GutCheck/Services/ServerStatusService.swift
@@ -11,19 +11,19 @@ import Network
 import FirebaseFirestore
 
 @MainActor
-class ServerStatusService: ObservableObject {
+@Observable class ServerStatusService {
     static let shared = ServerStatusService()
 
     // MARK: - Published State
 
-    @Published private(set) var isFirebaseReachable: Bool = true
-    @Published private(set) var isNetworkAvailable: Bool = true
-    @Published private(set) var secondsUntilRecheck: Int = 0
-    @Published private(set) var isRechecking: Bool = false
-    @Published private(set) var pendingChangesCount: Int = 0
+    private(set) var isFirebaseReachable: Bool = true
+    private(set) var isNetworkAvailable: Bool = true
+    private(set) var secondsUntilRecheck: Int = 0
+    private(set) var isRechecking: Bool = false
+    private(set) var pendingChangesCount: Int = 0
 
     /// Toggle from debug views to simulate offline mode
-    @Published var isDebugOfflineMode: Bool = false
+    var isDebugOfflineMode: Bool = false
 
     /// Convenience: true when the app should show offline UI
     var isOffline: Bool {

--- a/GutCheck/GutCheck/Services/TimeoutManager.swift
+++ b/GutCheck/GutCheck/Services/TimeoutManager.swift
@@ -2,10 +2,10 @@ import Foundation
 import SwiftUI
 
 @MainActor
-class TimeoutManager: ObservableObject {
+@Observable class TimeoutManager {
     static let shared = TimeoutManager()
     
-    @Published private(set) var shouldResetToHome = false
+    private(set) var shouldResetToHome = false
     private var backgroundEnteredTime: Date?
     private let timeoutInterval: TimeInterval = 300 // 5 minutes in seconds
     

--- a/GutCheck/GutCheck/Services/UnifiedDataService.swift
+++ b/GutCheck/GutCheck/Services/UnifiedDataService.swift
@@ -22,7 +22,7 @@ protocol DataClassifiable {
 
 /// Unified data service that automatically routes data to appropriate storage
 /// based on privacy classification and user preferences
-class UnifiedDataService: ObservableObject {
+@Observable class UnifiedDataService {
     static let shared = UnifiedDataService()
     
     // MARK: - Private Properties

--- a/GutCheck/GutCheck/Services/UnifiedProfileImageService.swift
+++ b/GutCheck/GutCheck/Services/UnifiedProfileImageService.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 @MainActor
-class UnifiedProfileImageService: ObservableObject {
-    @Published var isUploading = false
-    @Published var uploadProgress: Double = 0.0
-    @Published var errorMessage: String?
+@Observable class UnifiedProfileImageService {
+    var isUploading = false
+    var uploadProgress: Double = 0.0
+    var errorMessage: String?
     
     private let loadingState = UploadLoadingStateManager()
     

--- a/GutCheck/GutCheck/Utils/NetworkMonitor.swift
+++ b/GutCheck/GutCheck/Utils/NetworkMonitor.swift
@@ -1,12 +1,12 @@
 import Network
 import Foundation
 
-class NetworkMonitor: ObservableObject {
-    private let monitor = NWPathMonitor()
+@Observable class NetworkMonitor {
+    @ObservationIgnored private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "NetworkMonitor")
     
-    @Published var isConnected = true
-    @Published var connectionType: ConnectionType = .unknown
+    var isConnected = true
+    var connectionType: ConnectionType = .unknown
     
     init() {
         monitor.pathUpdateHandler = { [weak self] path in

--- a/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 @MainActor
-class CategoryInsightsViewModel: ObservableObject {
-    @Published var activeInsights: [HealthInsight] = []
-    @Published var historicalInsights: [HealthInsight] = []
-    @Published var isLoading = false
-    @Published var error: String?
+@Observable class CategoryInsightsViewModel {
+    var activeInsights: [HealthInsight] = []
+    var historicalInsights: [HealthInsight] = []
+    var isLoading = false
+    var error: String?
     
     private let insightsService = InsightsService.shared
     private let mealRepository = MealRepository.shared

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightDetailViewModel.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 @MainActor
-class InsightDetailViewModel: ObservableObject {
-    @Published var isLoading = false
-    @Published var error: String? = nil
+@Observable class InsightDetailViewModel {
+    var isLoading = false
+    var error: String? = nil
     
     // Additional properties for storing insight-related data
-    @Published var relatedMeals: [Meal] = []
-    @Published var relatedSymptoms: [Symptom] = []
-    @Published var confidenceLevel: Double = 0.0
-    @Published var recommendations: [String] = []
+    var relatedMeals: [Meal] = []
+    var relatedSymptoms: [Symptom] = []
+    var confidenceLevel: Double = 0.0
+    var recommendations: [String] = []
     
     // Properties expected by the view
-    @Published var chartData: [Double] = []
-    @Published var contributingFactors: [ContributingFactor] = []
-    @Published var relatedInsights: [HealthInsight] = []
+    var chartData: [Double] = []
+    var contributingFactors: [ContributingFactor] = []
+    var relatedInsights: [HealthInsight] = []
     
     /// Load detailed data for the insight
     func loadData(for insight: HealthInsight) async {

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -8,20 +8,20 @@ struct RankedItem: Identifiable {
 }
 
 @MainActor
-class InsightsViewModel: ObservableObject {
-    @Published var recentInsights: [HealthInsight] = []
-    @Published var patterns: [HealthPattern] = []
-    @Published var recommendations: [HealthRecommendation] = []
-    @Published var isLoading = false
-    @Published var error: String?
+@Observable class InsightsViewModel {
+    var recentInsights: [HealthInsight] = []
+    var patterns: [HealthPattern] = []
+    var recommendations: [HealthRecommendation] = []
+    var isLoading = false
+    var error: String?
 
     // MARK: - Weekly Summary Data
 
-    @Published var weeklyMealCount: Int = 0
-    @Published var weeklySymptomCount: Int = 0
-    @Published var topSymptoms: [RankedItem] = []
-    @Published var topTriggerFoods: [RankedItem] = []
-    @Published var bestDays: [RankedItem] = []
+    var weeklyMealCount: Int = 0
+    var weeklySymptomCount: Int = 0
+    var topSymptoms: [RankedItem] = []
+    var topTriggerFoods: [RankedItem] = []
+    var bestDays: [RankedItem] = []
 
     private let insightsService = InsightsService.shared
     private let mealRepository = MealRepository.shared

--- a/GutCheck/GutCheck/ViewModels/AuthenticationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/AuthenticationViewModel.swift
@@ -10,20 +10,20 @@ import SwiftUI
 import AuthenticationServices
 
 @MainActor
-class AuthenticationViewModel: ObservableObject {
-    @Published var email = ""
-    @Published var password = ""
-    @Published var confirmPassword = ""
-    @Published var firstName = ""
-    @Published var lastName = ""
-    @Published var phoneNumber = ""
-    @Published var verificationCode = ""
+@Observable class AuthenticationViewModel {
+    var email = ""
+    var password = ""
+    var confirmPassword = ""
+    var firstName = ""
+    var lastName = ""
+    var phoneNumber = ""
+    var verificationCode = ""
     
-    @Published var isShowingSignUp = false
-    @Published var isShowingForgotPassword = false
-    @Published var isShowingPhoneAuth = false
-    @Published var showingSuccessAlert = false
-    @Published var successMessage = ""
+    var isShowingSignUp = false
+    var isShowingForgotPassword = false
+    var isShowingPhoneAuth = false
+    var showingSuccessAlert = false
+    var successMessage = ""
     
     private let authService: AuthService
     

--- a/GutCheck/GutCheck/ViewModels/Base/BaseViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Base/BaseViewModel.swift
@@ -11,12 +11,12 @@ import SwiftUI
 // MARK: - Base ViewModel Class
 
 @MainActor
-open class BaseViewModel: ObservableObject {
-    @Published var isLoading: Bool = false
-    @Published var isSaving: Bool = false
-    @Published var errorMessage: String? = nil
-    @Published var showingErrorAlert: Bool = false
-    @Published var shouldDismiss: Bool = false
+@Observable open class BaseViewModel {
+    var isLoading: Bool = false
+    var isSaving: Bool = false
+    var errorMessage: String? = nil
+    var showingErrorAlert: Bool = false
+    var shouldDismiss: Bool = false
     
     public init() {}
     
@@ -86,11 +86,11 @@ open class BaseViewModel: ObservableObject {
 /// Base ViewModel for detail views (editing single entities)
 @MainActor
 open class DetailViewModel<T>: BaseViewModel {
-    @Published var isEditing = false
-    @Published var showingDeleteConfirmation = false
+    var isEditing = false
+    var showingDeleteConfirmation = false
     
     /// The entity being viewed/edited
-    @Published var entity: T
+    var entity: T
     
     public init(entity: T) {
         self.entity = entity
@@ -140,8 +140,8 @@ open class DetailViewModel<T>: BaseViewModel {
 /// Base ViewModel for list views (displaying collections)
 @MainActor
 open class ListViewModel<T>: BaseViewModel {
-    @Published var items: [T] = []
-    @Published var hasMoreData: Bool = false
+    var items: [T] = []
+    var hasMoreData: Bool = false
     
     /// Override this to implement data loading
     open func loadItems() async {

--- a/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
@@ -2,11 +2,11 @@ import Foundation
 import FirebaseFirestore
 
 @MainActor
-class CalendarDetailViewModel: ObservableObject {
-    @Published var meals: [Meal] = []
-    @Published var symptoms: [Symptom] = []
-    @Published var patterns: [String]?
-    @Published var potentialTriggers: [String]?
+@Observable class CalendarDetailViewModel {
+    var meals: [Meal] = []
+    var symptoms: [Symptom] = []
+    var patterns: [String]?
+    var potentialTriggers: [String]?
     
     var hasAnalysis: Bool {
         (patterns != nil && !patterns!.isEmpty) || (potentialTriggers != nil && !potentialTriggers!.isEmpty)

--- a/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
@@ -18,32 +18,32 @@ import Combine
 /// Central data store for dashboard functionality
 /// Manages all dashboard-related data including health insights, meal/symptom data,
 /// and real-time calculations for health scoring and recommendations.
-final class DashboardDataStore: ObservableObject {
+@Observable final class DashboardDataStore {
     // MARK: - Published Properties
     
     /// Today's meals for the selected date
-    @Published var todaysMeals: [Meal] = []
+    var todaysMeals: [Meal] = []
     
     /// Today's symptoms for the selected date
-    @Published var todaysSymptoms: [Symptom] = []
+    var todaysSymptoms: [Symptom] = []
     
     /// Active trigger alerts that require immediate attention
-    @Published var triggerAlerts: [String] = []
+    var triggerAlerts: [String] = []
     
     /// Legacy insight message (deprecated - replaced by structured insights)
-    @Published var insightMessage: String? = nil
+    var insightMessage: String? = nil
     
     /// Current health score (1-10) calculated from symptoms and meals
-    @Published var todaysHealthScore: Int = 7
+    var todaysHealthScore: Int = 7
     
     /// Personalized health focus recommendation for the selected day
-    @Published var todaysFocus: String = ""
+    var todaysFocus: String = ""
     
     /// Smart avoidance tip based on recent symptom patterns
-    @Published var avoidanceTip: String = ""
+    var avoidanceTip: String = ""
     
     /// Currently selected date for dashboard data display
-    @Published var selectedDate: Date = Date.now
+    var selectedDate: Date = Date.now
     
     // MARK: - Private Properties
     

--- a/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
@@ -3,10 +3,10 @@ import FirebaseFirestore
 import HealthKit
 
 @MainActor
-class RecentActivityViewModel: ObservableObject {
-    @Published var recentEntries: [ActivityEntry] = []
-    @Published var isLoading = false
-    @Published var errorMessage: String?
+@Observable class RecentActivityViewModel {
+    var recentEntries: [ActivityEntry] = []
+    var isLoading = false
+    var errorMessage: String?
     
     // Repository dependencies
     private let mealRepository: MealRepository

--- a/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
@@ -2,15 +2,15 @@ import SwiftUI
 import HealthKit
 
 @MainActor
-final class HealthKitViewModel: ObservableObject {
-    @Published var healthData: UserHealthData?
-    @Published var isAuthorized = false
-    @Published var showPermissionError = false
-    @AppStorage("lastHealthKitSyncTimestamp") private var lastSyncTimestamp: Double = 0
+@Observable final class HealthKitViewModel {
+    var healthData: UserHealthData?
+    var isAuthorized = false
+    var showPermissionError = false
+    @ObservationIgnored @AppStorage("lastHealthKitSyncTimestamp") private var lastSyncTimestamp: Double = 0
 
     // MARK: - Write authorization statuses (keyed by identifier rawValue for Codable-free storage)
-    @Published var mealWriteStatuses:    [HKQuantityTypeIdentifier:  HKAuthorizationStatus] = [:]
-    @Published var symptomWriteStatuses: [HKCategoryTypeIdentifier:  HKAuthorizationStatus] = [:]
+    var mealWriteStatuses:    [HKQuantityTypeIdentifier:  HKAuthorizationStatus] = [:]
+    var symptomWriteStatuses: [HKCategoryTypeIdentifier:  HKAuthorizationStatus] = [:]
 
     /// True if any write type is not yet authorized (not determined or denied).
     var hasWriteIssues: Bool {

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -8,15 +8,15 @@ import Foundation
 import Combine
 
 @MainActor
-class FoodSearchViewModel: ObservableObject {
+@Observable class FoodSearchViewModel {
     // Search state
-    @Published var searchQuery: String = ""
-    @Published var isSearching: Bool = false
-    @Published var hasSearched: Bool = false
-    @Published var searchResults: [FoodItem] = []
-    @Published var selectedFoodItem: FoodItem?
-    @Published var recentSearches: [String] = ["Oatmeal", "Chicken breast", "Greek yogurt"]
-    @Published var recentItems: [FoodItem] = []
+    var searchQuery: String = ""
+    var isSearching: Bool = false
+    var hasSearched: Bool = false
+    var searchResults: [FoodItem] = []
+    var selectedFoodItem: FoodItem?
+    var recentSearches: [String] = ["Oatmeal", "Chicken breast", "Greek yogurt"]
+    var recentItems: [FoodItem] = []
     
     let foodCategories = [
         "Fruits", "Vegetables", "Meat", "Dairy",

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -10,20 +10,20 @@ import FirebaseFirestore
 import FirebaseAuth
 
 @MainActor
-class MealBuilderViewModel: ObservableObject {
+@Observable class MealBuilderViewModel {
     // Meal properties
-    @Published var mealName: String = ""
-    @Published var mealType: MealType = .lunch
-    @Published var mealDate: Date = Date.now
-    @Published var notes: String = ""
-    @Published var foodItems: [FoodItem] = []
-    @Published var isSaving: Bool = false
+    var mealName: String = ""
+    var mealType: MealType = .lunch
+    var mealDate: Date = Date.now
+    var notes: String = ""
+    var foodItems: [FoodItem] = []
+    var isSaving: Bool = false
     
     // Error state
-    @Published var errorMessage: String?
+    var errorMessage: String?
     
     // Food item being edited
-    @Published var editingFoodItem: FoodItem?
+    var editingFoodItem: FoodItem?
     
     // Repository dependency
     private let mealRepository: MealRepository

--- a/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
@@ -3,18 +3,18 @@ import FirebaseFirestore
 import SwiftUI
 
 @MainActor
-class MealDetailViewModel: ObservableObject {
-    @Published var meal: Meal
-    @Published var mealId: String?
-    @Published var notes: String = ""
-    @Published var isEditing = false
-    @Published var isSaving = false
-    @Published var isLoading = false
-    @Published var editingFoodItem: FoodItem?
-    @Published var showingDeleteConfirmation = false
-    @Published var showingErrorAlert = false
-    @Published var errorMessage = ""
-    @Published var shouldDismiss = false
+@Observable class MealDetailViewModel {
+    var meal: Meal
+    var mealId: String?
+    var notes: String = ""
+    var isEditing = false
+    var isSaving = false
+    var isLoading = false
+    var editingFoodItem: FoodItem?
+    var showingDeleteConfirmation = false
+    var showingErrorAlert = false
+    var errorMessage = ""
+    var shouldDismiss = false
     
     // Repository dependency
     private let mealRepository: MealRepository

--- a/GutCheck/GutCheck/ViewModels/Meal/MealHistoryViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealHistoryViewModel.swift
@@ -27,13 +27,13 @@ enum MealFilter: String, CaseIterable {
 }
 
 @MainActor
-class MealHistoryViewModel: ObservableObject, HasLoadingState {
-    @Published var groupedMeals: [Date: [Meal]] = [:]
-    @Published var hasMoreData = true
-    @Published var error: Error?
-    @Published var selectedFilter: MealFilter = .all
-    @Published var startDate: Date?
-    @Published var endDate: Date?
+@Observable class MealHistoryViewModel: HasLoadingState {
+    var groupedMeals: [Date: [Meal]] = [:]
+    var hasMoreData = true
+    var error: Error?
+    var selectedFilter: MealFilter = .all
+    var startDate: Date?
+    var endDate: Date?
     
     let loadingState = LoadingStateManager()
     

--- a/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
@@ -12,19 +12,19 @@ import SwiftUI
 // MARK: - Medication List ViewModel
 
 @MainActor
-class MedicationViewModel: ObservableObject, HasLoadingState {
+@Observable class MedicationViewModel: HasLoadingState {
 
     // MARK: - Published: List State
 
-    @Published var activeMedications: [MedicationRecord] = []
-    @Published var allMedications: [MedicationRecord] = []
+    var activeMedications: [MedicationRecord] = []
+    var allMedications: [MedicationRecord] = []
 
     // MARK: - Published: UI State
 
-    @Published var showingAddMedication = false
-    @Published var showingErrorAlert    = false
-    @Published var showingDeleteConfirmation = false
-    @Published var medicationToDelete: MedicationRecord?
+    var showingAddMedication = false
+    var showingErrorAlert    = false
+    var showingDeleteConfirmation = false
+    var medicationToDelete: MedicationRecord?
 
     // MARK: - Loading State (HasLoadingState)
 
@@ -90,24 +90,24 @@ class MedicationViewModel: ObservableObject, HasLoadingState {
 // MARK: - Add Medication ViewModel
 
 @MainActor
-class AddMedicationViewModel: ObservableObject, HasLoadingState {
+@Observable class AddMedicationViewModel: HasLoadingState {
 
     // MARK: - Form Fields
 
-    @Published var name:          String             = ""
-    @Published var dosageAmount:  String             = ""
-    @Published var dosageUnit:    String             = "mg"
-    @Published var frequency:     MedicationFrequency = .onceDaily
-    @Published var startDate:     Date               = Date.now
-    @Published var hasEndDate:    Bool               = false
-    @Published var endDate:       Date               = Date.now
-    @Published var isActive:      Bool               = true
-    @Published var notes:         String             = ""
+    var name:          String             = ""
+    var dosageAmount:  String             = ""
+    var dosageUnit:    String             = "mg"
+    var frequency:     MedicationFrequency = .onceDaily
+    var startDate:     Date               = Date.now
+    var hasEndDate:    Bool               = false
+    var endDate:       Date               = Date.now
+    var isActive:      Bool               = true
+    var notes:         String             = ""
 
     // MARK: - UI State
 
-    @Published var showingSuccessAlert = false
-    @Published var showingErrorAlert   = false
+    var showingSuccessAlert = false
+    var showingErrorAlert   = false
 
     // MARK: - Loading State (HasLoadingState)
 
@@ -198,24 +198,24 @@ class AddMedicationViewModel: ObservableObject, HasLoadingState {
 
 /// Handles the "Log a dose I just took" form.
 @MainActor
-class LogMedicationDoseViewModel: ObservableObject, HasLoadingState {
+@Observable class LogMedicationDoseViewModel: HasLoadingState {
 
     // MARK: - Published: Medication Picker
 
     /// Active medications the user can select from.
-    @Published var availableMedications: [MedicationRecord] = []
-    @Published var selectedMedication: MedicationRecord?
+    var availableMedications: [MedicationRecord] = []
+    var selectedMedication: MedicationRecord?
 
     // MARK: - Published: Form Fields
 
     /// Date and time the dose was taken (defaults to now).
-    @Published var dateTaken: Date = Date.now
-    @Published var notes: String   = ""
+    var dateTaken: Date = Date.now
+    var notes: String   = ""
 
     // MARK: - Published: UI State
 
-    @Published var showingSuccessAlert = false
-    @Published var showingErrorAlert   = false
+    var showingSuccessAlert = false
+    var showingErrorAlert   = false
 
     // MARK: - Loading State
 

--- a/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
@@ -1,14 +1,42 @@
 import SwiftUI
 
 @Observable class SettingsViewModel {
-    @ObservationIgnored @AppStorage("appLanguage") var languageRaw: String = AppLanguage.english.rawValue
-    @ObservationIgnored @AppStorage("unitOfMeasure") var unitRaw: String = UnitSystem.metric.rawValue
-    @ObservationIgnored @AppStorage("appColorScheme") var colorSchemeRaw: String = AppColorScheme.system.rawValue
+    private static let defaults = UserDefaults.standard
 
-    // HealthKit write preferences
-    @ObservationIgnored @AppStorage("healthKitSyncEnabled") var healthKitSyncEnabled: Bool = true
-    @ObservationIgnored @AppStorage("healthKitWriteMeals") var healthKitWriteMeals: Bool = true
-    @ObservationIgnored @AppStorage("healthKitWriteSymptoms") var healthKitWriteSymptoms: Bool = true
+    // MARK: - Stored properties (tracked by @Observable)
+
+    var languageRaw: String {
+        didSet { Self.defaults.set(languageRaw, forKey: "appLanguage") }
+    }
+    var unitRaw: String {
+        didSet { Self.defaults.set(unitRaw, forKey: "unitOfMeasure") }
+    }
+    var colorSchemeRaw: String {
+        didSet { Self.defaults.set(colorSchemeRaw, forKey: "appColorScheme") }
+    }
+    var healthKitSyncEnabled: Bool {
+        didSet { Self.defaults.set(healthKitSyncEnabled, forKey: "healthKitSyncEnabled") }
+    }
+    var healthKitWriteMeals: Bool {
+        didSet { Self.defaults.set(healthKitWriteMeals, forKey: "healthKitWriteMeals") }
+    }
+    var healthKitWriteSymptoms: Bool {
+        didSet { Self.defaults.set(healthKitWriteSymptoms, forKey: "healthKitWriteSymptoms") }
+    }
+
+    // MARK: - Init (read current values from UserDefaults)
+
+    init() {
+        let defaults = Self.defaults
+        self.languageRaw = defaults.string(forKey: "appLanguage") ?? AppLanguage.english.rawValue
+        self.unitRaw = defaults.string(forKey: "unitOfMeasure") ?? UnitSystem.metric.rawValue
+        self.colorSchemeRaw = defaults.string(forKey: "appColorScheme") ?? AppColorScheme.system.rawValue
+        self.healthKitSyncEnabled = defaults.object(forKey: "healthKitSyncEnabled") as? Bool ?? true
+        self.healthKitWriteMeals = defaults.object(forKey: "healthKitWriteMeals") as? Bool ?? true
+        self.healthKitWriteSymptoms = defaults.object(forKey: "healthKitWriteSymptoms") as? Bool ?? true
+    }
+
+    // MARK: - Computed convenience properties
 
     var language: AppLanguage {
         get { AppLanguage(rawValue: languageRaw) ?? .english }

--- a/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Settings/SettingsViewModel.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-class SettingsViewModel: ObservableObject {
-    @AppStorage("appLanguage") var languageRaw: String = AppLanguage.english.rawValue
-    @AppStorage("unitOfMeasure") var unitRaw: String = UnitSystem.metric.rawValue
-    @AppStorage("appColorScheme") var colorSchemeRaw: String = AppColorScheme.system.rawValue
+@Observable class SettingsViewModel {
+    @ObservationIgnored @AppStorage("appLanguage") var languageRaw: String = AppLanguage.english.rawValue
+    @ObservationIgnored @AppStorage("unitOfMeasure") var unitRaw: String = UnitSystem.metric.rawValue
+    @ObservationIgnored @AppStorage("appColorScheme") var colorSchemeRaw: String = AppColorScheme.system.rawValue
 
     // HealthKit write preferences
-    @AppStorage("healthKitSyncEnabled") var healthKitSyncEnabled: Bool = true
-    @AppStorage("healthKitWriteMeals") var healthKitWriteMeals: Bool = true
-    @AppStorage("healthKitWriteSymptoms") var healthKitWriteSymptoms: Bool = true
+    @ObservationIgnored @AppStorage("healthKitSyncEnabled") var healthKitSyncEnabled: Bool = true
+    @ObservationIgnored @AppStorage("healthKitWriteMeals") var healthKitWriteMeals: Bool = true
+    @ObservationIgnored @AppStorage("healthKitWriteSymptoms") var healthKitWriteSymptoms: Bool = true
 
     var language: AppLanguage {
         get { AppLanguage(rawValue: languageRaw) ?? .english }

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -11,19 +11,19 @@ import FirebaseAuth
 import UserNotifications
 
 @MainActor
-class LogSymptomViewModel: ObservableObject, HasLoadingState {
+@Observable class LogSymptomViewModel: HasLoadingState {
     // Form state (unchanged)
-    @Published var symptomDate = Date.now
-    @Published var selectedStoolType: StoolType?
-    @Published var selectedPainLevel: Int = 0
-    @Published var selectedUrgencyLevel: UrgencyLevel = .none
-    @Published var selectedTags: Set<String> = []
-    @Published var customTag: String = ""
-    @Published var notes: String = ""
+    var symptomDate = Date.now
+    var selectedStoolType: StoolType?
+    var selectedPainLevel: Int = 0
+    var selectedUrgencyLevel: UrgencyLevel = .none
+    var selectedTags: Set<String> = []
+    var customTag: String = ""
+    var notes: String = ""
     
     // UI state (unchanged)
-    @Published var showingSuccessAlert = false
-    @Published var showingErrorAlert = false
+    var showingSuccessAlert = false
+    var showingErrorAlert = false
     
     let loadingState = LoadingStateManager()
     

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 class SymptomDetailViewModel: DetailViewModel<Symptom> {
-    @Published var symptomId: String?
+    var symptomId: String?
     
     private let repository: SymptomRepository
     

--- a/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
@@ -2,15 +2,15 @@ import SwiftUI
 import FirebaseFirestore
 
 @MainActor
-class SymptomHistoryViewModel: ObservableObject {
-    @Published var groupedSymptoms: [Date: [Symptom]] = [:]
-    @Published var isLoading = false
-    @Published var isLoadingMore = false
-    @Published var hasMoreData = true
-    @Published var error: Error?
-    @Published var startDate = Date.distantPast
-    @Published var endDate = Date.now
-    @Published var selectedFilter: SymptomFilter = .all
+@Observable class SymptomHistoryViewModel {
+    var groupedSymptoms: [Date: [Symptom]] = [:]
+    var isLoading = false
+    var isLoadingMore = false
+    var hasMoreData = true
+    var error: Error?
+    var startDate = Date.distantPast
+    var endDate = Date.now
+    var selectedFilter: SymptomFilter = .all
     
     private let firebaseManager = FirebaseManager.shared
     private var lastDocument: DocumentSnapshot?

--- a/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
+++ b/GutCheck/GutCheck/Views/Admin/DataDeletionAdminView.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 
 struct DataDeletionAdminView: View {
-    @StateObject private var deletionService = DataDeletionService.shared
+    @State private var deletionService = DataDeletionService.shared
     @State private var deletionRequests: [DataDeletionRequest] = []
     @State private var selectedRequest: DataDeletionRequest?
     @State private var showingRequestDetail = false

--- a/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CategoryInsightsView: View {
     let category: InsightCategory
-    @StateObject private var viewModel = CategoryInsightsViewModel()
+    @State private var viewModel = CategoryInsightsViewModel()
     
     var body: some View {
         ScrollView {

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct InsightDetailView: View {
     let insight: HealthInsight
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel = InsightDetailViewModel()
+    @State private var viewModel = InsightDetailViewModel()
     
     var body: some View {
         ScrollView {

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct InsightsView: View {
-    @EnvironmentObject var authService: AuthService
-    @EnvironmentObject var router: AppRouter
-    @StateObject private var viewModel = InsightsViewModel()
+    @Environment(AuthService.self) var authService
+    @Environment(AppRouter.self) var router
+    @State private var viewModel = InsightsViewModel()
     
     var body: some View {
         NavigationStack {
@@ -451,11 +451,11 @@ private struct RecommendationCard: View {
 
 #Preview {
     InsightsView()
-        .environmentObject(AuthService())
-        .environmentObject(AppRouter.shared)
+        .environment(AuthService())
+        .environment(AppRouter.shared)
 }
 
 #Preview {
     InsightsView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct AppRoot: View {
-    @StateObject private var router = AppRouter.shared
-    @StateObject private var refreshManager = RefreshManager.shared
-    @EnvironmentObject var authService: AuthService
-    @EnvironmentObject var serverStatusService: ServerStatusService
+    @State private var router = AppRouter.shared
+    @State private var refreshManager = RefreshManager.shared
+    @Environment(AuthService.self) var authService
+    @Environment(ServerStatusService.self) var serverStatusService
     @State private var showingServerStatusSheet = false
     
     var body: some View {
@@ -52,7 +52,7 @@ struct AppRoot: View {
             // Server status sheet (separate from router sheets)
             .sheet(isPresented: $showingServerStatusSheet) {
                 ServerStatusSheet()
-                    .environmentObject(serverStatusService)
+                    .environment(serverStatusService)
             }
             
             // Handle the sheet presentations
@@ -62,45 +62,45 @@ struct AppRoot: View {
                     case .profile:
                         if let currentUser = authService.currentUser {
                             UserProfileView(user: currentUser)
-                                .environmentObject(authService)
+                                .environment(authService)
                         } else {
                             Text("User information unavailable")
-                                .environmentObject(authService)
+                                .environment(authService)
                         }
                     case .mealForm(let id):
                         MealBuilderView(mealId: id)
-                            .environmentObject(router)
-                            .environmentObject(refreshManager)
+                            .environment(router)
+                            .environment(refreshManager)
                     case .symptomForm(let id):
                         if id != nil {
                             // Edit existing symptom - need to create LogSymptomView_New with id support
                             LogSymptomView()
-                                .environmentObject(router)
-                                .environmentObject(refreshManager)
+                                .environment(router)
+                                .environment(refreshManager)
                         } else {
                             // Create new symptom
                             LogSymptomView()
-                                .environmentObject(router)
-                                .environmentObject(refreshManager)
+                                .environment(router)
+                                .environment(refreshManager)
                         }
                     case .logEntry:
                         LogEntryView()
-                            .environmentObject(router)
+                            .environment(router)
                     }
                 }
             }
         }
 
-        .environmentObject(router)
-        .environmentObject(refreshManager)
+        .environment(router)
+        .environment(refreshManager)
     }
 }
 
 // MARK: - Shared Navigation Destinations
 
 private struct AppNavigationDestinations: ViewModifier {
-    @ObservedObject var router: AppRouter
-    @ObservedObject var refreshManager: RefreshManager
+    var router: AppRouter
+    var refreshManager: RefreshManager
 
     func body(content: Content) -> some View {
         content
@@ -113,16 +113,16 @@ private struct AppNavigationDestinations: ViewModifier {
                 case .mealDetail(let id):
                     if let id = id {
                         MealDetailView(mealId: id)
-                            .environmentObject(router)
-                            .environmentObject(refreshManager)
+                            .environment(router)
+                            .environment(refreshManager)
                     } else {
                         Text("Invalid meal")
                     }
                 case .symptomDetail(let id):
                     if let id = id {
                         SymptomDetailView(symptomId: id)
-                            .environmentObject(router)
-                            .environmentObject(refreshManager)
+                            .environment(router)
+                            .environment(refreshManager)
                     } else {
                         Text("Invalid symptom")
                     }
@@ -143,5 +143,5 @@ extension View {
 
 #Preview {
     AppRoot()
-        .environmentObject(PreviewAuthService())
+        .environment(PreviewAuthService())
 }

--- a/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/EmailVerificationView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EmailVerificationView: View {
-    @ObservedObject var authService: AuthService
+    var authService: AuthService
     @State private var showResendSuccess = false
     
     var body: some View {

--- a/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/RegisterView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import FirebaseAuth
 
 struct RegisterView: View {
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     @Environment(\.dismiss) private var dismiss
     
     @State private var email = ""
@@ -171,5 +171,5 @@ struct RegisterView: View {
 
 #Preview {
     RegisterView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct WelcomeView: View {
-    @EnvironmentObject var authViewModel: AuthenticationViewModel
+    @Environment(AuthenticationViewModel.self) var authViewModel
     @State private var currentPage = 0
     
     private let pages = [
@@ -103,19 +103,19 @@ private struct WelcomePageView: View {
 
 #Preview {
     WelcomeView()
-        .environmentObject(AuthenticationViewModel(authService: AuthService()))
+        .environment(AuthenticationViewModel(authService: AuthService()))
 }
 
 // MARK: - Preview Helpers
 
-private class MockAuthService: AuthenticationProtocol {
-    @Published var isAuthStateResolved = true
-    @Published var isAuthenticated = false
-    @Published var isLoading = false
-    @Published var errorMessage: String?
-    @Published var isPhoneVerificationInProgress = false
-    @Published var isAwaitingEmailVerification = false
-    @Published var currentUser: User?
+@Observable private class MockAuthService: AuthenticationProtocol {
+    var isAuthStateResolved = true
+    var isAuthenticated = false
+    var isLoading = false
+    var errorMessage: String?
+    var isPhoneVerificationInProgress = false
+    var isAwaitingEmailVerification = false
+    var currentUser: User?
     
     func signIn(email: String, password: String) async throws {}
     func signUp(email: String, password: String, firstName: String, lastName: String, privacyPolicyAccepted: Bool) async throws {}

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct AuthenticationView: View {
-    @StateObject private var viewModel: AuthenticationViewModel
-    @ObservedObject private var authService: AuthService
+    @State private var viewModel: AuthenticationViewModel
+    private var authService: AuthService
     
     init(authService: AuthService) {
         self.authService = authService
-        self._viewModel = StateObject(wrappedValue: AuthenticationViewModel(authService: authService))
+        self._viewModel = State(wrappedValue: AuthenticationViewModel(authService: authService))
     }
     
     var body: some View {

--- a/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/LogSymptomView.swift
@@ -311,8 +311,8 @@ struct TagSelectionView: View {
 
 struct LogSymptomView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var authService: AuthService
-    @StateObject private var coordinator = LogSymptomViewModel()
+    @Environment(AuthService.self) var authService
+    @State private var coordinator = LogSymptomViewModel()
     @State private var showProfileSheet = false
     @State private var infoTypeToShow: SymptomInfoType? = nil
     @State private var showingDatePicker = false
@@ -633,6 +633,6 @@ struct SectionHeader: View {
 #if DEBUG
 #Preview {
     LogSymptomView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }
 #endif

--- a/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/PaginatedSymptomHistoryView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct PaginatedSymptomHistoryView: View {
-    @StateObject private var viewModel = SymptomHistoryViewModel()
-    @EnvironmentObject var authService: AuthService
+    @State private var viewModel = SymptomHistoryViewModel()
+    @Environment(AuthService.self) var authService
     @State private var optionalStartDate: Date? = nil
     @State private var optionalEndDate: Date? = nil
     
@@ -367,5 +367,5 @@ extension StoolType {
 
 #Preview {
     PaginatedSymptomHistoryView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomDetailView.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
 struct SymptomDetailView: View {
-    @StateObject private var viewModel: SymptomDetailViewModel
+    @State private var viewModel: SymptomDetailViewModel
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var refreshManager: RefreshManager
+    @Environment(AppRouter.self) var router
+    @Environment(RefreshManager.self) var refreshManager
     @State private var showingEditSheet = false
 
     // New initializer that takes a symptom ID
     init(symptomId: String) {
-        self._viewModel = StateObject(wrappedValue: SymptomDetailViewModel(symptomId: symptomId))
+        self._viewModel = State(wrappedValue: SymptomDetailViewModel(symptomId: symptomId))
     }
 
     // Keep the original initializer for backward compatibility
     init(symptom: Symptom) {
-        self._viewModel = StateObject(wrappedValue: SymptomDetailViewModel(entity: symptom))
+        self._viewModel = State(wrappedValue: SymptomDetailViewModel(entity: symptom))
     }
 
     var body: some View {
@@ -425,8 +425,8 @@ struct SymptomDetailView: View {
 
 #Preview {
     SymptomDetailView(symptom: Symptom.sampleSymptom())
-        .environmentObject(AppRouter.shared)
-        .environmentObject(RefreshManager.shared)
+        .environment(AppRouter.shared)
+        .environment(RefreshManager.shared)
 }
 
 // Add this if not available elsewhere

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 struct SymptomHistoryView: View {
-    @StateObject private var viewModel = SymptomHistoryViewModel()
+    @State private var viewModel = SymptomHistoryViewModel()
     @State private var selectedFilter: SymptomFilter = .all
     @State private var showingDatePicker = false
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var authService: AuthService
+    @Environment(AppRouter.self) var router
+    @Environment(AuthService.self) var authService
     
     private var symptomsList: some View {
         let sortedDates = viewModel.groupedSymptoms.keys.sorted(by: >)

--- a/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct CalendarDetailView: View {
     let date: Date
-    @StateObject private var viewModel = CalendarDetailViewModel()
-    @EnvironmentObject private var authService: AuthService
-    @EnvironmentObject private var router: AppRouter
+    @State private var viewModel = CalendarDetailViewModel()
+    @Environment(AuthService.self) private var authService
+    @Environment(AppRouter.self) private var router
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
@@ -92,6 +92,6 @@ struct CalendarDetailView: View {
     NavigationStack {
         CalendarDetailView(date: Date.now)
     }
-    .environmentObject(AuthService())
-    .environmentObject(AppRouter.shared)
+    .environment(AuthService())
+    .environment(AppRouter.shared)
 }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -18,10 +18,10 @@ import UIKit
 import Foundation // Required for Tab enum
 
 struct CalendarView: View {
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var authService: AuthService
-    @EnvironmentObject var refreshManager: RefreshManager
-    @StateObject private var viewModel = CalendarViewModel()
+    @Environment(AppRouter.self) var router
+    @Environment(AuthService.self) var authService
+    @Environment(RefreshManager.self) var refreshManager
+    @State private var viewModel = CalendarViewModel()
     @State private var isShowingActionMenu = false
     @State private var showNutritionDetail = false
 
@@ -237,8 +237,8 @@ struct CalendarView: View {
 // Static header for the meals section: DailyNutritionCard + Log Meal button + section title.
 // Kept as a separate view to reduce compiler complexity in CalendarView.
 struct CalendarMealsSectionHeader: View {
-    @ObservedObject var viewModel: CalendarViewModel
-    @EnvironmentObject var router: AppRouter
+    var viewModel: CalendarViewModel
+    @Environment(AppRouter.self) var router
     let onNutritionTap: () -> Void
 
     var body: some View {
@@ -289,8 +289,8 @@ struct CalendarMealsSectionHeader: View {
 // Static header for the symptoms section: DailySymptomCard + Log Symptom button + section title.
 // Kept as a separate view to reduce compiler complexity in CalendarView.
 struct CalendarSymptomsSectionHeader: View {
-    @ObservedObject var viewModel: CalendarViewModel
-    @EnvironmentObject var router: AppRouter
+    var viewModel: CalendarViewModel
+    @Environment(AppRouter.self) var router
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -364,13 +364,13 @@ struct EmptyStateCard: View {
 }
 
 // MARK: - ViewModel
-class CalendarViewModel: ObservableObject {
-    @Published var selectedDate = Date.now
-    @Published var meals: [Meal] = []
-    @Published var symptoms: [Symptom] = []
-    @Published var isLoadingMeals = false
-    @Published var isLoadingSymptoms = false
-    @Published var calendarDays: [CalendarDay] = []
+@Observable class CalendarViewModel {
+    var selectedDate = Date.now
+    var meals: [Meal] = []
+    var symptoms: [Symptom] = []
+    var isLoadingMeals = false
+    var isLoadingSymptoms = false
+    var calendarDays: [CalendarDay] = []
     
 
     
@@ -1263,6 +1263,6 @@ private struct NutritionDetailFoodRow: View {
 // MARK: - Preview
 #Preview {
     CalendarView(selectedTab: Tab.meals)
-        .environmentObject(AppRouter())
-        .environmentObject(AuthService())
+        .environment(AppRouter())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct UnifiedCalendarView: View {
-    @StateObject private var viewModel = CalendarViewModel()
+    @State private var viewModel = CalendarViewModel()
     @State private var selectedDate = Date.now
     @State private var showingDatePicker = false
     

--- a/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CustomTabBar: View {
     @Binding var selectedTab: Tab
     let actionHandler: (TabBarAction) -> Void
-    @EnvironmentObject var router: AppRouter
+    @Environment(AppRouter.self) var router
     
     // Using shared Tab enum from Models/Core/Tab.swift
 

--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -5,7 +5,7 @@ struct ProfileAvatarButton: View {
     let size: CGFloat
     let action: () -> Void
     
-    @StateObject private var profileImageService = UnifiedProfileImageService(strategy: LocalProfileImageStrategy())
+    @State private var profileImageService = UnifiedProfileImageService(strategy: LocalProfileImageStrategy())
     @State private var profileImage: UIImage?
     @State private var isLoadingImage = false
     

--- a/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
+++ b/GutCheck/GutCheck/Views/Components/ReauthenticationView.swift
@@ -16,7 +16,7 @@ struct ReauthenticationView: View {
     let onSuccess: () -> Void
     let onCancel: () -> Void
     
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     @State private var email = ""
     @State private var password = ""
     @State private var showPhoneAuth = false
@@ -147,7 +147,7 @@ struct PhoneReauthenticationView: View {
     let onSuccess: () -> Void
     let onCancel: () -> Void
     
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     @State private var phoneNumber = ""
     @State private var verificationCode = ""
     @State private var codeSent = false

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -11,7 +11,7 @@ struct UnifiedFoodDetailView: View {
     @State private var foodItem: FoodItem
     @State private var servingMultiplier: Double = 1.0
     @State private var customQuantity: String = ""
-    @StateObject private var detailService = FoodDetailService.shared
+    @State private var detailService = FoodDetailService.shared
     
     private let config: FoodDetailConfig
     private let baseNutrition: NutritionInfo

--- a/GutCheck/GutCheck/Views/ContentView.swift
+++ b/GutCheck/GutCheck/Views/ContentView.swift
@@ -1,7 +1,7 @@
 #Preview {
     ContentView()
-        .environmentObject(AuthService())
-        .environmentObject(AppRouter.shared)
+        .environment(AuthService())
+        .environment(AppRouter.shared)
 }
 //
 //  ContentView.swift
@@ -13,8 +13,8 @@
 import SwiftUI
 
 struct ContentView: View {
-    @EnvironmentObject var authService: AuthService
-    @ObservedObject var router = AppRouter.shared
+    @Environment(AuthService.self) var authService
+    @Bindable var router = AppRouter.shared
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -44,7 +44,7 @@ struct ContentView: View {
                 handleTabBarAction(action)
             }
         }
-        .environmentObject(router)
+        .environment(router)
         .background(ColorTheme.background.ignoresSafeArea())
 
     }
@@ -94,13 +94,13 @@ struct ContentView: View {
             }
         case .mealForm(_):
             MealBuilderView()
-                .environmentObject(router)
+                .environment(router)
         case .symptomForm(_):
             LogSymptomView()
-                .environmentObject(router)
+                .environment(router)
         case .logEntry:
             LogEntryView()
-                .environmentObject(router)
+                .environment(router)
         }
     }
     

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
@@ -27,19 +27,19 @@ struct DashboardView: View {
     // MARK: - Environment Objects
     
     /// Authentication service for user management and data access
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     
     /// Navigation router for programmatic navigation
-    @EnvironmentObject var router: AppRouter
+    @Environment(AppRouter.self) var router
     
     /// Data store containing dashboard-specific data and insights
-    @StateObject private var dashboardStore = DashboardDataStore(preview: false)
+    @State private var dashboardStore = DashboardDataStore(preview: false)
     
     /// View model for recent activity display
-    @StateObject private var recentActivityViewModel = RecentActivityViewModel()
+    @State private var recentActivityViewModel = RecentActivityViewModel()
 
     /// Manager for coordinating data refresh across the app
-    @EnvironmentObject private var refreshManager: RefreshManager
+    @Environment(RefreshManager.self) private var refreshManager
 
     var body: some View {
         VStack(spacing: 0) {
@@ -471,8 +471,8 @@ struct DashboardInsightsView: View {
 
 #Preview {
     DashboardView()
-        .environmentObject(PreviewAuthService())
-        .environmentObject(AppRouter.shared)
-        .environmentObject(RefreshManager.shared)
+        .environment(PreviewAuthService())
+        .environment(AppRouter.shared)
+        .environment(RefreshManager.shared)
 
 }

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView_Previews+Env.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView_Previews+Env.swift
@@ -3,5 +3,5 @@ import SwiftUI
 // This preview injects a dummy AuthService so @EnvironmentObject is satisfied
 #Preview {
     DashboardView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/GreetingHeaderView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct GreetingHeaderView: View {
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     
     private var greeting: String {
         if let user = authService.currentUser {

--- a/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/RecentActivityListView.swift
@@ -3,9 +3,9 @@ import FirebaseFirestore
 import FirebaseAuth
 
 struct RecentActivityListView: View {
-    @StateObject private var viewModel = RecentActivityViewModel()
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var authService: AuthService
+    @State private var viewModel = RecentActivityViewModel()
+    @Environment(AppRouter.self) var router
+    @Environment(AuthService.self) var authService
     let selectedDate: Date
     
     var body: some View {

--- a/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/TodaysActivitySummaryView.swift
@@ -3,9 +3,9 @@ import FirebaseFirestore
 import FirebaseAuth
 
 struct TodaysActivitySummaryView: View {
-    @ObservedObject var viewModel: RecentActivityViewModel
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var authService: AuthService
+    var viewModel: RecentActivityViewModel
+    @Environment(AppRouter.self) var router
+    @Environment(AuthService.self) var authService
     let selectedDate: Date
     @State private var isExpanded = false
     
@@ -147,7 +147,7 @@ struct TodaysActivitySummaryView: View {
         viewModel: RecentActivityViewModel(),
         selectedDate: Date.now
     )
-    .environmentObject(AppRouter.shared)
-    .environmentObject(PreviewAuthService())
+    .environment(AppRouter.shared)
+    .environment(PreviewAuthService())
     .padding()
 }

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Comprehensive insights dashboard showing food triggers, patterns, and recommendations
 struct InsightsDashboardView: View {
-    @StateObject private var insightsService = InsightsService.shared
+    @State private var insightsService = InsightsService.shared
     @State private var selectedTimeRange: TimeRange = .last30Days
     @State private var selectedCategory: InsightCategory? = nil
     

--- a/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
+++ b/GutCheck/GutCheck/Views/LogEntry/LogEntryView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct LogEntryView: View {
-    @EnvironmentObject var router: AppRouter
+    @Environment(AppRouter.self) var router
     
     var body: some View {
         VStack(spacing: 40) {
@@ -62,5 +62,5 @@ struct LogOptionButton: View {
 
 #Preview {
     LogEntryView()
-        .environmentObject(AppRouter.shared)
+        .environment(AppRouter.shared)
 }

--- a/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
+++ b/GutCheck/GutCheck/Views/Meal/FoodSearchView.swift
@@ -10,8 +10,8 @@ import Combine
 
 struct FoodSearchView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var serverStatus: ServerStatusService
-    @StateObject private var viewModel = FoodSearchViewModel()
+    @Environment(ServerStatusService.self) private var serverStatus
+    @State private var viewModel = FoodSearchViewModel()
     @State private var navigationPath = NavigationPath()
     @State private var selectedFoodItem: FoodItem?
     var onSelect: ((FoodItem) -> Void)?

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -12,9 +12,9 @@ struct MealBuilderView: View {
     var mealId: String? = nil
 
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var refreshManager: RefreshManager
-    @StateObject private var mealService = MealBuilderService.shared
+    @Environment(AppRouter.self) var router
+    @Environment(RefreshManager.self) var refreshManager
+    @State private var mealService = MealBuilderService.shared
     @State private var showingDatePicker = false
     @State private var showingConfirmation = false
     @State private var showingDiscard = false
@@ -303,7 +303,7 @@ struct MealBuilderView: View {
                     MealBuilderService.shared.addFoodItem(foodItem)
                     showingFoodOptions = false
                 }
-                .environmentObject(router)
+                .environment(router)
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct MealConfirmationView: View {
     let meal: Meal
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var router: AppRouter
-    @EnvironmentObject private var serverStatus: ServerStatusService
-    @StateObject private var viewModel = MealConfirmationViewModel()
+    @Environment(AppRouter.self) private var router
+    @Environment(ServerStatusService.self) private var serverStatus
+    @State private var viewModel = MealConfirmationViewModel()
     
     var body: some View {
         ScrollView {
@@ -298,7 +298,7 @@ struct MealAnalysis {
             notes: "Quick lunch at home",
             createdBy: "preview-user"
         ))
-        .environmentObject(AppRouter.shared)
-        .environmentObject(ServerStatusService.shared)
+        .environment(AppRouter.shared)
+        .environment(ServerStatusService.shared)
     }
 }

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationViewModel.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationViewModel.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-class MealConfirmationViewModel: ObservableObject {
-    @Published private(set) var totalNutrition: NutritionInfo?
-    @Published private(set) var aiAnalysis: MealAnalysis?
-    @Published private(set) var errorMessage: String?
-    @Published var showError = false
-    @Published var isSaving = false
+@Observable class MealConfirmationViewModel {
+    private(set) var totalNutrition: NutritionInfo?
+    private(set) var aiAnalysis: MealAnalysis?
+    private(set) var errorMessage: String?
+    var showError = false
+    var isSaving = false
     
     @MainActor
     func analyzeMeal(_ meal: Meal) async {

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -2,19 +2,19 @@ import SwiftUI
 import FirebaseFirestore
 
 struct MealDetailView: View {
-    @StateObject private var viewModel: MealDetailViewModel
+    @State private var viewModel: MealDetailViewModel
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var refreshManager: RefreshManager
+    @Environment(AppRouter.self) var router
+    @Environment(RefreshManager.self) var refreshManager
     
     // New initializer that takes a meal ID
     init(mealId: String) {
-        self._viewModel = StateObject(wrappedValue: MealDetailViewModel(mealId: mealId))
+        self._viewModel = State(wrappedValue: MealDetailViewModel(mealId: mealId))
     }
     
     // Keep the original initializer for backward compatibility
     init(meal: Meal) {
-        self._viewModel = StateObject(wrappedValue: MealDetailViewModel(meal: meal))
+        self._viewModel = State(wrappedValue: MealDetailViewModel(meal: meal))
     }
     
     var body: some View {
@@ -296,6 +296,6 @@ struct MealDetailView: View {
 
 #Preview {
     MealDetailView(meal: Meal.sampleMeal)
-        .environmentObject(AppRouter.shared)
-        .environmentObject(RefreshManager.shared)
+        .environment(AppRouter.shared)
+        .environment(RefreshManager.shared)
 }

--- a/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealLoggingOptionsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MealLoggingOptionsView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var router: AppRouter
+    @Environment(AppRouter.self) var router
     @State private var showingSearchView = false
     
     var body: some View {
@@ -80,7 +80,7 @@ struct MealLoggingOptionsView: View {
                     // Close the search sheet to return to MealBuilderView
                     showingSearchView = false
                 }
-                .environmentObject(router)
+                .environment(router)
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
@@ -91,6 +91,6 @@ struct MealLoggingOptionsView: View {
 // Preview
 #Preview {
     MealLoggingOptionsView()
-        .environmentObject(AppRouter.shared)
+        .environment(AppRouter.shared)
 }
 

--- a/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
+++ b/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AddMedicationView: View {
-    @StateObject private var viewModel = AddMedicationViewModel()
+    @State private var viewModel = AddMedicationViewModel()
     @Environment(\.dismiss) private var dismiss
 
     /// Called after a successful save so the parent list can refresh.

--- a/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
+++ b/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct LogMedicationDoseView: View {
-    @StateObject private var viewModel = LogMedicationDoseViewModel()
+    @State private var viewModel = LogMedicationDoseViewModel()
     @Environment(\.dismiss) private var dismiss
 
     var onSave: (() -> Void)?

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -11,10 +11,10 @@ import SwiftUI
 // MARK: - Main View
 
 struct MedicationCalendarView: View {
-    @EnvironmentObject var authService: AuthService
-    @EnvironmentObject var router: AppRouter
-    @EnvironmentObject var refreshManager: RefreshManager
-    @StateObject private var viewModel = MedicationCalendarViewModel()
+    @Environment(AuthService.self) var authService
+    @Environment(AppRouter.self) var router
+    @Environment(RefreshManager.self) var refreshManager
+    @State private var viewModel = MedicationCalendarViewModel()
     @State private var showingLogDose        = false
     @State private var showingAddMedication  = false
 
@@ -132,7 +132,7 @@ struct MedicationCalendarView: View {
 // MARK: - Medications Section Header
 
 struct CalendarMedicationsSectionHeader: View {
-    @ObservedObject var viewModel: MedicationCalendarViewModel
+    var viewModel: MedicationCalendarViewModel
     let onLogDose: () -> Void
 
     var body: some View {
@@ -328,10 +328,10 @@ struct DoseCalendarRow: View {
 // MARK: - ViewModel
 
 @MainActor
-class MedicationCalendarViewModel: ObservableObject {
-    @Published var selectedDate = Date.now
-    @Published var doses: [MedicationDoseLog] = []
-    @Published var isLoading = false
+@Observable class MedicationCalendarViewModel {
+    var selectedDate = Date.now
+    var doses: [MedicationDoseLog] = []
+    var isLoading = false
 
     private let doseRepo: MedicationDoseRepository
 
@@ -368,7 +368,7 @@ class MedicationCalendarViewModel: ObservableObject {
 // MARK: - Preview
 #Preview {
     MedicationCalendarView()
-        .environmentObject(AuthService())
-        .environmentObject(AppRouter.shared)
-        .environmentObject(RefreshManager.shared)
+        .environment(AuthService())
+        .environment(AppRouter.shared)
+        .environment(RefreshManager.shared)
 }

--- a/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct MedicationListView: View {
-    @StateObject private var viewModel = MedicationViewModel()
+    @State private var viewModel = MedicationViewModel()
 
     // MARK: - Body
 

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct MedicationsView: View {
-    @StateObject private var viewModel   = MedicationViewModel()
+    @State private var viewModel   = MedicationViewModel()
     @State private var showingLogDose    = false
     @State private var showingAddMed     = false
     @State private var todayDoses: [MedicationDoseLog] = []

--- a/GutCheck/GutCheck/Views/PhoneAuthView.swift
+++ b/GutCheck/GutCheck/Views/PhoneAuthView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct PhoneAuthView: View {
-    @StateObject private var viewModel: AuthenticationViewModel
-    @ObservedObject private var authService: AuthService
+    @State private var viewModel: AuthenticationViewModel
+    private var authService: AuthService
     @Environment(\.dismiss) private var dismiss
     
     init(authService: AuthService) {
         self.authService = authService
-        self._viewModel = StateObject(wrappedValue: AuthenticationViewModel(authService: authService))
+        self._viewModel = State(wrappedValue: AuthenticationViewModel(authService: authService))
     }
     
     var body: some View {

--- a/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
+++ b/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct DeleteAccountView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     @State private var showingReauthentication = false
     @State private var showingFinalConfirmation = false
     @State private var showingAlert = false
@@ -193,6 +193,6 @@ struct DataRow: View {
 #Preview {
     NavigationStack {
         DeleteAccountView()
-            .environmentObject(AuthService())
+            .environment(AuthService())
     }
 }

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 import HealthKit
 
 struct HealthDataIntegrationView: View {
-    @EnvironmentObject var settingsVM: SettingsViewModel
-    @EnvironmentObject var authService: AuthService
-    @StateObject private var healthKitVM = HealthKitViewModel()
+    @Environment(SettingsViewModel.self) var settingsVM
+    @Environment(AuthService.self) var authService
+    @State private var healthKitVM = HealthKitViewModel()
     @Environment(\.dismiss) private var dismiss
     @State private var showPermissionsGuide = false
 
     var body: some View {
+        @Bindable var settingsVM = settingsVM
         NavigationStack {
             Form {
 

--- a/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
+++ b/GutCheck/GutCheck/Views/Profile/ProfileSetupView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ProfileSetupView: View {
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     @State private var firstName: String = ""
     @State private var lastName: String = ""
     @State private var isSaving = false

--- a/GutCheck/GutCheck/Views/Profile/ProfileSheetView.swift
+++ b/GutCheck/GutCheck/Views/Profile/ProfileSheetView.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
 struct ProfileSheetView: View {
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
 
     var body: some View {
         Group {
             if let currentUser = authService.currentUser {
                 UserProfileView(user: currentUser)
-                    .environmentObject(authService)
+                    .environment(authService)
             } else if authService.isAuthenticated {
                 ProfileSetupView()
-                    .environmentObject(authService)
+                    .environment(authService)
             } else {
                 VStack(spacing: 20) {
                     ProgressView()

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -6,8 +6,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @EnvironmentObject var settingsVM: SettingsViewModel
-    @EnvironmentObject var authService: AuthService
+    @Environment(SettingsViewModel.self) var settingsVM
+    @Environment(AuthService.self) var authService
     @Environment(\.dismiss) private var dismiss
     @AppStorage("lastHealthKitSyncTimestamp") private var lastHealthKitSyncTimestamp: Double = 0
     @State private var showAppleHealth = false
@@ -263,15 +263,15 @@ struct SettingsView: View {
             }
             .sheet(isPresented: $showAppleHealth) {
                 HealthDataIntegrationView()
-                    .environmentObject(settingsVM)
-                    .environmentObject(authService)
+                    .environment(settingsVM)
+                    .environment(authService)
             }
         }
     }
 }
 
 struct LanguageSelectionView: View {
-    @EnvironmentObject var settingsVM: SettingsViewModel
+    @Environment(SettingsViewModel.self) var settingsVM
     var body: some View {
         List {
             ForEach(AppLanguage.allCases, id: \ .self) { lang in
@@ -304,7 +304,7 @@ struct LanguageSelectionView: View {
 }
 
 struct UnitSelectionView: View {
-    @EnvironmentObject var settingsVM: SettingsViewModel
+    @Environment(SettingsViewModel.self) var settingsVM
     var body: some View {
         List {
             ForEach(UnitSystem.allCases, id: \ .self) { unit in
@@ -337,7 +337,7 @@ struct UnitSelectionView: View {
 }
 
 struct AppearanceSelectionView: View {
-    @EnvironmentObject var settingsVM: SettingsViewModel
+    @Environment(SettingsViewModel.self) var settingsVM
     var body: some View {
         List {
             ForEach(AppColorScheme.allCases, id: \ .self) { scheme in

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -8,7 +8,7 @@ struct ProfileImageView: View {
     let user: User
     @Binding var profileImage: UIImage?
     @Binding var showImagePicker: Bool
-    @StateObject private var profileImageService = UnifiedProfileImageService(strategy: LocalProfileImageStrategy())
+    @State private var profileImageService = UnifiedProfileImageService(strategy: LocalProfileImageStrategy())
     @State private var isLoadingImage = false
     @State private var showingUploadError = false
     
@@ -190,7 +190,7 @@ struct ImagePicker: UIViewControllerRepresentable {
 
 struct ProfileInfoSection: View {
     let user: User
-    @EnvironmentObject var settingsVM: SettingsViewModel
+    @Environment(SettingsViewModel.self) var settingsVM
     
     var body: some View {
         VStack(spacing: 24) {
@@ -247,13 +247,13 @@ import PhotosUI
 
 struct UserProfileView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var authService: AuthService
+    @Environment(AuthService.self) var authService
     let user: User
     
     @State private var profileImage: UIImage? = nil
     @State private var showImagePicker = false
     @State private var showSettings = false
-    @EnvironmentObject var settingsVM: SettingsViewModel
+    @Environment(SettingsViewModel.self) var settingsVM
 
     var body: some View {
         NavigationStack {
@@ -262,7 +262,7 @@ struct UserProfileView: View {
                     profileHeaderSection
                     
                     ProfileInfoSection(user: user)
-                        .environmentObject(settingsVM)
+                        .environment(settingsVM)
                     
                     ProfileActionSection(
                         showSettings: $showSettings,
@@ -285,8 +285,8 @@ struct UserProfileView: View {
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView()
-                    .environmentObject(settingsVM)
-                    .environmentObject(authService)
+                    .environment(settingsVM)
+                    .environment(authService)
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserRemindersView.swift
@@ -3,8 +3,8 @@ import UserNotifications
 import EventKit
 
 struct UserRemindersView: View {
-    @StateObject private var reminderService = ReminderSettingsService.shared
-    @StateObject private var remindersKit = RemindersKitService.shared
+    @State private var reminderService = ReminderSettingsService.shared
+    @State private var remindersKit = RemindersKitService.shared
     @State private var localSettings = ReminderSettings()
     @State private var showingSaveConfirmation = false
     @State private var showingRemindersPermissionDeniedAlert = false

--- a/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/OfflineBannerView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct OfflineBannerView: View {
-    @EnvironmentObject private var serverStatus: ServerStatusService
+    @Environment(ServerStatusService.self) private var serverStatus
     @Binding var showingStatusSheet: Bool
 
     var body: some View {

--- a/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
+++ b/GutCheck/GutCheck/Views/ServerStatus/ServerStatusSheet.swift
@@ -9,8 +9,8 @@
 import SwiftUI
 
 struct ServerStatusSheet: View {
-    @EnvironmentObject private var serverStatus: ServerStatusService
-    @ObservedObject private var syncService = DataSyncService.shared
+    @Environment(ServerStatusService.self) private var serverStatus
+    private var syncService = DataSyncService.shared
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -284,5 +284,5 @@ struct ServerStatusSheet: View {
 
 #Preview {
     ServerStatusSheet()
-        .environmentObject(ServerStatusService.shared)
+        .environment(ServerStatusService.shared)
 }

--- a/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 
 struct DataDeletionRequestView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var authService: AuthService
-    @StateObject private var deletionService = DataDeletionService.shared
+    @Environment(AuthService.self) var authService
+    @State private var deletionService = DataDeletionService.shared
     
     @State private var reason = ""
     @State private var deleteUserProfile = true
@@ -171,5 +171,5 @@ struct DataDeletionRequestView: View {
 
 #Preview {
     DataDeletionRequestView()
-        .environmentObject(AuthService())
+        .environment(AuthService())
 }

--- a/GutCheck/GutCheck/Views/Settings/DebugView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DebugView.swift
@@ -4,8 +4,8 @@ import Network
 
 struct DebugView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var authService: AuthService
-    @StateObject private var networkMonitor = NetworkMonitor()
+    @Environment(AuthService.self) private var authService
+    @State private var networkMonitor = NetworkMonitor()
     @State private var showingResetConfirmation = false
     @State private var isResetting = false
     @State private var resetError: Error?
@@ -139,7 +139,7 @@ private struct LogViewer: View {
 }
 
 private struct NetworkDebugger: View {
-    @StateObject private var viewModel = NetworkDebuggerViewModel()
+    @State private var viewModel = NetworkDebuggerViewModel()
     
     var body: some View {
         List(viewModel.requests) { request in
@@ -164,8 +164,8 @@ private struct NetworkDebugger: View {
 
 // MARK: - Supporting Types
 
-private class NetworkDebuggerViewModel: ObservableObject {
-    @Published var requests: [NetworkRequest] = []
+@Observable private class NetworkDebuggerViewModel {
+    var requests: [NetworkRequest] = []
     
     func loadRequests() {
         // Load network requests from debug storage

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct HealthcareExportView: View {
-    @StateObject private var exportService = HealthcareExportService.shared
+    @State private var exportService = HealthcareExportService.shared
     @State private var exportOptions = ExportOptions.default
     @State private var showingExportOptions = false
     @State private var showingShareSheet = false

--- a/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
+++ b/GutCheck/GutCheck/Views/Settings/LocalStorageSettingsView.swift
@@ -11,9 +11,9 @@ import SwiftUI
 import CoreData
 
 struct LocalStorageSettingsView: View {
-    @EnvironmentObject private var dataSyncService: DataSyncService
-    @EnvironmentObject private var localStorage: CoreDataStorageService
-    @EnvironmentObject private var coreDataStack: CoreDataStack
+    @Environment(DataSyncService.self) private var dataSyncService
+    @Environment(CoreDataStorageService.self) private var localStorage
+    @Environment(CoreDataStack.self) private var coreDataStack
     
     @State private var showingSyncAlert = false
     @State private var showingClearDataAlert = false
@@ -175,8 +175,8 @@ struct LocalStorageSettingsView: View {
 #Preview {
     NavigationStack {
         LocalStorageSettingsView()
-            .environmentObject(DataSyncService.shared)
-            .environmentObject(CoreDataStorageService.shared)
-            .environmentObject(CoreDataStack.shared)
+            .environment(DataSyncService.shared)
+            .environment(CoreDataStorageService.shared)
+            .environment(CoreDataStack.shared)
     }
 }

--- a/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/ReminderSettingsTestView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ReminderSettingsTestView: View {
-    @StateObject private var reminderService = ReminderSettingsService.shared
+    @State private var reminderService = ReminderSettingsService.shared
     
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## Summary
- Migrated 49 `ObservableObject` classes to the `@Observable` macro across 102 files
- Updated all view-side property wrappers: `@StateObject` → `@State`, `@ObservedObject` → `var`/`@Bindable`, `@EnvironmentObject` → `@Environment(Type.self)`
- Replaced all `.environmentObject()` injection with `.environment()`
- Decoupled 3 protocols from `ObservableObject` constraint (`AuthenticationProtocol`, `LoadingStateManaging`, `HasLoadingState`)
- Special-cased `SettingsViewModel` (`@AppStorage` → `@ObservationIgnored @AppStorage`) and `PermissionManager` (kept as `ObservableObject` due to `NSObject` inheritance)
- Added `@ObservationIgnored` to `lazy var` properties and `deinit`-accessed properties to avoid macro conflicts

## Test plan
- [x] Verify app launches and navigates between all tabs
- [ ] Verify authentication flow (sign in, sign up, sign out)
- [ ] Verify settings changes persist (language, units, color scheme)
- [ ] Verify HealthKit integration toggles work
- [ ] Verify meal and symptom logging workflows
- [ ] Verify medication tracking and calendar
- [ ] Verify dashboard data loads and refreshes
- [ ] Verify permission flows (camera, notifications, HealthKit)
- [ ] Verify profile and account deletion flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)