### PR TITLE
fix(#217): migrate PermissionManager to @Observable and fix auth UI t…

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -147,7 +147,10 @@ struct GutCheckApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if !authService.isAuthStateResolved {
+                if ProcessInfo.processInfo.arguments.contains("--uitesting") {
+                    // UI Testing mode: skip auth and show the auth screen directly
+                    AuthenticationView(authService: authService)
+                } else if !authService.isAuthStateResolved {
                     // Show loading while Firebase restores auth session
                     ZStack {
                         ColorTheme.background

--- a/GutCheck/GutCheck/Services/Permissions/PermissionManager.swift
+++ b/GutCheck/GutCheck/Services/Permissions/PermissionManager.swift
@@ -16,15 +16,15 @@ import UIKit
 
 /// Centralized permission management following Apple's iOS 18.5+ guidelines
 @MainActor
-class PermissionManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+@Observable class PermissionManager: NSObject, CLLocationManagerDelegate {
     static let shared = PermissionManager()
     
-    // MARK: - Published States
-    @Published var cameraStatus: PermissionStatus = .notDetermined
-    @Published var photoLibraryStatus: PermissionStatus = .notDetermined
-    @Published var notificationStatus: PermissionStatus = .notDetermined
-    @Published var healthKitStatus: PermissionStatus = .notDetermined
-    @Published var locationStatus: PermissionStatus = .notDetermined
+    // MARK: - Observable States
+    var cameraStatus: PermissionStatus = .notDetermined
+    var photoLibraryStatus: PermissionStatus = .notDetermined
+    var notificationStatus: PermissionStatus = .notDetermined
+    var healthKitStatus: PermissionStatus = .notDetermined
+    var locationStatus: PermissionStatus = .notDetermined
     
     // MARK: - Permission Status Enum
     enum PermissionStatus: Equatable {

--- a/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/CameraPermissionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CameraPermissionView: View {
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     @State private var isRequesting = false
     
     let title: String
@@ -196,7 +196,7 @@ struct CameraPermissionView: View {
 
 struct BarcodeCameraPermissionView: View {
     let onPermissionGranted: () -> Void
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     
     var body: some View {
         CameraPermissionView(

--- a/GutCheck/GutCheck/Views/Components/CustomButton.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomButton.swift
@@ -82,6 +82,7 @@ struct CustomButton: View {
             .shadow(color: ColorTheme.shadowColor, radius: 4, x: 0, y: 2)
         }
         .disabled(isDisabled || isLoading)
+        .accessibilityIdentifier("\(title.replacingOccurrences(of: " ", with: ""))Button")
         .animation(.easeInOut(duration: 0.2), value: isLoading)
         .animation(.easeInOut(duration: 0.2), value: isDisabled)
     }

--- a/GutCheck/GutCheck/Views/Components/CustomTextField.swift
+++ b/GutCheck/GutCheck/Views/Components/CustomTextField.swift
@@ -45,6 +45,7 @@ struct CustomTextField: View {
                             .textFieldStyle(PlainTextFieldStyle())
                             .keyboardType(keyboardType)
                             .focused($isFocused)
+                            .accessibilityIdentifier("\(title)Field")
                     } else {
                         TextField(placeholder, text: $text)
                             .textFieldStyle(PlainTextFieldStyle())
@@ -52,6 +53,7 @@ struct CustomTextField: View {
                             .focused($isFocused)
                             .autocapitalization(.none)
                             .disableAutocorrection(true)
+                            .accessibilityIdentifier("\(title)Field")
                     }
                 }
                 .padding(.horizontal, 16)

--- a/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
+++ b/GutCheck/GutCheck/Views/Components/NotificationPermissionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct NotificationPermissionView: View {
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     @State private var isRequesting = false
     
     let title: String

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingHealthKitStep.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct OnboardingHealthKitStep: View {
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     @Binding var currentStep: Int
     
     @State private var isRequesting = false

--- a/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
+++ b/GutCheck/GutCheck/Views/Onboarding/OnboardingPermissionsStep.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OnboardingPermissionsStep: View {
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     @Binding var currentStep: Int
     
     @State private var isRequestingPermissions = false

--- a/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Permissions/PermissionRequestView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PermissionRequestView: View {
-    @StateObject private var permissionManager = PermissionManager.shared
+    @State private var permissionManager = PermissionManager.shared
     @Environment(\.dismiss) private var dismiss
     
     @State private var currentStep = 0

--- a/GutCheck/GutCheckUITests/AuthenticationViewUITests.swift
+++ b/GutCheck/GutCheckUITests/AuthenticationViewUITests.swift
@@ -5,29 +5,27 @@ final class AuthenticationViewUITests: XCTestCase {
     
     override func setUpWithError() throws {
         continueAfterFailure = false
+        app.launchArguments = ["--uitesting"]
         app.launch()
     }
     
     func testAuthenticationScreenElements() throws {
         // Check for email field
-        let emailField = app.textFields["Email"]
-        XCTAssertTrue(emailField.exists, "Email field should exist")
+        let emailField = app.textFields["EmailField"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5), "Email field should exist")
         
         // Check for password field
-        let passwordField = app.secureTextFields["Password"]
+        let passwordField = app.secureTextFields["PasswordField"]
         XCTAssertTrue(passwordField.exists, "Password field should exist")
         
         // Check for sign in button
-        let signInButton = app.buttons["Sign In"]
+        let signInButton = app.buttons["SignInButton"]
         XCTAssertTrue(signInButton.exists, "Sign In button should exist")
-        
-        // Check for phone sign-in button
-        let phoneButton = app.buttons["Phone"]
-        XCTAssertTrue(phoneButton.exists, "Phone sign-in button should exist")
     }
     
     func testSignInButtonDisabledWhenFieldsEmpty() throws {
-        let signInButton = app.buttons["Sign In"]
+        let signInButton = app.buttons["SignInButton"]
+        XCTAssertTrue(signInButton.waitForExistence(timeout: 5), "Sign In button should exist")
         XCTAssertFalse(signInButton.isEnabled, "Sign In button should be disabled when fields are empty")
     }
 }


### PR DESCRIPTION
…ests

Complete the @Observable migration by converting the last remaining ObservableObject class (PermissionManager) and update all 6 consuming views from @StateObject to @State.

Fix AuthenticationViewUITests by adding a --uitesting launch argument to bypass auth state, adding accessibility identifiers to CustomTextField and CustomButton, and updating test queries to use them. Remove assertion for non-existent Phone button (phone auth is commented out).