### PR TITLE
fix(#222): Fix SettingsRoute navigation destination visibility for Data Deletion

### DIFF
--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -289,6 +289,9 @@ struct UserProfileView: View {
                         .environment(settingsVM)
                         .environment(authService)
                 }
+                .navigationDestination(for: SettingsRoute.self) { route in
+                    SettingsRoute.destinationView(for: route)
+                }
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
@@ -26,8 +26,7 @@ struct DataDeletionRequestView: View {
     @State private var showingSuccess = false
     
     var body: some View {
-        NavigationStack {
-            Form {
+        Form {
                 Section {
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
@@ -125,7 +124,6 @@ struct DataDeletionRequestView: View {
             } message: {
                 Text("Your data deletion request has been submitted successfully. You will receive an email confirmation within 24 hours.")
             }
-        }
     }
     
     // MARK: - Computed Properties

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -25,8 +25,7 @@ struct HealthcareExportView: View {
     @State private var endDate = Date.now
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
+        ScrollView {
                 VStack(spacing: 24) {
                     // Header
                     headerSection
@@ -72,7 +71,6 @@ struct HealthcareExportView: View {
             } message: {
                 Text(errorMessage)
             }
-        }
     }
     
     // MARK: - Header Section


### PR DESCRIPTION
## Summary
- Fixes the "NavigationLink is presenting a value of type SettingsRoute but there is no matching navigationDestination declaration" runtime warning when tapping "Request Data Deletion" from Settings
- **Root cause**: The `NavigationStack` wrapping `SettingsView` in `UserProfileView`'s `.sheet` was missing a `navigationDestination(for: SettingsRoute.self)` handler
- Also removes nested `NavigationStack` wrappers from `DataDeletionRequestView` and `HealthcareExportView` — these are pushed destinations inside the Settings navigation stack and should not have their own `NavigationStack`

## Test plan
- [ ] Open Profile → Settings → Request Data Deletion — verify no runtime warning and the view pushes correctly
- [ ] Open Profile → Settings → Healthcare Export — verify it pushes correctly without nested navigation bars
- [ ] Verify back navigation works correctly from both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)