### PR TITLE
feat(#7): implement AI Insights card on dashboard

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -36,6 +36,7 @@ enum AccessibilityIdentifiers {
         static let avoidanceTipCard = "dashboard.avoidanceTip.card"
         static let weekSelector = "dashboard.weekSelector"
         static let activitySummary = "dashboard.activitySummary"
+        static let aiInsightsCard = "dashboard.aiInsights.card"
     }
     
     // MARK: - Meal Builder

--- a/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
@@ -15,6 +15,29 @@ import Foundation
 import SwiftUI
 import Combine
 
+/// Severity level for AI-generated insight messages
+enum AIInsightSeverity {
+    case positive
+    case neutral
+    case warning
+    
+    var color: Color {
+        switch self {
+        case .positive: return ColorTheme.success
+        case .neutral: return ColorTheme.info
+        case .warning: return ColorTheme.warning
+        }
+    }
+    
+    var icon: String {
+        switch self {
+        case .positive: return "checkmark.seal.fill"
+        case .neutral: return "sparkles"
+        case .warning: return "exclamationmark.triangle.fill"
+        }
+    }
+}
+
 /// Central data store for dashboard functionality
 /// Manages all dashboard-related data including health insights, meal/symptom data,
 /// and real-time calculations for health scoring and recommendations.
@@ -41,6 +64,12 @@ import Combine
     
     /// Smart avoidance tip based on recent symptom patterns
     var avoidanceTip: String = ""
+    
+    /// AI-generated insight summary for the selected day
+    var aiInsightSummary: String = ""
+    
+    /// Severity level of the current AI insight
+    var aiInsightSeverity: AIInsightSeverity = .neutral
     
     /// Currently selected date for dashboard data display
     var selectedDate: Date = Date.now
@@ -163,6 +192,34 @@ import Combine
         if todaysSymptoms.contains(where: { $0.painLevel.rawValue >= 8 }) {
             triggerAlerts.append("High pain level detected - consider consulting healthcare provider")
         }
+        
+        // Generate AI insight summary
+        generateAIInsight()
+    }
+    
+    /// Generate AI insight based on current meal and symptom data
+    /// Uses placeholder logic; future versions will integrate with AIAnalysisService
+    private func generateAIInsight() {
+        if todaysSymptoms.isEmpty && todaysMeals.count >= 2 {
+            aiInsightSummary = "No triggers detected today. Your digestion looks healthy!"
+            aiInsightSeverity = .positive
+        } else if todaysSymptoms.isEmpty && todaysMeals.isEmpty {
+            aiInsightSummary = "Start logging meals to get personalized insights about your gut health."
+            aiInsightSeverity = .neutral
+        } else if todaysSymptoms.isEmpty {
+            aiInsightSummary = "Looking good so far. Keep logging meals for better insights."
+            aiInsightSeverity = .neutral
+        } else if todaysSymptoms.contains(where: { $0.painLevel.rawValue >= 7 }) {
+            aiInsightSummary = "Elevated symptoms detected. Consider gentle, easy-to-digest foods."
+            aiInsightSeverity = .warning
+        } else if !todaysSymptoms.isEmpty && !todaysMeals.isEmpty {
+            let recentMealName = todaysMeals.last?.name ?? "your recent meal"
+            aiInsightSummary = "Possible trigger: \(recentMealName). Symptoms appeared after eating."
+            aiInsightSeverity = .warning
+        } else {
+            aiInsightSummary = "Keep logging to help identify patterns."
+            aiInsightSeverity = .neutral
+        }
     }
     
     // MARK: - Preview Support
@@ -198,6 +255,8 @@ import Combine
         self.todaysHealthScore = 8
         self.todaysFocus = "Focus on eating slowly and mindfully today. Try setting your fork down between bites."
         self.avoidanceTip = "Skip dairy products (milk, cheese, ice cream) - they've caused bloating 3 times this week"
+        self.aiInsightSummary = "No triggers detected today. Your digestion looks healthy!"
+        self.aiInsightSeverity = .positive
     }
     
     // MARK: - Private Load Logic
@@ -247,6 +306,8 @@ import Combine
                     self.insightMessage = nil
                     self.todaysFocus = "Unable to load data. Please try again."
                     self.avoidanceTip = "Check your connection and try refreshing."
+                    self.aiInsightSummary = "Unable to generate insights right now."
+                    self.aiInsightSeverity = .neutral
                 }
             }
         }

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardComponents.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardComponents.swift
@@ -150,6 +150,49 @@ struct DashboardInsightCard: View {
     }
 }
 
+/// AI Insights Card - Full-width card displaying AI-generated health insight
+struct AIInsightsCard: View {
+    let summary: String
+    let severity: AIInsightSeverity
+    
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: severity.icon)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(severity.color)
+                .frame(width: 36, height: 36)
+                .background(severity.color.opacity(0.15))
+                .clipShape(.rect(cornerRadius: 8))
+                .accessibleDecorative()
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text("AI Insights")
+                    .typography(Typography.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(ColorTheme.primaryText)
+                
+                Text(summary)
+                    .typography(Typography.caption)
+                    .foregroundStyle(ColorTheme.secondaryText)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(ColorTheme.cardBackground)
+                .shadow(color: ColorTheme.shadowColor.opacity(0.08), radius: 6, x: 0, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(severity.color.opacity(0.3), lineWidth: 1)
+        )
+    }
+}
+
 /// Floating Action Button - Modern circular button with label
 struct FloatingActionButton: View {
     let icon: String

--- a/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
+++ b/GutCheck/GutCheck/Views/Dashboard/DashboardView.swift
@@ -91,6 +91,15 @@ struct DashboardView: View {
                         }
                     }
                     
+                    // AI Insights Card
+                    AIInsightsCard(
+                        summary: dashboardStore.aiInsightSummary,
+                        severity: dashboardStore.aiInsightSeverity
+                    )
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("AI Insights: \(dashboardStore.aiInsightSummary)")
+                    .accessibilityIdentifier(AccessibilityIdentifiers.Dashboard.aiInsightsCard)
+                    
                     // Trigger alerts with better styling
                     if !dashboardStore.triggerAlerts.isEmpty {
                         VStack(spacing: 12) {


### PR DESCRIPTION
## Summary
- Add a full-width **AI Insights card** to the dashboard, positioned between the existing Focus/Watch Out grid and trigger alerts
- Card displays context-aware health messages with color-coded severity (green for positive, blue for neutral, orange for warning)
- Placeholder logic analyzes current meal and symptom data to generate 6 different insight states (healthy day, no data, good so far, high severity symptoms, possible meal trigger, fallback)
- Designed for future integration with `AIAnalysisService`

## Test plan
- [x] Project builds successfully
- [x] All 217 tests pass (0 failures, 0 regressions)
- [x] Zero compiler diagnostics on all modified files
- [x] Preview data includes sample AI insight for visual verification

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)