### PR TITLE
fix(#232): Extract computed view properties into separate View structs

### DIFF
--- a/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomEditView.swift
@@ -32,7 +32,7 @@ struct SymptomEditView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Symptom Time
-                    symptomTimeSection
+                    SymptomEditTimeSection(symptomDate: $symptomDate)
 
                     // Bristol Stool Scale
                     Text("Bristol Stool Scale")
@@ -59,10 +59,15 @@ struct SymptomEditView: View {
                     UrgencyLevelSelectionView(selectedUrgencyLevel: $selectedUrgencyLevel)
 
                     // Notes
-                    notesSection
+                    SymptomEditNotesSection(notes: $notes)
 
                     // Action buttons
-                    actionButtonsSection
+                    SymptomEditActionButtons(
+                        isSaving: isSaving,
+                        isFormValid: isFormValid,
+                        onSave: { saveChanges() },
+                        onCancel: { dismiss() }
+                    )
                 }
                 .padding()
             }
@@ -82,104 +87,6 @@ struct SymptomEditView: View {
                 Text("Your symptom has been successfully updated.")
             }
         }
-    }
-    
-    // MARK: - View Components
-    
-    private var symptomTimeSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Symptom Time")
-                .font(.title3)
-                .fontWeight(.semibold)
-                .foregroundStyle(ColorTheme.primaryText)
-            DatePicker(
-                "",
-                selection: $symptomDate,
-                displayedComponents: [.date, .hourAndMinute]
-            )
-            .datePickerStyle(.compact)
-            .accentColor(ColorTheme.primary)
-        }
-        .padding()
-        .background(ColorTheme.surface)
-        .clipShape(.rect(cornerRadius: 12))
-    }
-    
-    private var notesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Notes")
-                .font(.title3)
-                .fontWeight(.semibold)
-                .foregroundStyle(ColorTheme.primaryText)
-            
-            TextEditor(text: $notes)
-                .frame(minHeight: 100)
-                .padding(12)
-                .background(ColorTheme.cardBackground)
-                .clipShape(.rect(cornerRadius: 8))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
-                )
-        }
-        .padding()
-        .background(ColorTheme.surface)
-        .clipShape(.rect(cornerRadius: 12))
-    }
-    
-    private var actionButtonsSection: some View {
-        VStack(spacing: 12) {
-            // Save button
-            Button(action: {
-                saveChanges()
-            }) {
-                HStack(spacing: 8) {
-                    if isSaving {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                            .scaleEffect(0.9)
-                    } else {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.title3)
-                    }
-                    
-                    Text(isSaving ? "Saving..." : "Save Changes")
-                        .font(.headline)
-                        .fontWeight(.semibold)
-                }
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(isFormValid ? ColorTheme.primary : ColorTheme.disabled)
-                )
-            }
-            .disabled(!isFormValid || isSaving)
-            
-            // Cancel button
-            Button(action: {
-                dismiss()
-            }) {
-                Text("Cancel")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundStyle(ColorTheme.secondaryText)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(ColorTheme.cardBackground)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
-                    )
-            }
-        }
-        .padding()
-        .background(ColorTheme.surface)
-        .clipShape(.rect(cornerRadius: 12))
     }
     
     private var isFormValid: Bool {
@@ -208,6 +115,115 @@ struct SymptomEditView: View {
             isSaving = false
             showingSuccessAlert = true
         }
+    }
+}
+
+// MARK: - Extracted Subviews
+
+struct SymptomEditTimeSection: View {
+    @Binding var symptomDate: Date
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Symptom Time")
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(ColorTheme.primaryText)
+            DatePicker(
+                "",
+                selection: $symptomDate,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            .datePickerStyle(.compact)
+            .accentColor(ColorTheme.primary)
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+    }
+}
+
+struct SymptomEditNotesSection: View {
+    @Binding var notes: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Notes")
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(ColorTheme.primaryText)
+            
+            TextEditor(text: $notes)
+                .frame(minHeight: 100)
+                .padding(12)
+                .background(ColorTheme.cardBackground)
+                .clipShape(.rect(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
+                )
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+    }
+}
+
+struct SymptomEditActionButtons: View {
+    let isSaving: Bool
+    let isFormValid: Bool
+    let onSave: () -> Void
+    let onCancel: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            // Save button
+            Button(action: onSave) {
+                HStack(spacing: 8) {
+                    if isSaving {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                            .scaleEffect(0.9)
+                    } else {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.title3)
+                    }
+                    
+                    Text(isSaving ? "Saving..." : "Save Changes")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                }
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(isFormValid ? ColorTheme.primary : ColorTheme.disabled)
+                )
+            }
+            .disabled(!isFormValid || isSaving)
+            
+            // Cancel button
+            Button(action: onCancel) {
+                Text("Cancel")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(ColorTheme.secondaryText)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(ColorTheme.cardBackground)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(ColorTheme.border.opacity(0.3), lineWidth: 1)
+                    )
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
     }
 }
 

