### PR TITLE
fix(#222): migrate NavigationLink(destination:) to value-based NavigationLink

### DIFF
--- a/GutCheck/GutCheck/Navigation/AppRouter.swift
+++ b/GutCheck/GutCheck/Navigation/AppRouter.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// Main navigation destinations
+// Main navigation destinations (used by AppRoot tab NavigationStacks)
 enum AppDestination: Hashable {
     case dashboard
     case calendar(Date)
@@ -8,6 +8,45 @@ enum AppDestination: Hashable {
     case symptomDetail(String? = nil) // nil for new symptom, String ID for existing
     case settings
     case analytics
+    case symptomHistory(Symptom)
+    case medicationList
+}
+
+// Settings sub-screen navigation
+enum SettingsRoute: Hashable {
+    case language
+    case units
+    case appearance
+    case reminders
+    case medications
+    case healthcareExport
+    case privacyPolicy
+    case dataDeletion
+    case localStorage
+    case deleteAccount
+}
+
+// Insights navigation
+enum InsightsRoute: Hashable {
+    case insightDetail(HealthInsight)
+    case categoryInsights(InsightCategory)
+}
+
+// Privacy policy navigation
+enum PrivacyPolicyRoute: Hashable {
+    case sectionDetail(PolicySection)
+}
+
+// Profile menu navigation
+enum ProfileMenuRoute: Hashable {
+    case settings
+    case reminders
+}
+
+// Calendar navigation
+enum CalendarRoute: Hashable {
+    case dayDetail(Date)
+    case fullCalendar(Date)
 }
 
 // Sheet presentations

--- a/GutCheck/GutCheck/Navigation/AppRouter.swift
+++ b/GutCheck/GutCheck/Navigation/AppRouter.swift
@@ -24,6 +24,32 @@ enum SettingsRoute: Hashable {
     case dataDeletion
     case localStorage
     case deleteAccount
+
+    @ViewBuilder
+    static func destinationView(for route: SettingsRoute) -> some View {
+        switch route {
+        case .language:
+            LanguageSelectionView()
+        case .units:
+            UnitSelectionView()
+        case .appearance:
+            AppearanceSelectionView()
+        case .reminders:
+            UserRemindersView()
+        case .medications:
+            MedicationListView()
+        case .healthcareExport:
+            HealthcareExportView()
+        case .privacyPolicy:
+            PrivacyPolicyView()
+        case .dataDeletion:
+            DataDeletionRequestView()
+        case .localStorage:
+            LocalStorageSettingsView()
+        case .deleteAccount:
+            DeleteAccountView()
+        }
+    }
 }
 
 // Insights navigation

--- a/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/CategoryInsightsView.swift
@@ -58,7 +58,7 @@ struct CategoryInsightsView: View {
                 .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.activeInsights) { insight in
-                NavigationLink(destination: InsightDetailView(insight: insight)) {
+                NavigationLink(value: InsightsRoute.insightDetail(insight)) {
                     ActiveInsightRow(insight: insight)
                 }
             }
@@ -72,7 +72,7 @@ struct CategoryInsightsView: View {
                 .foregroundStyle(ColorTheme.primaryText)
             
             ForEach(viewModel.historicalInsights) { insight in
-                NavigationLink(destination: InsightDetailView(insight: insight)) {
+                NavigationLink(value: InsightsRoute.insightDetail(insight)) {
                     HistoricalInsightRow(insight: insight)
                 }
             }

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -177,7 +177,7 @@ private struct RelatedInsightRow: View {
     let insight: HealthInsight
     
     var body: some View {
-        NavigationLink(destination: InsightDetailView(insight: insight)) {
+        NavigationLink(value: InsightsRoute.insightDetail(insight)) {
             HStack {
                 Label(insight.title, systemImage: insight.iconName)
                     .font(.subheadline)
@@ -193,7 +193,7 @@ private struct RelatedInsightRow: View {
 
 // MARK: - Supporting Types
 
-struct HealthInsight: Identifiable {
+struct HealthInsight: Identifiable, Hashable {
     let id = UUID()
     let title: String
     let summary: String

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -13,51 +13,57 @@ struct InsightsView: View {
     @State private var viewModel = InsightsViewModel()
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 24) {
-                    // Weekly Stats Row
-                    weeklyStatsRow
+        ScrollView {
+            VStack(spacing: 24) {
+                // Weekly Stats Row
+                weeklyStatsRow
 
-                    // Top Summary Cards
-                    topSymptomsCard
-                    triggerFoodsCard
-                    bestDaysCard
+                // Top Summary Cards
+                topSymptomsCard
+                triggerFoodsCard
+                bestDaysCard
 
-                    // Recent Insights Section
-                    if !viewModel.recentInsights.isEmpty {
-                        recentInsightsSection
-                    }
-                    
-                    // Categories Section
-                    insightCategoriesSection
-                    
-                    // Patterns Section
-                    if !viewModel.patterns.isEmpty {
-                        patternsSection
-                    }
-                    
-                    // Recommendations Section
-                    if !viewModel.recommendations.isEmpty {
-                        recommendationsSection
-                    }
+                // Recent Insights Section
+                if !viewModel.recentInsights.isEmpty {
+                    recentInsightsSection
                 }
-                .padding()
-            }
-            .navigationTitle("Insights")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    ProfileAvatarButton(user: authService.currentUser) {
-                        router.presentSheet(.profile)
-                    }
+                
+                // Categories Section
+                insightCategoriesSection
+                
+                // Patterns Section
+                if !viewModel.patterns.isEmpty {
+                    patternsSection
+                }
+                
+                // Recommendations Section
+                if !viewModel.recommendations.isEmpty {
+                    recommendationsSection
                 }
             }
-            .refreshable {
-                await viewModel.loadInsights()
+            .padding()
+        }
+        .navigationTitle("Insights")
+        .navigationDestination(for: InsightsRoute.self) { route in
+            switch route {
+            case .insightDetail(let insight):
+                InsightDetailView(insight: insight)
+            case .categoryInsights(let category):
+                CategoryInsightsView(category: category)
             }
-            .task {
-                await viewModel.loadInsights()
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ProfileAvatarButton(user: authService.currentUser) {
+                    router.presentSheet(.profile)
+                }
             }
+        }
+        .refreshable {
+            await viewModel.loadInsights()
+        }
+        .task {
+            await viewModel.loadInsights()
         }
     }
     
@@ -313,7 +319,7 @@ private struct AnalyticsInsightCard: View {
     let insight: HealthInsight
     
     var body: some View {
-        NavigationLink(destination: InsightDetailView(insight: insight)) {
+        NavigationLink(value: InsightsRoute.insightDetail(insight)) {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     Image(systemName: insight.iconName)
@@ -354,7 +360,7 @@ private struct CategoryCard: View {
     let category: InsightCategory
     
     var body: some View {
-        NavigationLink(destination: CategoryInsightsView(category: category)) {
+        NavigationLink(value: InsightsRoute.categoryInsights(category)) {
             VStack(spacing: 12) {
                 Image(systemName: category.iconName)
                     .font(.title)

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -34,6 +34,7 @@ struct AppRoot: View {
                 SwiftUI.Tab("Meds", systemImage: "pills.fill", value: GutCheck.Tab.medications) {
                     NavigationStack {
                         MedicationCalendarView()
+                            .withAppNavigationDestinations(router: router, refreshManager: refreshManager)
                     }
                 }
 
@@ -130,6 +131,10 @@ private struct AppNavigationDestinations: ViewModifier {
                     SettingsView()
                 case .analytics:
                     InsightsView()
+                case .symptomHistory(let symptom):
+                    SymptomDetailView(symptom: symptom)
+                case .medicationList:
+                    MedicationListView()
                 }
             }
     }

--- a/GutCheck/GutCheck/Views/AppRoot.swift
+++ b/GutCheck/GutCheck/Views/AppRoot.swift
@@ -137,6 +137,9 @@ private struct AppNavigationDestinations: ViewModifier {
                     MedicationListView()
                 }
             }
+            .navigationDestination(for: SettingsRoute.self) { route in
+                SettingsRoute.destinationView(for: route)
+            }
     }
 }
 

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -26,13 +26,9 @@ struct SymptomHistoryView: View {
     }
     
     private func symptomNavigationLink(for symptom: Symptom) -> some View {
-        NavigationLink(destination: symptomDetailView(for: symptom)) {
+        NavigationLink(value: AppDestination.symptomHistory(symptom)) {
             SymptomRow(symptom: symptom)
         }
-    }
-    
-    private func symptomDetailView(for symptom: Symptom) -> some View {
-        SymptomDetailView(symptom: symptom)
     }
     
     var body: some View {

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -35,7 +35,7 @@ struct UnifiedCalendarView: View {
                 
                 // Daily Summary
                 if let selectedDay = viewModel.calendarDays.first(where: { calendar.isDate($0.date, inSameDayAs: selectedDate) }) {
-                    NavigationLink(destination: CalendarDetailView(date: selectedDate)) {
+                    NavigationLink(value: CalendarRoute.dayDetail(selectedDate)) {
                         DailySummaryCard(day: selectedDay)
                             .padding()
                     }
@@ -44,6 +44,14 @@ struct UnifiedCalendarView: View {
                 Spacer()
             }
             .navigationTitle("Calendar")
+            .navigationDestination(for: CalendarRoute.self) { route in
+                switch route {
+                case .dayDetail(let date):
+                    CalendarDetailView(date: date)
+                case .fullCalendar(let date):
+                    CalendarView(selectedDate: date)
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: { showingDatePicker = true }) {

--- a/GutCheck/GutCheck/Views/ContentView.swift
+++ b/GutCheck/GutCheck/Views/ContentView.swift
@@ -34,6 +34,9 @@ struct ContentView: View {
                 .navigationDestination(for: AppDestination.self) { destination in
                     destinationView(for: destination)
                 }
+                .navigationDestination(for: SettingsRoute.self) { route in
+                    SettingsRoute.destinationView(for: route)
+                }
                 .sheet(item: $router.activeSheet) { sheet in
                     sheetView(for: sheet)
                 }

--- a/GutCheck/GutCheck/Views/ContentView.swift
+++ b/GutCheck/GutCheck/Views/ContentView.swift
@@ -80,6 +80,10 @@ struct ContentView: View {
             SettingsView()
         case .analytics:
             InsightsView()
+        case .symptomHistory(let symptom):
+            SymptomDetailView(symptom: symptom)
+        case .medicationList:
+            MedicationListView()
         }
     }
     

--- a/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/CalendarShortcutButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CalendarShortcutButton: View {
     var body: some View {
-        NavigationLink(destination: CalendarView(selectedDate: Date.now)) {
+        NavigationLink(value: AppDestination.calendar(Date.now)) {
             HStack {
                 Image(systemName: "calendar")
                     .foregroundStyle(ColorTheme.accent)

--- a/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationCalendarView.swift
@@ -100,7 +100,7 @@ struct MedicationCalendarView: View {
                 }
             }
             ToolbarItem(placement: .topBarLeading) {
-                NavigationLink(destination: MedicationListView()) {
+                NavigationLink(value: AppDestination.medicationList) {
                     Image(systemName: "list.bullet")
                         .accessibilityLabel("Manage medications")
                 }

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -168,7 +168,7 @@ struct MedicationsView: View {
             }
 
             // Link to full catalog
-            NavigationLink(destination: MedicationListView()) {
+            NavigationLink(value: AppDestination.medicationList) {
                 Text("Manage all medications…")
                     .font(.subheadline)
                     .foregroundStyle(.purple)

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -74,7 +74,7 @@ struct HealthDataIntegrationView: View {
                     header: Text("Medications"),
                     footer: Text("Track your medications manually within GutCheck to help surface insights about how they affect your gut health.")
                 ) {
-                    NavigationLink(destination: MedicationListView()) {
+                    NavigationLink(value: SettingsRoute.medications) {
                         Label("My Medications", systemImage: "pills.fill")
                             .foregroundStyle(.primary)
                     }
@@ -225,6 +225,14 @@ struct HealthDataIntegrationView: View {
                 }
             }
             .navigationTitle("Apple Health")
+            .navigationDestination(for: SettingsRoute.self) { route in
+                switch route {
+                case .medications:
+                    MedicationListView()
+                default:
+                    EmptyView()
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Close") { dismiss() }

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -24,7 +24,7 @@ struct SettingsView: View {
         NavigationStack {
             List {
                 Section("Preferences") {
-                    NavigationLink(destination: LanguageSelectionView()) {
+                    NavigationLink(value: SettingsRoute.language) {
                         HStack {
                             Text("Language")
                                 .typography(Typography.body)
@@ -37,7 +37,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Language: \(settingsVM.language.displayName)")
                     .accessibilityHint("Tap to change app language")
                     
-                    NavigationLink(destination: UnitSelectionView()) {
+                    NavigationLink(value: SettingsRoute.units) {
                         HStack {
                             Text("Units")
                                 .typography(Typography.body)
@@ -50,7 +50,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Units: \(settingsVM.unitOfMeasure.displayName)")
                     .accessibilityHint("Tap to change measurement units")
 
-                    NavigationLink(destination: AppearanceSelectionView()) {
+                    NavigationLink(value: SettingsRoute.appearance) {
                         HStack {
                             Text("Appearance")
                                 .typography(Typography.body)
@@ -65,7 +65,7 @@ struct SettingsView: View {
                 }
                 
                 Section("Notifications") {
-                    NavigationLink(destination: UserRemindersView()) {
+                    NavigationLink(value: SettingsRoute.reminders) {
                         HStack {
                             Image(systemName: "bell.badge")
                                 .foregroundStyle(.orange)
@@ -79,7 +79,7 @@ struct SettingsView: View {
                 }
 
                 Section("Medications") {
-                    NavigationLink(destination: MedicationListView()) {
+                    NavigationLink(value: SettingsRoute.medications) {
                         HStack {
                             Image(systemName: "pills.fill")
                                 .foregroundStyle(.purple)
@@ -114,7 +114,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Apple Health: \(appleHealthStatusText)")
                     .accessibilityHint("Tap to manage Apple Health sync")
 
-                    NavigationLink(destination: HealthcareExportView()) {
+                    NavigationLink(value: SettingsRoute.healthcareExport) {
                         HStack {
                             Image(systemName: "heart.text.square")
                                 .foregroundStyle(.blue)
@@ -132,7 +132,7 @@ struct SettingsView: View {
                 }
                 
                 Section("Privacy & Security") {
-                    NavigationLink(destination: PrivacyPolicyView()) {
+                    NavigationLink(value: SettingsRoute.privacyPolicy) {
                         HStack {
                             Image(systemName: "lock.shield")
                                 .foregroundStyle(.green)
@@ -144,7 +144,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Privacy Policy")
                     .accessibilityHint("Tap to read the privacy policy")
 
-                    NavigationLink(destination: DataDeletionRequestView()) {
+                    NavigationLink(value: SettingsRoute.dataDeletion) {
                         HStack {
                             Image(systemName: "trash.circle")
                                 .foregroundStyle(.orange)
@@ -182,7 +182,7 @@ struct SettingsView: View {
                 }
                 
                 Section("Data & Storage") {
-                    NavigationLink(destination: LocalStorageSettingsView()) {
+                    NavigationLink(value: SettingsRoute.localStorage) {
                         HStack {
                             Image(systemName: "internaldrive")
                                 .foregroundStyle(.blue)
@@ -235,7 +235,7 @@ struct SettingsView: View {
                     .accessibilityHint("Tap to sign out of your account")
                     
                     // Delete account
-                    NavigationLink(destination: DeleteAccountView()) {
+                    NavigationLink(value: SettingsRoute.deleteAccount) {
                         HStack {
                             Image(systemName: "trash")
                                 .foregroundStyle(.red)
@@ -249,6 +249,30 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+            .navigationDestination(for: SettingsRoute.self) { route in
+                switch route {
+                case .language:
+                    LanguageSelectionView()
+                case .units:
+                    UnitSelectionView()
+                case .appearance:
+                    AppearanceSelectionView()
+                case .reminders:
+                    UserRemindersView()
+                case .medications:
+                    MedicationListView()
+                case .healthcareExport:
+                    HealthcareExportView()
+                case .privacyPolicy:
+                    PrivacyPolicyView()
+                case .dataDeletion:
+                    DataDeletionRequestView()
+                case .localStorage:
+                    LocalStorageSettingsView()
+                case .deleteAccount:
+                    DeleteAccountView()
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Close") {

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -21,8 +21,7 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            List {
+        List {
                 Section("Preferences") {
                     NavigationLink(value: SettingsRoute.language) {
                         HStack {
@@ -248,48 +247,47 @@ struct SettingsView: View {
                     }
                 }
             }
-            .navigationTitle("Settings")
-            .navigationDestination(for: SettingsRoute.self) { route in
-                switch route {
-                case .language:
-                    LanguageSelectionView()
-                case .units:
-                    UnitSelectionView()
-                case .appearance:
-                    AppearanceSelectionView()
-                case .reminders:
-                    UserRemindersView()
-                case .medications:
-                    MedicationListView()
-                case .healthcareExport:
-                    HealthcareExportView()
-                case .privacyPolicy:
-                    PrivacyPolicyView()
-                case .dataDeletion:
-                    DataDeletionRequestView()
-                case .localStorage:
-                    LocalStorageSettingsView()
-                case .deleteAccount:
-                    DeleteAccountView()
+        .navigationTitle("Settings")
+        .navigationDestination(for: SettingsRoute.self) { route in
+            switch route {
+            case .language:
+                LanguageSelectionView()
+            case .units:
+                UnitSelectionView()
+            case .appearance:
+                AppearanceSelectionView()
+            case .reminders:
+                UserRemindersView()
+            case .medications:
+                MedicationListView()
+            case .healthcareExport:
+                HealthcareExportView()
+            case .privacyPolicy:
+                PrivacyPolicyView()
+            case .dataDeletion:
+                DataDeletionRequestView()
+            case .localStorage:
+                LocalStorageSettingsView()
+            case .deleteAccount:
+                DeleteAccountView()
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Close") {
+                    HapticManager.shared.light()
+                    dismiss()
                 }
+                .accessibleButton(
+                    label: "Close",
+                    hint: "Close settings"
+                )
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Close") {
-                        HapticManager.shared.light()
-                        dismiss()
-                    }
-                    .accessibleButton(
-                        label: "Close",
-                        hint: "Close settings"
-                    )
-                }
-            }
-            .sheet(isPresented: $showAppleHealth) {
-                HealthDataIntegrationView()
-                    .environment(settingsVM)
-                    .environment(authService)
-            }
+        }
+        .sheet(isPresented: $showAppleHealth) {
+            HealthDataIntegrationView()
+                .environment(settingsVM)
+                .environment(authService)
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -249,28 +249,7 @@ struct SettingsView: View {
             }
         .navigationTitle("Settings")
         .navigationDestination(for: SettingsRoute.self) { route in
-            switch route {
-            case .language:
-                LanguageSelectionView()
-            case .units:
-                UnitSelectionView()
-            case .appearance:
-                AppearanceSelectionView()
-            case .reminders:
-                UserRemindersView()
-            case .medications:
-                MedicationListView()
-            case .healthcareExport:
-                HealthcareExportView()
-            case .privacyPolicy:
-                PrivacyPolicyView()
-            case .dataDeletion:
-                DataDeletionRequestView()
-            case .localStorage:
-                LocalStorageSettingsView()
-            case .deleteAccount:
-                DeleteAccountView()
-            }
+            SettingsRoute.destinationView(for: route)
         }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {

--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -284,9 +284,11 @@ struct UserProfileView: View {
                 }
             }
             .sheet(isPresented: $showSettings) {
-                SettingsView()
-                    .environment(settingsVM)
-                    .environment(authService)
+                NavigationStack {
+                    SettingsView()
+                        .environment(settingsVM)
+                        .environment(authService)
+                }
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
+++ b/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
@@ -1,56 +1,52 @@
 import SwiftUI
 
 struct PrivacyPolicyView: View {
-    @Environment(\.dismiss) private var dismiss
-    @State private var selectedSection: PolicySection?
-    
     private let sections = PolicySection.allSections
     
     var body: some View {
-        NavigationStack {
-            List {
-                // Introduction Section
-                Section {
-                    Text("Last Updated: July 2025")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    
-                    Text("This Privacy Policy describes how GutCheck collects, uses, and protects your personal information.")
-                        .font(.subheadline)
-                }
+        List {
+            // Introduction Section
+            Section {
+                Text("Last Updated: July 2025")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
                 
-                // Main Policy Sections
-                ForEach(sections) { section in
-                    NavigationLink(destination: PolicyDetailView(section: section)) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(section.title)
-                                .font(.headline)
-                            Text(section.summary)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.vertical, 4)
-                    }
-                }
-                
-                // Contact Section
-                Section {
+                Text("This Privacy Policy describes how GutCheck collects, uses, and protects your personal information.")
+                    .font(.subheadline)
+            }
+            
+            // Main Policy Sections
+            ForEach(sections) { section in
+                NavigationLink(value: PrivacyPolicyRoute.sectionDetail(section)) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Questions or Concerns?")
+                        Text(section.title)
                             .font(.headline)
-                        Text("Contact us at privacy@gutcheck.app")
+                        Text(section.summary)
                             .font(.subheadline)
+                            .foregroundStyle(.secondary)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 4)
                 }
             }
-            .navigationTitle("Privacy Policy")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { dismiss() }
+            
+            // Contact Section
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Questions or Concerns?")
+                        .font(.headline)
+                    Text("Contact us at privacy@gutcheck.app")
+                        .font(.subheadline)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
+            }
+        }
+        .navigationTitle("Privacy Policy")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: PrivacyPolicyRoute.self) { route in
+            switch route {
+            case .sectionDetail(let section):
+                PolicyDetailView(section: section)
             }
         }
     }
@@ -120,7 +116,13 @@ private struct PolicyDetailSection: View {
 
 // MARK: - Supporting Types
 
-struct PolicySection: Identifiable {
+struct PolicySection: Identifiable, Hashable {
+    static func == (lhs: PolicySection, rhs: PolicySection) -> Bool {
+        lhs.id == rhs.id
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
     let id = UUID()
     let title: String
     let summary: String

--- a/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
+++ b/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
@@ -40,6 +40,9 @@ struct ProfileMenuSheet: View {
                     UserRemindersView()
                 }
             }
+            .navigationDestination(for: SettingsRoute.self) { route in
+                SettingsRoute.destinationView(for: route)
+            }
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
+++ b/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
@@ -7,7 +7,7 @@ struct ProfileMenuSheet: View {
         NavigationStack {
             List {
                 Section {
-                    NavigationLink(destination: SettingsView()) {
+                    NavigationLink(value: ProfileMenuRoute.settings) {
                         Text("Settings")
                     }
                     Button("Privacy Policy") {
@@ -18,7 +18,7 @@ struct ProfileMenuSheet: View {
                         // TODO: Trigger export
                         dismiss()
                     }
-                    NavigationLink(destination: UserRemindersView()) {
+                    NavigationLink(value: ProfileMenuRoute.reminders) {
                         Label("Reminders", systemImage: "bell.badge")
                     }
                 }
@@ -32,6 +32,14 @@ struct ProfileMenuSheet: View {
             }
             .navigationTitle("Account")
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: ProfileMenuRoute.self) { route in
+                switch route {
+                case .settings:
+                    SettingsView()
+                case .reminders:
+                    UserRemindersView()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced all 23 `NavigationLink(destination:)` calls across 12 files with value-based `NavigationLink(value:)` + `navigationDestination(for:)` modifiers
- Added route enums (`SettingsRoute`, `InsightsRoute`, `PrivacyPolicyRoute`, `ProfileMenuRoute`, `CalendarRoute`) to AppRouter.swift
- Extended `AppDestination` with `symptomHistory` and `medicationList` cases
- Added `Hashable` conformance to `HealthInsight` and `PolicySection`
- Removed nested `NavigationStack` from `InsightsView` (already wrapped by AppRoot)
- Removed standalone `NavigationStack` from `PrivacyPolicyView` (now pushed inside SettingsView's stack)

## Test plan
- [ ] Verify Settings screen: all sub-screens (Language, Units, Appearance, Reminders, Medications, Healthcare Export, Privacy Policy, Data Deletion, Local Storage, Delete Account) navigate correctly and back button works
- [ ] Verify Privacy Policy section detail pages navigate correctly
- [ ] Verify Insights tab: insight cards and category cards navigate to detail views
- [ ] Verify CategoryInsightsView navigates to individual insight details
- [ ] Verify Profile menu sheet navigates to Settings and Reminders
- [ ] Verify Calendar shortcut from Dashboard navigates to full calendar
- [ ] Verify UnifiedCalendarView daily summary navigates to day detail
- [ ] Verify Medications tab: "Manage all medications" and toolbar button navigate to medication list
- [ ] Verify Health Data Integration sheet navigates to medication list
- [ ] Verify Symptom History navigates to symptom detail
- [ ] Confirm zero `NavigationLink(destination:)` calls remain in codebase

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)