### PR TITLE
fix(#236): Remove unnecessary GeometryReader and modernize usage

### DIFF
--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -17,25 +17,23 @@ struct AuthenticationView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                VStack(spacing: 30) {
-                    // Header
-                    headerSection
-                    
-                    // Form
-                    if viewModel.isShowingSignUp {
-                        signUpForm
-                    } else {
-                        signInForm
-                    }
-                    
-                    // Toggle Auth Mode
-                    authToggleSection
+        ScrollView {
+            VStack(spacing: 30) {
+                // Header
+                headerSection
+                
+                // Form
+                if viewModel.isShowingSignUp {
+                    signUpForm
+                } else {
+                    signInForm
                 }
-                .padding(.horizontal, 24)
-                .frame(minHeight: geometry.size.height)
+                
+                // Toggle Auth Mode
+                authToggleSection
             }
+            .padding(.horizontal, 24)
+            .containerRelativeFrame(.vertical, alignment: .center)
         }
         .background(ColorTheme.background)
         .alert("Success", isPresented: $viewModel.showingSuccessAlert) {

--- a/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTabBar.swift
@@ -15,17 +15,12 @@ struct CustomTabBar: View {
     // Using shared Tab enum from Models/Core/Tab.swift
 
     var body: some View {
-        GeometryReader { geo in
-            ZStack {
-                // Tab Bar (always fixed to bottom)
-                VStack {
-                    Spacer()
-                    CustomTabBarContent(
-                        selectedTab: selectedTab,
-                        onTabSelected: { handleTabSelection($0) }
-                    )
-                }
-            }
+        VStack {
+            Spacer()
+            CustomTabBarContent(
+                selectedTab: selectedTab,
+                onTabSelected: { handleTabSelection($0) }
+            )
         }
     }
     


### PR DESCRIPTION
## Summary
- **CustomTabBar.swift**: Removed unused `GeometryReader` — the `geo` parameter was never referenced, and the wrapping `ZStack` was also unnecessary
- **AuthenticationView.swift**: Replaced `GeometryReader` + `.frame(minHeight: geometry.size.height)` pattern with `.containerRelativeFrame(.vertical, alignment: .center)` for modern, declarative layout sizing
- **DashboardView.swift**: No changes needed — the GeometryReader referenced in the issue (line 226, progress bar width) no longer exists in the current codebase

Closes #236

## Test plan
- [ ] Verify CustomTabBar renders and positions correctly at the bottom of the screen
- [ ] Verify AuthenticationView content is vertically centered on the sign-in screen
- [ ] Verify sign-up form scrolls properly when content exceeds screen height
- [ ] Test on different device sizes to confirm layout adapts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)