### PR TITLE
feat(#41): add weekly trigger report with week-over-week comparison

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -190,6 +190,8 @@ enum AccessibilityIdentifiers {
         static let timeRangeSelector = "insights.timeRange"
         static let filterButton = "insights.filter.button"
         static let insightCardsList = "insights.cards.list"
+        static let weeklyTriggerReportCard = "insights.weeklyTriggerReport.card"
+        static let weeklyTriggerReportView = "insights.weeklyTriggerReport.view"
         
         static func insightCard(_ index: Int) -> String {
             "insights.card.\(index)"

--- a/GutCheck/GutCheck/Models/Core/WeeklyTriggerReport.swift
+++ b/GutCheck/GutCheck/Models/Core/WeeklyTriggerReport.swift
@@ -1,0 +1,70 @@
+//
+//  WeeklyTriggerReport.swift
+//  GutCheck
+//
+//  Weekly trigger report model for week-over-week food trigger comparison.
+//
+
+import Foundation
+
+// MARK: - Trend Direction
+
+enum TrendDirection: String, Hashable {
+    case improving
+    case worsening
+    case stable
+
+    var icon: String {
+        switch self {
+        case .improving: return "arrow.down.right"
+        case .worsening: return "arrow.up.right"
+        case .stable: return "minus"
+        }
+    }
+}
+
+// MARK: - Trigger Entry
+
+struct TriggerEntry: Identifiable, Hashable {
+    let id: UUID
+    let foodName: String
+    let correlationCount: Int
+    let confidence: Double
+    let averageOnsetHours: Double
+    let associatedSymptoms: [String]
+    let recommendations: [String]
+}
+
+// MARK: - Weekly Trigger Report
+
+struct WeeklyTriggerReport: Identifiable, Hashable {
+    let id: UUID
+    let generatedDate: Date
+    let weekStart: Date
+    let weekEnd: Date
+    let newTriggers: [TriggerEntry]
+    let recurringTriggers: [TriggerEntry]
+    let resolvedTriggers: [TriggerEntry]
+    let currentWeekSymptomCount: Int
+    let previousWeekSymptomCount: Int
+    let currentWeekMealCount: Int
+    let previousWeekMealCount: Int
+
+    var totalTriggerCount: Int {
+        newTriggers.count + recurringTriggers.count
+    }
+
+    var symptomTrend: TrendDirection {
+        if currentWeekSymptomCount < previousWeekSymptomCount { return .improving }
+        if currentWeekSymptomCount > previousWeekSymptomCount { return .worsening }
+        return .stable
+    }
+
+    var symptomChangePercentage: Int {
+        guard previousWeekSymptomCount > 0 else {
+            return currentWeekSymptomCount > 0 ? 100 : 0
+        }
+        let change = Double(currentWeekSymptomCount - previousWeekSymptomCount) / Double(previousWeekSymptomCount) * 100
+        return Int(change)
+    }
+}

--- a/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
+++ b/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
@@ -51,6 +51,7 @@ enum SettingsRoute: Hashable {
 enum InsightsRoute: Hashable {
     case insightDetail(HealthInsight)
     case categoryInsights(InsightCategory)
+    case weeklyTriggerReport(WeeklyTriggerReport)
 }
 
 // Privacy policy navigation

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -22,6 +22,7 @@ struct RankedItem: Identifiable {
     var topSymptoms: [RankedItem] = []
     var topTriggerFoods: [RankedItem] = []
     var bestDays: [RankedItem] = []
+    var weeklyTriggerReport: WeeklyTriggerReport?
 
     private let insightsService = InsightsService.shared
     private let mealRepository = MealRepository.shared
@@ -75,6 +76,9 @@ struct RankedItem: Identifiable {
 
             // Compute weekly summary cards
             computeWeeklySummaries(meals: meals, symptoms: symptoms)
+
+            // Compute weekly trigger report (week-over-week comparison)
+            computeWeeklyTriggerReport(meals: meals, symptoms: symptoms)
 
         } catch {
             self.error = error.localizedDescription
@@ -234,6 +238,128 @@ struct RankedItem: Identifiable {
             .sorted { $0.value > $1.value }
             .prefix(3)
             .map { RankedItem(name: $0.key, count: $0.value) }
+    }
+
+    // MARK: - Weekly Trigger Report
+
+    private func computeWeeklyTriggerReport(meals: [Meal], symptoms: [Symptom]) {
+        let calendar = Calendar.current
+        let now = Date.now
+        let currentWeekStart = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+        let previousWeekStart = calendar.date(byAdding: .day, value: -14, to: now) ?? now
+
+        let currentWeekMeals = meals.filter { $0.date >= currentWeekStart }
+        let currentWeekSymptoms = symptoms.filter { $0.date >= currentWeekStart }
+        let previousWeekMeals = meals.filter { $0.date >= previousWeekStart && $0.date < currentWeekStart }
+        let previousWeekSymptoms = symptoms.filter { $0.date >= previousWeekStart && $0.date < currentWeekStart }
+
+        let currentTriggers = computeTriggerEntries(meals: currentWeekMeals, symptoms: currentWeekSymptoms)
+        let previousTriggers = computeTriggerEntries(meals: previousWeekMeals, symptoms: previousWeekSymptoms)
+
+        let currentFoodNames = Set(currentTriggers.keys)
+        let previousFoodNames = Set(previousTriggers.keys)
+
+        let newTriggers = currentFoodNames.subtracting(previousFoodNames)
+            .compactMap { currentTriggers[$0] }
+            .sorted { $0.correlationCount > $1.correlationCount }
+        let recurringTriggers = currentFoodNames.intersection(previousFoodNames)
+            .compactMap { currentTriggers[$0] }
+            .sorted { $0.correlationCount > $1.correlationCount }
+        let resolvedTriggers = previousFoodNames.subtracting(currentFoodNames)
+            .compactMap { previousTriggers[$0] }
+            .sorted { $0.correlationCount > $1.correlationCount }
+
+        // Only produce a report if there is meaningful data
+        guard !newTriggers.isEmpty || !recurringTriggers.isEmpty || !resolvedTriggers.isEmpty else {
+            weeklyTriggerReport = nil
+            return
+        }
+
+        weeklyTriggerReport = WeeklyTriggerReport(
+            id: UUID(),
+            generatedDate: now,
+            weekStart: currentWeekStart,
+            weekEnd: now,
+            newTriggers: newTriggers,
+            recurringTriggers: recurringTriggers,
+            resolvedTriggers: resolvedTriggers,
+            currentWeekSymptomCount: currentWeekSymptoms.count,
+            previousWeekSymptomCount: previousWeekSymptoms.count,
+            currentWeekMealCount: currentWeekMeals.count,
+            previousWeekMealCount: previousWeekMeals.count
+        )
+    }
+
+    /// Compute trigger entries for a given set of meals and symptoms using 2-8 hour correlation.
+    private func computeTriggerEntries(meals: [Meal], symptoms: [Symptom]) -> [String: TriggerEntry] {
+        var foodData: [String: (count: Int, onsetHours: [Double], symptomTypes: Set<String>)] = [:]
+
+        for symptom in symptoms {
+            guard symptom.painLevel != .none || symptom.urgencyLevel != .none
+                    || symptom.stoolType == .type1 || symptom.stoolType == .type2
+                    || symptom.stoolType == .type6 || symptom.stoolType == .type7 else {
+                continue
+            }
+
+            // Determine symptom labels
+            var symptomLabels: [String] = []
+            switch symptom.painLevel {
+            case .mild: symptomLabels.append("Mild Pain")
+            case .moderate: symptomLabels.append("Moderate Pain")
+            case .severe: symptomLabels.append("Severe Pain")
+            case .none: break
+            }
+            switch symptom.urgencyLevel {
+            case .mild: symptomLabels.append("Mild Urgency")
+            case .moderate: symptomLabels.append("Moderate Urgency")
+            case .urgent: symptomLabels.append("High Urgency")
+            case .none: break
+            }
+            switch symptom.stoolType {
+            case .type1, .type2: symptomLabels.append("Constipation")
+            case .type6, .type7: symptomLabels.append("Loose Stool")
+            default: break
+            }
+
+            // Find meals eaten 2-8 hours before this symptom
+            let windowStart = symptom.date.addingTimeInterval(-8 * 3600)
+            let windowEnd = symptom.date.addingTimeInterval(-2 * 3600)
+            let precedingMeals = meals.filter { $0.date >= windowStart && $0.date <= windowEnd }
+
+            for meal in precedingMeals {
+                let onsetHours = symptom.date.timeIntervalSince(meal.date) / 3600
+                for item in meal.foodItems {
+                    var entry = foodData[item.name] ?? (count: 0, onsetHours: [], symptomTypes: Set())
+                    entry.count += 1
+                    entry.onsetHours.append(onsetHours)
+                    symptomLabels.forEach { entry.symptomTypes.insert($0) }
+                    foodData[item.name] = entry
+                }
+            }
+        }
+
+        var result: [String: TriggerEntry] = [:]
+        for (name, data) in foodData {
+            let avgOnset = data.onsetHours.isEmpty ? 0 : data.onsetHours.reduce(0, +) / Double(data.onsetHours.count)
+            let confidence = min(0.95, Double(data.count) / 10.0 + 0.3)
+
+            var recommendations = ["Consider reducing \(name) intake for 2-4 weeks"]
+            if data.count >= 3 {
+                recommendations.append("Strong correlation detected — consult a dietitian")
+            }
+            recommendations.append("Reintroduce gradually to confirm sensitivity")
+
+            result[name] = TriggerEntry(
+                id: UUID(),
+                foodName: name,
+                correlationCount: data.count,
+                confidence: confidence,
+                averageOnsetHours: avgOnset,
+                associatedSymptoms: Array(data.symptomTypes).sorted(),
+                recommendations: recommendations
+            )
+        }
+        return result
     }
 
     /// Rank days of the week by lowest symptom count (last 30 days)

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -18,6 +18,11 @@ struct InsightsView: View {
                 // Weekly Stats Row
                 weeklyStatsRow
 
+                // Weekly Trigger Report Card
+                if let report = viewModel.weeklyTriggerReport {
+                    weeklyTriggerReportCard(report: report)
+                }
+
                 // Top Summary Cards
                 topSymptomsCard
                 triggerFoodsCard
@@ -50,6 +55,8 @@ struct InsightsView: View {
                 InsightDetailView(insight: insight)
             case .categoryInsights(let category):
                 CategoryInsightsView(category: category)
+            case .weeklyTriggerReport(let report):
+                WeeklyTriggerReportView(report: report)
             }
         }
         .toolbar {
@@ -151,6 +158,53 @@ struct InsightsView: View {
                 color: ColorTheme.accent
             )
         }
+    }
+
+    private func weeklyTriggerReportCard(report: WeeklyTriggerReport) -> some View {
+        NavigationLink(value: InsightsRoute.weeklyTriggerReport(report)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.title2)
+                        .foregroundStyle(ColorTheme.accent)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Weekly Trigger Report")
+                            .font(.headline)
+                            .foregroundStyle(ColorTheme.primaryText)
+                        Text(reportDateRange(report))
+                            .font(.caption)
+                            .foregroundStyle(ColorTheme.secondaryText)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                HStack(spacing: 12) {
+                    TriggerCountPill(count: report.newTriggers.count, label: "New", color: .red)
+                    TriggerCountPill(count: report.recurringTriggers.count, label: "Recurring", color: .orange)
+                    TriggerCountPill(count: report.resolvedTriggers.count, label: "Resolved", color: ColorTheme.success)
+                }
+            }
+            .padding()
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+        }
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.weeklyTriggerReportCard)
+    }
+
+    private func reportDateRange(_ report: WeeklyTriggerReport) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        let start = formatter.string(from: report.weekStart)
+        let endFormatter = DateFormatter()
+        endFormatter.dateFormat = "MMM d, yyyy"
+        let end = endFormatter.string(from: report.weekEnd)
+        return "\(start) – \(end)"
     }
 
     private var topSymptomsCard: some View {

--- a/GutCheck/GutCheck/Views/Analytics/WeeklyTriggerReportView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/WeeklyTriggerReportView.swift
@@ -1,0 +1,411 @@
+//
+//  WeeklyTriggerReportView.swift
+//  GutCheck
+//
+//  Detail view for the weekly trigger report showing new, recurring, and resolved triggers.
+//
+
+import SwiftUI
+
+struct WeeklyTriggerReportView: View {
+    let report: WeeklyTriggerReport
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                reportHeader
+                summaryStats
+                if !report.newTriggers.isEmpty { newTriggersSection }
+                if !report.recurringTriggers.isEmpty { recurringTriggersSection }
+                if !report.resolvedTriggers.isEmpty { resolvedTriggersSection }
+                symptomTrendCard
+                recommendationsSection
+            }
+            .padding()
+        }
+        .navigationTitle("Weekly Report")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.weeklyTriggerReportView)
+    }
+
+    // MARK: - Header
+
+    private var reportHeader: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.title2)
+                    .foregroundStyle(ColorTheme.accent)
+
+                Text("Weekly Trigger Report")
+                    .font(.title2.bold())
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                Spacer()
+
+                TrendBadge(trend: report.symptomTrend)
+            }
+
+            Text(dateRangeString)
+                .font(.subheadline)
+                .foregroundStyle(ColorTheme.secondaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    // MARK: - Summary Stats
+
+    private var summaryStats: some View {
+        HStack(spacing: 12) {
+            TriggerCountPill(
+                count: report.newTriggers.count,
+                label: "New",
+                color: .red
+            )
+            TriggerCountPill(
+                count: report.recurringTriggers.count,
+                label: "Recurring",
+                color: .orange
+            )
+            TriggerCountPill(
+                count: report.resolvedTriggers.count,
+                label: "Resolved",
+                color: ColorTheme.success
+            )
+        }
+    }
+
+    // MARK: - Trigger Sections
+
+    private var newTriggersSection: some View {
+        triggerSection(
+            title: "New Triggers",
+            icon: "exclamationmark.triangle.fill",
+            accentColor: .red,
+            triggers: report.newTriggers,
+            badge: nil
+        )
+    }
+
+    private var recurringTriggersSection: some View {
+        triggerSection(
+            title: "Recurring Triggers",
+            icon: "arrow.triangle.2.circlepath",
+            accentColor: .orange,
+            triggers: report.recurringTriggers,
+            badge: "2+ weeks"
+        )
+    }
+
+    private var resolvedTriggersSection: some View {
+        triggerSection(
+            title: "Resolved Triggers",
+            icon: "checkmark.circle.fill",
+            accentColor: ColorTheme.success,
+            triggers: report.resolvedTriggers,
+            badge: "No longer detected"
+        )
+    }
+
+    private func triggerSection(
+        title: String,
+        icon: String,
+        accentColor: Color,
+        triggers: [TriggerEntry],
+        badge: String?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label(title, systemImage: icon)
+                    .font(.headline)
+                    .foregroundStyle(accentColor)
+
+                Spacer()
+
+                if let badge {
+                    Text(badge)
+                        .font(.caption)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(accentColor.opacity(0.8)))
+                }
+            }
+
+            ForEach(triggers) { trigger in
+                TriggerEntryRow(trigger: trigger, accentColor: accentColor)
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    // MARK: - Symptom Trend
+
+    private var symptomTrendCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Symptom Trend", systemImage: "chart.line.uptrend.xyaxis")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            HStack(spacing: 24) {
+                VStack(spacing: 4) {
+                    Text("\(report.currentWeekSymptomCount)")
+                        .font(.title.bold())
+                        .foregroundStyle(ColorTheme.primaryText)
+                    Text("This week")
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Image(systemName: "arrow.right")
+                    .foregroundStyle(ColorTheme.secondaryText)
+
+                VStack(spacing: 4) {
+                    Text("\(report.previousWeekSymptomCount)")
+                        .font(.title.bold())
+                        .foregroundStyle(ColorTheme.secondaryText)
+                    Text("Last week")
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Spacer()
+
+                VStack(spacing: 4) {
+                    TrendBadge(trend: report.symptomTrend)
+                    if report.symptomChangePercentage != 0 {
+                        Text("\(abs(report.symptomChangePercentage))%")
+                            .font(.caption.bold())
+                            .foregroundStyle(trendColor)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    // MARK: - Recommendations
+
+    private var recommendationsSection: some View {
+        let allRecommendations = aggregatedRecommendations
+        guard !allRecommendations.isEmpty else { return AnyView(EmptyView()) }
+
+        return AnyView(
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Recommendations", systemImage: "lightbulb.fill")
+                    .font(.headline)
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                ForEach(allRecommendations, id: \.self) { recommendation in
+                    Label(recommendation, systemImage: "checkmark.circle")
+                        .font(.subheadline)
+                        .foregroundStyle(ColorTheme.accent)
+                }
+            }
+            .padding()
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private var dateRangeString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        let start = formatter.string(from: report.weekStart)
+        let endFormatter = DateFormatter()
+        endFormatter.dateFormat = "MMM d, yyyy"
+        let end = endFormatter.string(from: report.weekEnd)
+        return "\(start) – \(end)"
+    }
+
+    private var trendColor: Color {
+        switch report.symptomTrend {
+        case .improving: return ColorTheme.success
+        case .worsening: return .red
+        case .stable: return ColorTheme.secondaryText
+        }
+    }
+
+    private var aggregatedRecommendations: [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        let allTriggers = report.newTriggers + report.recurringTriggers
+        for trigger in allTriggers {
+            for rec in trigger.recommendations {
+                if seen.insert(rec).inserted {
+                    result.append(rec)
+                }
+            }
+        }
+        return result
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct TriggerEntryRow: View {
+    let trigger: TriggerEntry
+    let accentColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(trigger.foodName)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                Spacer()
+
+                Text("\(trigger.correlationCount) correlation\(trigger.correlationCount == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+
+            HStack(spacing: 12) {
+                // Confidence bar
+                HStack(spacing: 4) {
+                    Text("Confidence")
+                        .font(.caption2)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                    ProgressView(value: trigger.confidence)
+                        .tint(accentColor)
+                        .frame(width: 60)
+                }
+
+                // Average onset
+                Label(String(format: "%.1fh onset", trigger.averageOnsetHours), systemImage: "clock")
+                    .font(.caption2)
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+
+            if !trigger.associatedSymptoms.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(trigger.associatedSymptoms, id: \.self) { symptom in
+                        Text(symptom)
+                            .font(.caption2)
+                            .foregroundStyle(accentColor)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(accentColor.opacity(0.1)))
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct TrendBadge: View {
+    let trend: TrendDirection
+
+    var body: some View {
+        Image(systemName: trend.icon)
+            .font(.caption.bold())
+            .foregroundStyle(.white)
+            .frame(width: 28, height: 28)
+            .background(Circle().fill(color))
+    }
+
+    private var color: Color {
+        switch trend {
+        case .improving: return ColorTheme.success
+        case .worsening: return .red
+        case .stable: return ColorTheme.secondaryText
+        }
+    }
+}
+
+struct TriggerCountPill: View {
+    let count: Int
+    let label: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Text("\(count)")
+                .font(.title2.bold())
+                .foregroundStyle(count > 0 ? color : ColorTheme.secondaryText)
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(ColorTheme.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        WeeklyTriggerReportView(report: WeeklyTriggerReport(
+            id: UUID(),
+            generatedDate: .now,
+            weekStart: Calendar.current.date(byAdding: .day, value: -7, to: .now)!,
+            weekEnd: .now,
+            newTriggers: [
+                TriggerEntry(
+                    id: UUID(),
+                    foodName: "Spicy Chicken",
+                    correlationCount: 4,
+                    confidence: 0.7,
+                    averageOnsetHours: 3.5,
+                    associatedSymptoms: ["Moderate Pain", "Loose Stool"],
+                    recommendations: ["Consider reducing Spicy Chicken intake for 2-4 weeks", "Reintroduce gradually to confirm sensitivity"]
+                ),
+                TriggerEntry(
+                    id: UUID(),
+                    foodName: "Fried Rice",
+                    correlationCount: 2,
+                    confidence: 0.5,
+                    averageOnsetHours: 4.2,
+                    associatedSymptoms: ["Mild Urgency"],
+                    recommendations: ["Consider reducing Fried Rice intake for 2-4 weeks"]
+                )
+            ],
+            recurringTriggers: [
+                TriggerEntry(
+                    id: UUID(),
+                    foodName: "Dairy Milk",
+                    correlationCount: 5,
+                    confidence: 0.8,
+                    averageOnsetHours: 2.8,
+                    associatedSymptoms: ["Moderate Pain", "High Urgency", "Loose Stool"],
+                    recommendations: ["Consider reducing Dairy Milk intake for 2-4 weeks", "Strong correlation detected — consult a dietitian", "Reintroduce gradually to confirm sensitivity"]
+                )
+            ],
+            resolvedTriggers: [
+                TriggerEntry(
+                    id: UUID(),
+                    foodName: "Wheat Bread",
+                    correlationCount: 3,
+                    confidence: 0.6,
+                    averageOnsetHours: 5.0,
+                    associatedSymptoms: ["Mild Pain"],
+                    recommendations: ["Consider reducing Wheat Bread intake for 2-4 weeks"]
+                )
+            ],
+            currentWeekSymptomCount: 8,
+            previousWeekSymptomCount: 12,
+            currentWeekMealCount: 18,
+            previousWeekMealCount: 15
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Weekly Trigger Report feature that auto-generates a week-over-week summary of food triggers
- Classifies triggers as **new** (only current week), **recurring** (both weeks), or **resolved** (only previous week) using 2-8 hour meal-to-symptom correlation
- Displays a prominent entry card in InsightsView that navigates to a full detail view with trigger sections, symptom trend, and aggregated recommendations

## Changes
- **New:** `WeeklyTriggerReport.swift` — `WeeklyTriggerReport`, `TriggerEntry`, `TrendDirection` models
- **New:** `WeeklyTriggerReportView.swift` — Detail view with 7 sections (header, summary stats, new/recurring/resolved triggers, symptom trend, recommendations)
- **Modified:** `InsightsViewModel.swift` — Added `computeWeeklyTriggerReport()` and `computeTriggerEntries()` methods
- **Modified:** `NavigationRoutes.swift` — Added `.weeklyTriggerReport` case to `InsightsRoute`
- **Modified:** `InsightsView.swift` — Added entry card and navigation destination
- **Modified:** `AccessibilityIdentifiers.swift` — Added report card and view identifiers

## Test plan
- [x] Build succeeds with zero errors
- [x] WeeklyTriggerReportView preview renders correctly
- [x] All 217 existing tests pass with no regressions
- [ ] Verify entry card appears in InsightsView when trigger data exists
- [ ] Verify navigation from entry card to detail view works
- [ ] Verify empty state (no card shown when no triggers detected)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)