### PR TITLE
fix(#223): Replace DispatchQueue usage with modern Swift concurrency

### DIFF
--- a/GutCheck/AccessibilityHelpers.swift
+++ b/GutCheck/AccessibilityHelpers.swift
@@ -173,7 +173,10 @@ class AccessibilityAnnouncement {
     ///   - message: The message to announce
     ///   - delay: Optional delay before announcement
     static func announce(_ message: String, after delay: TimeInterval = 0) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+        Task { @MainActor in
+            if delay > 0 {
+                try? await Task.sleep(for: .seconds(delay))
+            }
             UIAccessibility.post(notification: .announcement, argument: message)
         }
     }

--- a/GutCheck/GutCheck/Navigation/AppRouter.swift
+++ b/GutCheck/GutCheck/Navigation/AppRouter.swift
@@ -139,7 +139,8 @@ enum SheetDestination: Identifiable {
         activePath.append(destination)
         
         // Reset navigation flag after a short delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        Task {
+            try? await Task.sleep(for: .milliseconds(100))
             self.isNavigating = false
         }
     }

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
@@ -275,12 +275,7 @@ final class HealthKitManager {
         }
         
         healthStore.save(samples) { success, error in
-            DispatchQueue.main.async {
-                #if DEBUG
-                if success {
-                } else {
-                }
-                #endif
+            Task { @MainActor in
                 completion(success, error)
             }
         }
@@ -360,12 +355,7 @@ final class HealthKitManager {
         }
 
         healthStore.save(samples) { success, error in
-            DispatchQueue.main.async {
-                #if DEBUG
-                if success {
-                } else {
-                }
-                #endif
+            Task { @MainActor in
                 completion(success, error)
             }
         }
@@ -382,10 +372,7 @@ final class HealthKitManager {
         let waterSample = HKQuantitySample(type: waterType, quantity: waterQuantity, start: date, end: date)
         
         healthStore.save(waterSample) { success, error in
-            DispatchQueue.main.async {
-                if success {
-                } else {
-                }
+            Task { @MainActor in
                 completion(success, error)
             }
         }

--- a/GutCheck/GutCheck/Services/ML/FoodRecognitionService.swift
+++ b/GutCheck/GutCheck/Services/ML/FoodRecognitionService.swift
@@ -35,7 +35,7 @@ class FoodRecognitionService {
             completion(topResults)
         }
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-        DispatchQueue.global(qos: .userInitiated).async {
+        Task.detached(priority: .userInitiated) {
             try? handler.perform([request])
         }
     }

--- a/GutCheck/GutCheck/Utils/NetworkMonitor.swift
+++ b/GutCheck/GutCheck/Utils/NetworkMonitor.swift
@@ -10,7 +10,7 @@ import Foundation
     
     init() {
         monitor.pathUpdateHandler = { [weak self] path in
-            DispatchQueue.main.async {
+            Task { @MainActor [weak self] in
                 self?.isConnected = path.status == .satisfied
                 self?.connectionType = self?.checkConnectionType(path) ?? .unknown
             }

--- a/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
@@ -203,7 +203,8 @@ struct SymptomEditView: View {
         onSave(updatedSymptom)
         
         // Show success feedback and reset state
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        Task {
+            try? await Task.sleep(for: .milliseconds(300))
             isSaving = false
             showingSuccessAlert = true
         }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -567,7 +567,8 @@ struct MealCalendarRow: View {
             isNavigating = true
             
             // Debounce the navigation
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            Task {
+                try? await Task.sleep(for: .milliseconds(500))
                 isNavigating = false
             }
             
@@ -676,7 +677,8 @@ struct SymptomCalendarRow: View {
             isNavigating = true
             
             // Debounce the navigation
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            Task {
+                try? await Task.sleep(for: .milliseconds(500))
                 isNavigating = false
             }
             

--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -73,7 +73,8 @@ struct ProfileAvatarButton: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .profileImageUpdated)) { _ in
             // Reload profile image when updated
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            Task {
+                try? await Task.sleep(for: .milliseconds(500))
                 loadProfileImage()
             }
         }

--- a/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthKitTestView.swift
@@ -81,7 +81,7 @@ struct HealthKitTestView: View {
         statusMessage = "Requesting HealthKit authorization..."
         
         HealthKitManager.shared.requestAuthorization { success, error in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 isLoading = false
                 if success {
                     isAuthorized = true
@@ -127,7 +127,7 @@ struct HealthKitTestView: View {
         )
         
         HealthKitManager.shared.writeMealToHealthKit(testMeal) { success, error in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 isLoading = false
                 if success {
                     statusMessage = "✅ Test meal written to HealthKit successfully!"
@@ -156,7 +156,7 @@ struct HealthKitTestView: View {
         )
         
         HealthKitManager.shared.writeSymptomToHealthKit(testSymptom) { success, error in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 isLoading = false
                 if success {
                     statusMessage = "✅ Test symptom written to HealthKit successfully!"
@@ -176,7 +176,7 @@ struct HealthKitTestView: View {
         let waterAmount = 500.0 // 500ml
         
         HealthKitManager.shared.writeWaterIntakeToHealthKit(amount: waterAmount) { success, error in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 isLoading = false
                 if success {
                     statusMessage = "✅ Test water intake written to HealthKit successfully!"


### PR DESCRIPTION
## Summary
- Replaces 15 `DispatchQueue` calls across 9 files with structured Swift concurrency
- `DispatchQueue.main.asyncAfter` → `Task { try? await Task.sleep(for:) }` (6 occurrences)
- `DispatchQueue.main.async` → `Task { @MainActor in }` (8 occurrences)
- `DispatchQueue.global(qos:).async` → `Task.detached(priority:)` (1 occurrence)
- Three `DispatchQueue` usages intentionally kept where framework APIs require them (NWPathMonitor queue, Firestore dispatchQueue)

## Test plan
- [ ] Verify navigation debouncing still works (AppRouter, CalendarView rows)
- [ ] Verify SymptomEditView save feedback delay behaves correctly
- [ ] Verify ProfileAvatarButton image reload after notification
- [ ] Verify HealthKit authorization, meal/symptom/water write callbacks update UI
- [ ] Verify VoiceOver announcements with delay still work (AccessibilityHelpers)
- [ ] Verify network connectivity monitoring still updates (NetworkMonitor)
- [ ] Verify food recognition ML classification still runs off main thread (FoodRecognitionService)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)