### PR TITLE
feat(#39): add symptom explorer view for investigating meals before symptoms

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -202,6 +202,16 @@ enum AccessibilityIdentifiers {
         static func triggerPatternCard(_ index: Int) -> String {
             "insights.triggerPattern.card.\(index)"
         }
+        
+        // Symptom Explorer
+        static let symptomExplorerCard = "insights.symptomExplorer.card"
+        static let symptomExplorerView = "insights.symptomExplorer.view"
+        static let symptomExplorerPicker = "insights.symptomExplorer.picker"
+        static let symptomExplorerEmptyState = "insights.symptomExplorer.empty"
+        
+        static func suspectedMealCard(_ index: Int) -> String {
+            "insights.symptomExplorer.meal.\(index)"
+        }
     }
     
     // MARK: - Tab Bar

--- a/GutCheck/GutCheck/Models/Core/SuspectedMeal.swift
+++ b/GutCheck/GutCheck/Models/Core/SuspectedMeal.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A food item within a SuspectedMeal that has been flagged as a potential trigger.
+struct SuspectedFood: Identifiable, Hashable {
+    let id: UUID
+    let foodItem: FoodItem
+    let triggerScore: Int           // 0-100 individual food score
+    let compoundRisks: [String]     // e.g. ["Lactose", "Casein"]
+    let reason: String              // human-readable explanation
+}
+
+/// Represents a meal that was eaten 6-24 hours before a selected symptom,
+/// along with its computed trigger likelihood.
+struct SuspectedMeal: Identifiable, Hashable {
+    let id: UUID
+    let meal: Meal
+    let timeBefore: Double          // hours before the symptom
+    let triggerLikelihood: Int      // 0-100 composite score
+    let suspectedFoods: [SuspectedFood]
+
+    /// Human-readable time gap, e.g. "8.2 hours before"
+    var timeBeforeFormatted: String {
+        String(format: "%.1f hours before", timeBefore)
+    }
+}

--- a/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
+++ b/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
@@ -53,6 +53,7 @@ enum InsightsRoute: Hashable {
     case categoryInsights(InsightCategory)
     case weeklyTriggerReport(WeeklyTriggerReport)
     case triggerPatternDetail(TriggerPattern)
+    case symptomExplorer
 }
 
 // Privacy policy navigation

--- a/GutCheck/GutCheck/ViewModels/Analysis/SymptomExplorerViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/SymptomExplorerViewModel.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+@MainActor
+@Observable class SymptomExplorerViewModel {
+
+    // MARK: - Published State
+
+    var recentSymptoms: [Symptom] = []
+    var selectedSymptom: Symptom? = nil
+    var suspectedMeals: [SuspectedMeal] = []
+    var isLoading = false
+    var isLoadingMeals = false
+    var error: String?
+
+    // MARK: - Dependencies
+
+    private let mealRepository = MealRepository.shared
+    private let symptomRepository = SymptomRepository.shared
+    private let authService = AuthService()
+    private let compoundDatabase = FoodCompoundDatabase.shared
+
+    // Cached data for quick re-computation on symptom change
+    private var triggerPatterns: [TriggerPattern] = []
+    private var allMeals: [Meal] = []
+
+    // MARK: - Load Data
+
+    func loadData() async {
+        isLoading = true
+        error = nil
+
+        do {
+            let userId = getCurrentUserId()
+            let endDate = Date.now
+            let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
+
+            async let symptomsTask = symptomRepository.fetchSymptomsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+            async let mealsTask = mealRepository.fetchMealsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+
+            let symptoms = try await symptomsTask
+            let meals = try await mealsTask
+
+            recentSymptoms = symptoms
+                .filter { hasSignificantSymptoms($0) }
+                .sorted { $0.date > $1.date }
+
+            allMeals = meals
+
+            triggerPatterns = await PatternRecognitionService.shared
+                .analyzeTriggerPatterns(meals: meals, symptoms: symptoms)
+
+            // Auto-select the most recent symptom
+            if let first = recentSymptoms.first {
+                selectSymptom(first)
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Symptom Selection
+
+    func selectSymptom(_ symptom: Symptom) {
+        selectedSymptom = symptom
+        computeSuspectedMeals(for: symptom)
+    }
+
+    // MARK: - Core Computation
+
+    private func computeSuspectedMeals(for symptom: Symptom) {
+        isLoadingMeals = true
+
+        let windowStart = symptom.date.addingTimeInterval(-24 * 3600) // 24hrs before
+        let windowEnd = symptom.date.addingTimeInterval(-6 * 3600)    // 6hrs before
+
+        let precedingMeals = allMeals.filter { $0.date >= windowStart && $0.date <= windowEnd }
+
+        // Build lookup of known trigger foods by name
+        let knownTriggerFoods: [String: TriggerPattern] = Dictionary(
+            triggerPatterns.map { ($0.foodName.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var results: [SuspectedMeal] = []
+
+        for meal in precedingMeals {
+            let timeBefore = symptom.date.timeIntervalSince(meal.date) / 3600.0
+            var mealScore: Double = 0
+            var suspectedFoods: [SuspectedFood] = []
+
+            for item in meal.foodItems {
+                let foodKey = item.name.lowercased().trimmingCharacters(in: .whitespaces)
+                var foodScore: Double = 0
+                var reasons: [String] = []
+                var compoundRisks: [String] = []
+
+                // 1) Known trigger pattern match (40% weight)
+                if let pattern = knownTriggerFoods[foodKey] {
+                    foodScore += Double(pattern.triggerScore.overall) / 100.0 * 0.40
+                    reasons.append("Known trigger (score: \(pattern.triggerScore.overall))")
+                }
+
+                // 2) Compound risk from FoodCompoundDatabase (30% weight)
+                let compounds = compoundDatabase.getCompoundsForFood(
+                    name: item.name, ingredients: item.ingredients
+                )
+                let highRisk = compounds.filter { $0.severity == .high }
+                let medRisk = compounds.filter { $0.severity == .medium }
+                let compoundScore = min(1.0, Double(highRisk.count) * 0.3 + Double(medRisk.count) * 0.15)
+                foodScore += compoundScore * 0.30
+                compoundRisks = (highRisk + medRisk).map { $0.name }
+                if !highRisk.isEmpty {
+                    reasons.append("\(highRisk.count) high-risk compound(s)")
+                }
+                if !medRisk.isEmpty {
+                    reasons.append("\(medRisk.count) medium-risk compound(s)")
+                }
+
+                // 3) Time proximity (30% weight) — closer to 6hr = higher
+                let proximityScore = 1.0 - ((timeBefore - 6.0) / 18.0)
+                foodScore += max(0, min(1.0, proximityScore)) * 0.30
+
+                let finalScore = Int(min(100, max(0, foodScore * 100)))
+
+                if finalScore > 10 || !compoundRisks.isEmpty {
+                    suspectedFoods.append(SuspectedFood(
+                        id: UUID(),
+                        foodItem: item,
+                        triggerScore: finalScore,
+                        compoundRisks: compoundRisks,
+                        reason: reasons.isEmpty ? "Time proximity" : reasons.joined(separator: "; ")
+                    ))
+                }
+
+                mealScore = max(mealScore, foodScore)
+            }
+
+            suspectedFoods.sort { $0.triggerScore > $1.triggerScore }
+
+            results.append(SuspectedMeal(
+                id: UUID(),
+                meal: meal,
+                timeBefore: timeBefore,
+                triggerLikelihood: Int(min(100, max(0, mealScore * 100))),
+                suspectedFoods: suspectedFoods
+            ))
+        }
+
+        suspectedMeals = results.sorted { $0.triggerLikelihood > $1.triggerLikelihood }
+        isLoadingMeals = false
+    }
+
+    // MARK: - Helpers
+
+    private func getCurrentUserId() -> String {
+        authService.currentUser?.id ?? "default_user"
+    }
+
+    private func hasSignificantSymptoms(_ symptom: Symptom) -> Bool {
+        symptom.painLevel != .none
+            || symptom.urgencyLevel != .none
+            || symptom.stoolType == .type1 || symptom.stoolType == .type2
+            || symptom.stoolType == .type6 || symptom.stoolType == .type7
+    }
+
+    /// Format a symptom for display in the picker
+    func symptomLabel(for symptom: Symptom) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm a"
+        var parts = [formatter.string(from: symptom.date)]
+
+        switch symptom.painLevel {
+        case .mild: parts.append("Mild Pain")
+        case .moderate: parts.append("Moderate Pain")
+        case .severe: parts.append("Severe Pain")
+        case .none: break
+        }
+
+        switch symptom.urgencyLevel {
+        case .mild: parts.append("Mild Urgency")
+        case .moderate: parts.append("Moderate Urgency")
+        case .urgent: parts.append("Urgent")
+        case .none: break
+        }
+
+        return parts.joined(separator: " · ")
+    }
+}

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -31,6 +31,10 @@ struct InsightsView: View {
                 // Top Summary Cards
                 topSymptomsCard
                 triggerFoodsCard
+
+                // Symptom Explorer Card
+                symptomExplorerCard
+
                 bestDaysCard
 
                 // Recent Insights Section
@@ -64,6 +68,8 @@ struct InsightsView: View {
                 WeeklyTriggerReportView(report: report)
             case .triggerPatternDetail(let pattern):
                 TriggerPatternDetailView(pattern: pattern)
+            case .symptomExplorer:
+                SymptomExplorerView()
             }
         }
         .toolbar {
@@ -268,6 +274,37 @@ struct InsightsView: View {
         if score >= 70 { return .red }
         if score >= 40 { return .orange }
         return .yellow
+    }
+
+    // MARK: - Symptom Explorer
+
+    private var symptomExplorerCard: some View {
+        NavigationLink(value: InsightsRoute.symptomExplorer) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(ColorTheme.accent)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Symptom Explorer")
+                        .font(.headline)
+                        .foregroundStyle(ColorTheme.primaryText)
+                    Text("Investigate meals before symptoms")
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+            .padding()
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+        }
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomExplorerCard)
     }
 
     private var topSymptomsCard: some View {

--- a/GutCheck/GutCheck/Views/Analytics/SymptomExplorerView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/SymptomExplorerView.swift
@@ -1,0 +1,387 @@
+import SwiftUI
+
+struct SymptomExplorerView: View {
+    @State private var viewModel = SymptomExplorerViewModel()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                if viewModel.isLoading {
+                    ProgressView("Loading symptoms…")
+                        .padding(.top, 40)
+                } else if viewModel.recentSymptoms.isEmpty {
+                    noSymptomsState
+                } else {
+                    symptomPickerSection
+
+                    if let symptom = viewModel.selectedSymptom {
+                        selectedSymptomCard(symptom)
+                    }
+
+                    if viewModel.isLoadingMeals {
+                        ProgressView()
+                    } else if viewModel.suspectedMeals.isEmpty && viewModel.selectedSymptom != nil {
+                        emptyMealsState
+                    } else {
+                        suspectedMealsSection
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Symptom Explorer")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomExplorerView)
+        .task {
+            await viewModel.loadData()
+        }
+    }
+
+    // MARK: - Symptom Picker
+
+    private var symptomPickerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Select Symptom", systemImage: "heart.text.clipboard")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            Picker("Symptom", selection: Binding(
+                get: { viewModel.selectedSymptom },
+                set: { newValue in
+                    if let symptom = newValue {
+                        viewModel.selectSymptom(symptom)
+                    }
+                }
+            )) {
+                ForEach(viewModel.recentSymptoms) { symptom in
+                    Text(viewModel.symptomLabel(for: symptom))
+                        .tag(Optional(symptom))
+                }
+            }
+            .pickerStyle(.menu)
+            .padding(12)
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomExplorerPicker)
+        }
+    }
+
+    // MARK: - Selected Symptom Card
+
+    private func selectedSymptomCard(_ symptom: Symptom) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Symptom Details", systemImage: "info.circle.fill")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            HStack(spacing: 16) {
+                symptomDetailItem(
+                    icon: "calendar",
+                    label: "Date",
+                    value: formattedDate(symptom.date)
+                )
+
+                symptomDetailItem(
+                    icon: "clock",
+                    label: "Time",
+                    value: formattedTime(symptom.date)
+                )
+            }
+
+            HStack(spacing: 16) {
+                symptomDetailItem(
+                    icon: "bolt.fill",
+                    label: "Pain",
+                    value: painLabel(symptom.painLevel),
+                    color: painColor(symptom.painLevel)
+                )
+
+                symptomDetailItem(
+                    icon: "exclamationmark.triangle.fill",
+                    label: "Urgency",
+                    value: urgencyLabel(symptom.urgencyLevel),
+                    color: urgencyColor(symptom.urgencyLevel)
+                )
+
+                symptomDetailItem(
+                    icon: "chart.bar.fill",
+                    label: "Bristol",
+                    value: "Type \(symptom.stoolType.rawValue)"
+                )
+            }
+
+            if let notes = symptom.notes, !notes.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notes")
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                    Text(notes)
+                        .font(.subheadline)
+                        .foregroundStyle(ColorTheme.primaryText)
+                }
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    private func symptomDetailItem(
+        icon: String,
+        label: String,
+        value: String,
+        color: Color = ColorTheme.primaryText
+    ) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(ColorTheme.accent)
+            Text(value)
+                .font(.subheadline.bold())
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(ColorTheme.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Suspected Meals
+
+    private var suspectedMealsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Suspected Meals", systemImage: "fork.knife.circle.fill")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            Text("Meals eaten 6-24 hours before this symptom, ranked by trigger likelihood")
+                .font(.caption)
+                .foregroundStyle(ColorTheme.secondaryText)
+
+            ForEach(Array(viewModel.suspectedMeals.enumerated()), id: \.element.id) { index, suspected in
+                suspectedMealCard(suspected, index: index)
+            }
+        }
+    }
+
+    private func suspectedMealCard(_ suspected: SuspectedMeal, index: Int) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header: score badge, meal name, type, time gap
+            HStack(spacing: 12) {
+                // Trigger likelihood score badge
+                ZStack {
+                    Circle()
+                        .fill(scoreColor(suspected.triggerLikelihood).opacity(0.15))
+                        .frame(width: 44, height: 44)
+                    Text("\(suspected.triggerLikelihood)")
+                        .font(.subheadline.bold().monospacedDigit())
+                        .foregroundStyle(scoreColor(suspected.triggerLikelihood))
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Text(suspected.meal.name)
+                            .font(.subheadline.bold())
+                            .foregroundStyle(ColorTheme.primaryText)
+                            .lineLimit(1)
+
+                        mealTypeBadge(suspected.meal.type)
+                    }
+
+                    Text(suspected.timeBeforeFormatted)
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Spacer()
+            }
+
+            // Suspected food items
+            if !suspected.suspectedFoods.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(suspected.suspectedFoods) { food in
+                        suspectedFoodRow(food)
+                    }
+                }
+            } else {
+                Text("No specific trigger compounds identified")
+                    .font(.caption)
+                    .foregroundStyle(ColorTheme.tertiaryText)
+            }
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.suspectedMealCard(index))
+    }
+
+    private func suspectedFoodRow(_ food: SuspectedFood) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(food.foodItem.name)
+                    .font(.subheadline)
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                Spacer()
+
+                Text("\(food.triggerScore)%")
+                    .font(.caption.bold().monospacedDigit())
+                    .foregroundStyle(scoreColor(food.triggerScore))
+            }
+
+            if !food.compoundRisks.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(food.compoundRisks, id: \.self) { compound in
+                            Text(compound)
+                                .font(.caption2)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(ColorTheme.warning.opacity(0.15))
+                                .foregroundStyle(ColorTheme.warning)
+                                .clipShape(.rect(cornerRadius: 8))
+                        }
+                    }
+                }
+            }
+
+            Text(food.reason)
+                .font(.caption)
+                .foregroundStyle(ColorTheme.secondaryText)
+                .lineLimit(2)
+        }
+        .padding(8)
+        .background(ColorTheme.background.opacity(0.5))
+        .clipShape(.rect(cornerRadius: 8))
+    }
+
+    // MARK: - Empty States
+
+    private var noSymptomsState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "heart.text.clipboard")
+                .font(.largeTitle)
+                .foregroundStyle(ColorTheme.secondaryText)
+
+            Text("No Significant Symptoms")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            Text("Log symptoms with pain, urgency, or abnormal stool types to use the Symptom Explorer.")
+                .font(.subheadline)
+                .foregroundStyle(ColorTheme.secondaryText)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomExplorerEmptyState)
+    }
+
+    private var emptyMealsState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "fork.knife")
+                .font(.title)
+                .foregroundStyle(ColorTheme.secondaryText)
+
+            Text("No Meals Found")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            Text("No meals were logged 6-24 hours before this symptom.")
+                .font(.subheadline)
+                .foregroundStyle(ColorTheme.secondaryText)
+                .multilineTextAlignment(.center)
+        }
+        .padding(24)
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomExplorerEmptyState)
+    }
+
+    // MARK: - Helpers
+
+    private func mealTypeBadge(_ type: MealType) -> some View {
+        Text(type.rawValue)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(mealTypeColor(type).opacity(0.2))
+            .foregroundStyle(mealTypeColor(type))
+            .clipShape(.rect(cornerRadius: 8))
+    }
+
+    private func mealTypeColor(_ type: MealType) -> Color {
+        switch type {
+        case .breakfast: return .orange
+        case .lunch: return .green
+        case .dinner: return .blue
+        case .snack: return .purple
+        case .drink: return .cyan
+        }
+    }
+
+    private func scoreColor(_ score: Int) -> Color {
+        if score >= 70 { return .red }
+        if score >= 40 { return .orange }
+        return .yellow
+    }
+
+    private func painLabel(_ level: PainLevel) -> String {
+        switch level {
+        case .none: return "None"
+        case .mild: return "Mild"
+        case .moderate: return "Moderate"
+        case .severe: return "Severe"
+        }
+    }
+
+    private func painColor(_ level: PainLevel) -> Color {
+        switch level {
+        case .none: return ColorTheme.primaryText
+        case .mild: return .yellow
+        case .moderate: return .orange
+        case .severe: return .red
+        }
+    }
+
+    private func urgencyLabel(_ level: UrgencyLevel) -> String {
+        switch level {
+        case .none: return "None"
+        case .mild: return "Mild"
+        case .moderate: return "Moderate"
+        case .urgent: return "Urgent"
+        }
+    }
+
+    private func urgencyColor(_ level: UrgencyLevel) -> Color {
+        switch level {
+        case .none: return ColorTheme.primaryText
+        case .mild: return .yellow
+        case .moderate: return .orange
+        case .urgent: return .red
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+
+    private func formattedTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        SymptomExplorerView()
+            .environment(AuthService())
+            .environment(AppRouter.shared)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Symptom Explorer view accessible from the Insights tab that lets users select a logged symptom and view meals eaten 6-24 hours prior, ranked by trigger likelihood
- Computes per-meal trigger scores using three weighted signals: known trigger pattern match (40%), compound risk from FoodCompoundDatabase (30%), and time proximity (30%)
- Each suspected meal card shows per-food-item breakdown with compound risk capsule badges, trigger score percentages, and human-readable reasoning

## Test plan
- [ ] Verify build succeeds with zero errors
- [ ] Confirm Symptom Explorer card appears on InsightsView between "Top Triggering Foods" and "Best Days"
- [ ] Tap the card and verify navigation to SymptomExplorerView
- [ ] Verify symptom picker lists recent symptoms with date and severity indicators
- [ ] Select different symptoms and confirm meal list updates with correct 6-24hr window
- [ ] Verify meals are sorted by trigger likelihood descending
- [ ] Test empty states: no symptoms logged, no meals in window
- [ ] Run full test suite to confirm no regressions

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)