--- a/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
@@ -20,35 +20,14 @@ struct CustomTabBar: View {
                 // Tab Bar (always fixed to bottom)
                 VStack {
                     Spacer()
-                    tabBarView
+                    CustomTabBarContent(
+                        selectedTab: selectedTab,
+                        onTabSelected: { handleTabSelection($0) }
+                    )
                 }
             }
         }
     }
-    
-    private var tabBarView: some View {
-        HStack {
-            ForEach(Array(Tab.allCases), id: \.self) { tab in
-                TabBarItem(
-                    icon: tab.icon,
-                    label: tab.title,
-                    isSelected: selectedTab == tab
-                ) {
-                    handleTabSelection(tab)
-                }
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.top, 4)
-        .padding(.bottom, 8)
-        .background(
-            ColorTheme.cardBackground
-                .shadow(color: ColorTheme.shadowColor, radius: 8, x: 0, y: -2)
-                .edgesIgnoringSafeArea(.bottom)
-        )
-    }
-    
-    
     
     private func handleTabSelection(_ tab: Tab) {
         
@@ -62,5 +41,32 @@ struct CustomTabBar: View {
                 router.navigateToRoot()
             }
         }
+    }
+}
+
+struct CustomTabBarContent: View {
+    let selectedTab: Tab
+    let onTabSelected: (Tab) -> Void
+    
+    var body: some View {
+        HStack {
+            ForEach(Array(Tab.allCases), id: \.self) { tab in
+                TabBarItem(
+                    icon: tab.icon,
+                    label: tab.title,
+                    isSelected: selectedTab == tab
+                ) {
+                    onTabSelected(tab)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 4)
+        .padding(.bottom, 8)
+        .background(
+            ColorTheme.cardBackground
+                .shadow(color: ColorTheme.shadowColor, radius: 8, x: 0, y: -2)
+                .edgesIgnoringSafeArea(.bottom)
+        )
     }
 }

--- a/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
+++ b/GutCheck/GutCheck/Views/Components/ProfileAvatarButton.swift
@@ -17,47 +17,12 @@ struct ProfileAvatarButton: View {
     
     var body: some View {
         Button(action: action) {
-            ZStack {
-                if let image = profileImage {
-                    // Profile image
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: size, height: size)
-                        .clipShape(Circle())
-                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
-                } else if isLoadingImage {
-                    // Loading state
-                    Circle()
-                        .fill(ColorTheme.cardBackground)
-                        .frame(width: size, height: size)
-                        .overlay(
-                            ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle(tint: ColorTheme.accent))
-                                .scaleEffect(0.7)
-                        )
-                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
-                } else {
-                    // Default avatar with initials or fallback icon
-                    Circle()
-                        .fill(ColorTheme.accent.opacity(0.2))
-                        .frame(width: size, height: size)
-                        .overlay(
-                            Group {
-                                if let user = user {
-                                    Text(user.initials)
-                                        .font(.system(size: size * 0.4, weight: .semibold))
-                                        .foregroundStyle(ColorTheme.accent)
-                                } else {
-                                    Image(systemName: "person.circle.fill")
-                                        .font(.system(size: size * 0.8))
-                                        .foregroundStyle(ColorTheme.accent)
-                                }
-                            }
-                        )
-                        .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
-                }
-            }
+            ProfileAvatarContent(
+                user: user,
+                size: size,
+                profileImage: profileImage,
+                isLoadingImage: isLoadingImage
+            )
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityLabel("Profile Menu")
@@ -110,6 +75,56 @@ struct ProfileAvatarButton: View {
                 }
             }
         } else {
+        }
+    }
+}
+
+// MARK: - Avatar Content
+
+struct ProfileAvatarContent: View {
+    let user: User?
+    let size: CGFloat
+    let profileImage: UIImage?
+    let isLoadingImage: Bool
+    
+    var body: some View {
+        ZStack {
+            if let image = profileImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+                    .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
+            } else if isLoadingImage {
+                Circle()
+                    .fill(ColorTheme.cardBackground)
+                    .frame(width: size, height: size)
+                    .overlay(
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: ColorTheme.accent))
+                            .scaleEffect(0.7)
+                    )
+                    .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
+            } else {
+                Circle()
+                    .fill(ColorTheme.accent.opacity(0.2))
+                    .frame(width: size, height: size)
+                    .overlay(
+                        Group {
+                            if let user = user {
+                                Text(user.initials)
+                                    .font(.system(size: size * 0.4, weight: .semibold))
+                                    .foregroundStyle(ColorTheme.accent)
+                            } else {
+                                Image(systemName: "person.circle.fill")
+                                    .font(.system(size: size * 0.8))
+                                    .foregroundStyle(ColorTheme.accent)
+                            }
+                        }
+                    )
+                    .overlay { Circle().stroke(ColorTheme.accent, lineWidth: 2) }
+            }
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -37,17 +37,16 @@ struct InsightsDashboardView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
-                    // Header
-                    headerSection
+                    InsightsDashboardHeaderSection()
                     
-                    // Time range selector
-                    timeRangeSelector
+                    InsightsDashboardTimeRangeSelector(selectedTimeRange: $selectedTimeRange)
                     
-                    // Summary statistics
-                    summaryStatsSection
+                    InsightsDashboardSummaryStats(insights: insightsService.recentInsights)
                     
-                    // Insights content
-                    insightsContent
+                    InsightsDashboardContent(
+                        insights: insightsService.recentInsights,
+                        selectedCategory: $selectedCategory
+                    )
                 }
                 .padding()
             }
@@ -67,9 +66,15 @@ struct InsightsDashboardView: View {
         }
     }
     
-    // MARK: - Header Section
-    
-    private var headerSection: some View {
+    private func refreshInsights() async {
+        await insightsService.generateRecentInsights()
+    }
+}
+
+// MARK: - Header Section
+
+struct InsightsDashboardHeaderSection: View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Discover patterns in your health data")
                 .font(.title2)
@@ -81,79 +86,109 @@ struct InsightsDashboardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
+}
+
+// MARK: - Time Range Selector
+
+struct InsightsDashboardTimeRangeSelector: View {
+    @Binding var selectedTimeRange: InsightsDashboardView.TimeRange
     
-    // MARK: - Time Range Selector
-    
-    private var timeRangeSelector: some View {
+    var body: some View {
         Picker("Time Range", selection: $selectedTimeRange) {
-            ForEach(TimeRange.allCases) { timeRange in
+            ForEach(InsightsDashboardView.TimeRange.allCases) { timeRange in
                 Text(timeRange.displayName).tag(timeRange)
             }
         }
         .pickerStyle(.segmented)
     }
+}
+
+// MARK: - Summary Statistics
+
+struct InsightsDashboardSummaryStats: View {
+    let insights: [HealthInsight]
     
-    // MARK: - Summary Statistics
-    
-    private var summaryStatsSection: some View {
+    var body: some View {
         HStack(spacing: 16) {
             StatCard(
                 title: "Total Insights",
-                value: "\(insightsService.recentInsights.count)",
+                value: "\(insights.count)",
                 icon: "lightbulb.fill",
                 color: .blue
             )
             
             StatCard(
                 title: "Food Triggers",
-                value: "\(insightsService.recentInsights.filter { $0.title.lowercased().contains("food") || $0.title.lowercased().contains("dairy") || $0.title.lowercased().contains("gluten") }.count)",
+                value: "\(insights.filter { $0.title.lowercased().contains("food") || $0.title.lowercased().contains("dairy") || $0.title.lowercased().contains("gluten") }.count)",
                 icon: "exclamationmark.triangle.fill",
                 color: .red
             )
             
             StatCard(
                 title: "Patterns",
-                value: "\(insightsService.recentInsights.filter { $0.title.lowercased().contains("pattern") || $0.title.lowercased().contains("correlation") }.count)",
+                value: "\(insights.filter { $0.title.lowercased().contains("pattern") || $0.title.lowercased().contains("correlation") }.count)",
                 icon: "chart.bar.fill",
                 color: .green
             )
         }
     }
+}
+
+// MARK: - Insights Content
+
+struct InsightsDashboardContent: View {
+    let insights: [HealthInsight]
+    @Binding var selectedCategory: InsightCategory?
     
-    // MARK: - Insights Content
+    private var foodTriggerInsights: [HealthInsight] {
+        insights.filter { $0.title.lowercased().contains("food") || $0.title.lowercased().contains("dairy") || $0.title.lowercased().contains("gluten") }
+    }
     
-    private var insightsContent: some View {
+    private var temporalPatternInsights: [HealthInsight] {
+        insights.filter { $0.title.lowercased().contains("pattern") || $0.title.lowercased().contains("timing") }
+    }
+    
+    private var lifestyleCorrelationInsights: [HealthInsight] {
+        insights.filter { $0.title.lowercased().contains("correlation") || $0.title.lowercased().contains("activity") }
+    }
+    
+    private var nutritionTrendInsights: [HealthInsight] {
+        insights.filter { $0.title.lowercased().contains("nutrition") || $0.title.lowercased().contains("trend") }
+    }
+    
+    var body: some View {
         VStack(spacing: 24) {
-            if insightsService.recentInsights.isEmpty {
-                emptyStateSection
+            if insights.isEmpty {
+                InsightsDashboardEmptyState()
             } else {
-                // Category filter
-                categoryFilterSection
+                InsightsDashboardCategoryFilter(selectedCategory: $selectedCategory)
                 
-                // Food triggers section
                 if !foodTriggerInsights.isEmpty {
-                    foodTriggersSection
+                    InsightsDashboardFoodTriggers(insights: foodTriggerInsights)
                 }
                 
-                // Temporal patterns section
                 if !temporalPatternInsights.isEmpty {
-                    temporalPatternsSection
+                    InsightsDashboardTemporalPatterns(insights: temporalPatternInsights)
                 }
                 
-                // Lifestyle correlations section
                 if !lifestyleCorrelationInsights.isEmpty {
-                    lifestyleCorrelationsSection
+                    InsightsDashboardLifestyleCorrelations(insights: lifestyleCorrelationInsights)
                 }
                 
-                // Nutrition trends section
                 if !nutritionTrendInsights.isEmpty {
-                    nutritionTrendsSection
+                    InsightsDashboardNutritionTrends(insights: nutritionTrendInsights)
                 }
             }
         }
     }
+}
+
+// MARK: - Category Filter
+
+struct InsightsDashboardCategoryFilter: View {
+    @Binding var selectedCategory: InsightCategory?
     
-    private var categoryFilterSection: some View {
+    var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 12) {
                 CategoryFilterButton(
@@ -174,14 +209,14 @@ struct InsightsDashboardView: View {
         }
         .scrollIndicators(.hidden)
     }
+}
+
+// MARK: - Section Views
+
+struct InsightsDashboardFoodTriggers: View {
+    let insights: [HealthInsight]
     
-    // MARK: - Food Triggers Section
-    
-    private var foodTriggerInsights: [HealthInsight] {
-        insightsService.recentInsights.filter { $0.title.lowercased().contains("food") || $0.title.lowercased().contains("dairy") || $0.title.lowercased().contains("gluten") }
-    }
-    
-    private var foodTriggersSection: some View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             SectionHeader(
                 title: "Food Triggers",
@@ -190,19 +225,17 @@ struct InsightsDashboardView: View {
                 color: .red
             )
             
-            ForEach(foodTriggerInsights) { insight in
+            ForEach(insights) { insight in
                 FoodTriggerCard(insight: insight)
             }
         }
     }
+}
+
+struct InsightsDashboardTemporalPatterns: View {
+    let insights: [HealthInsight]
     
-    // MARK: - Temporal Patterns Section
-    
-    private var temporalPatternInsights: [HealthInsight] {
-        insightsService.recentInsights.filter { $0.title.lowercased().contains("pattern") || $0.title.lowercased().contains("timing") }
-    }
-    
-    private var temporalPatternsSection: some View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             SectionHeader(
                 title: "Temporal Patterns",
@@ -211,19 +244,17 @@ struct InsightsDashboardView: View {
                 color: .blue
             )
             
-            ForEach(temporalPatternInsights) { insight in
+            ForEach(insights) { insight in
                 TemporalPatternCard(insight: insight)
             }
         }
     }
+}
+
+struct InsightsDashboardLifestyleCorrelations: View {
+    let insights: [HealthInsight]
     
-    // MARK: - Lifestyle Correlations Section
-    
-    private var lifestyleCorrelationInsights: [HealthInsight] {
-        insightsService.recentInsights.filter { $0.title.lowercased().contains("correlation") || $0.title.lowercased().contains("activity") }
-    }
-    
-    private var lifestyleCorrelationsSection: some View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             SectionHeader(
                 title: "Lifestyle Correlations",
@@ -232,19 +263,17 @@ struct InsightsDashboardView: View {
                 color: .green
             )
             
-            ForEach(lifestyleCorrelationInsights) { insight in
+            ForEach(insights) { insight in
                 LifestyleCorrelationCard(insight: insight)
             }
         }
     }
+}
+
+struct InsightsDashboardNutritionTrends: View {
+    let insights: [HealthInsight]
     
-    // MARK: - Nutrition Trends Section
-    
-    private var nutritionTrendInsights: [HealthInsight] {
-        insightsService.recentInsights.filter { $0.title.lowercased().contains("nutrition") || $0.title.lowercased().contains("trend") }
-    }
-    
-    private var nutritionTrendsSection: some View {
+    var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             SectionHeader(
                 title: "Nutrition Trends",
@@ -253,15 +282,17 @@ struct InsightsDashboardView: View {
                 color: .purple
             )
             
-            ForEach(nutritionTrendInsights) { insight in
+            ForEach(insights) { insight in
                 NutritionTrendCard(insight: insight)
             }
         }
     }
-    
-    // MARK: - Loading & Error States
-    
-    private var loadingSection: some View {
+}
+
+// MARK: - State Views
+
+struct InsightsDashboardLoadingState: View {
+    var body: some View {
         VStack(spacing: 16) {
             ProgressView()
                 .scaleEffect(1.5)
@@ -271,8 +302,13 @@ struct InsightsDashboardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 60)
     }
+}
+
+struct InsightsDashboardErrorState: View {
+    let error: String
+    let onRetry: () -> Void
     
-    private func errorSection(_ error: String) -> some View {
+    var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 48))
@@ -286,18 +322,16 @@ struct InsightsDashboardView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             
-            Button("Try Again") {
-                Task {
-                    await refreshInsights()
-                }
-            }
-            .buttonStyle(.borderedProminent)
+            Button("Try Again", action: onRetry)
+                .buttonStyle(.borderedProminent)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 60)
     }
-    
-    private var emptyStateSection: some View {
+}
+
+struct InsightsDashboardEmptyState: View {
+    var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "chart.bar.doc.horizontal")
                 .font(.system(size: 48))
@@ -313,12 +347,6 @@ struct InsightsDashboardView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 60)
-    }
-    
-    // MARK: - Helper Methods
-    
-    private func refreshInsights() async {
-        await insightsService.generateRecentInsights()
     }
 }
 


### PR DESCRIPTION
## Summary
- Converts `private var ... : some View` computed properties into dedicated `View` structs across 4 files
- **InsightsDashboardView**: 11 computed properties → 12 extracted View structs (header, time range, stats, content, category filter, 4 section views, loading/error/empty states)
- **SymptomEditView**: 3 computed properties → `SymptomEditTimeSection`, `SymptomEditNotesSection`, `SymptomEditActionButtons`
- **CustomTabBar**: `tabBarView` → `CustomTabBarContent`
- **ProfileAvatarButton**: inline ZStack branching → `ProfileAvatarContent`

SwiftUI evaluates the entire `body` of a view when any state changes. Extracting subviews into separate `View` structs allows SwiftUI to skip re-evaluating parts whose inputs haven't changed.

## Test plan
- [ ] Verify Insights Dashboard loads, displays insights, time range picker works
- [ ] Verify Insights Dashboard empty state renders correctly
- [ ] Verify symptom edit view: time picker, notes, save/cancel buttons all function
- [ ] Verify tab bar renders correctly and tab switching works
- [ ] Verify profile avatar displays image, loading, and initials states correctly

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)