### PR TITLE
feat(#37): add interactive symptom charts with Swift Charts

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -212,6 +212,13 @@ enum AccessibilityIdentifiers {
         static func suspectedMealCard(_ index: Int) -> String {
             "insights.symptomExplorer.meal.\(index)"
         }
+        
+        // Symptom Charts
+        static let symptomChartsCard = "insights.symptomCharts.card"
+        static let symptomChartsView = "insights.symptomCharts.view"
+        static let chartTimeRangePicker = "insights.symptomCharts.timeRange.picker"
+        static let chartSymptomFilterPicker = "insights.symptomCharts.symptomFilter.picker"
+        static let chartTabPicker = "insights.symptomCharts.tab.picker"
     }
     
     // MARK: - Tab Bar

--- a/GutCheck/GutCheck/Models/Core/ChartDataModels.swift
+++ b/GutCheck/GutCheck/Models/Core/ChartDataModels.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Time Range for Charts
+
+enum ChartTimeRange: String, CaseIterable, Identifiable {
+    case last7Days = "7d"
+    case last30Days = "30d"
+    case last90Days = "90d"
+
+    var id: String { rawValue }
+
+    var days: Int {
+        switch self {
+        case .last7Days: return 7
+        case .last30Days: return 30
+        case .last90Days: return 90
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .last7Days: return "7 Days"
+        case .last30Days: return "30 Days"
+        case .last90Days: return "90 Days"
+        }
+    }
+}
+
+// MARK: - Symptom Chart Filter
+
+enum SymptomChartFilter: String, CaseIterable, Identifiable {
+    case all = "All"
+    case pain = "Pain"
+    case urgency = "Urgency"
+    case stool = "Stool"
+
+    var id: String { rawValue }
+}
+
+// MARK: - Chart Tab Selection
+
+enum ChartTab: String, CaseIterable, Identifiable {
+    case timeline = "Timeline"
+    case severity = "Severity"
+    case weekly = "Weekly"
+    case ingredients = "Ingredients"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .timeline: return "calendar.day.timeline.left"
+        case .severity: return "chart.xyaxis.line"
+        case .weekly: return "chart.bar.fill"
+        case .ingredients: return "chart.pie.fill"
+        }
+    }
+}
+
+// MARK: - Data Points
+
+/// Timeline chart: one dot per symptom log day, color-coded by max severity
+struct TimelineDataPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let severityLevel: Int       // 0=none, 1=mild, 2=moderate, 3=severe
+    let symptomCount: Int
+    let label: String
+
+    var severityColor: Color {
+        switch severityLevel {
+        case 0: return .green
+        case 1: return .yellow
+        case 2: return .orange
+        default: return .red
+        }
+    }
+}
+
+/// Severity line chart: daily max severity for pain and urgency
+struct SeverityLineDataPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let value: Int               // 0-3 severity scale
+    let series: String           // "Pain" or "Urgency"
+}
+
+/// Weekly bar chart: symptom count per calendar week
+struct WeeklyBarDataPoint: Identifiable {
+    let id = UUID()
+    let weekLabel: String        // e.g. "Mar 3"
+    let weekStart: Date
+    let count: Int
+}
+
+/// Ingredient pie chart: top repeated ingredients
+struct IngredientSliceDataPoint: Identifiable {
+    let id = UUID()
+    let name: String
+    let count: Int
+}

--- a/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
+++ b/GutCheck/GutCheck/Navigation/NavigationRoutes.swift
@@ -54,6 +54,7 @@ enum InsightsRoute: Hashable {
     case weeklyTriggerReport(WeeklyTriggerReport)
     case triggerPatternDetail(TriggerPattern)
     case symptomExplorer
+    case symptomCharts
 }
 
 // Privacy policy navigation

--- a/GutCheck/GutCheck/ViewModels/Analysis/SymptomChartsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/SymptomChartsViewModel.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+@MainActor
+@Observable class SymptomChartsViewModel {
+
+    // MARK: - Published State
+
+    var timelineData: [TimelineDataPoint] = []
+    var severityData: [SeverityLineDataPoint] = []
+    var weeklyData: [WeeklyBarDataPoint] = []
+    var ingredientData: [IngredientSliceDataPoint] = []
+
+    var selectedTimeRange: ChartTimeRange = .last30Days
+    var selectedFilter: SymptomChartFilter = .all
+    var selectedTab: ChartTab = .timeline
+
+    var isLoading = false
+    var error: String?
+
+    // MARK: - Dependencies
+
+    private let mealRepository = MealRepository.shared
+    private let symptomRepository = SymptomRepository.shared
+    private let authService = AuthService()
+
+    // Cached raw data for re-filtering without re-fetching
+    private var allSymptoms: [Symptom] = []
+    private var allMeals: [Meal] = []
+
+    // MARK: - Load Data
+
+    func loadData() async {
+        isLoading = true
+        error = nil
+
+        do {
+            let userId = authService.currentUser?.id ?? "default_user"
+            let endDate = Date.now
+            let startDate = Calendar.current.date(
+                byAdding: .day, value: -selectedTimeRange.days, to: endDate
+            ) ?? endDate
+
+            async let symptomsTask = symptomRepository.fetchSymptomsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+            async let mealsTask = mealRepository.fetchMealsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+
+            allSymptoms = try await symptomsTask
+            allMeals = try await mealsTask
+
+            recomputeChartData()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Recompute on Filter Change
+
+    func recomputeChartData() {
+        let filtered = filterSymptoms(allSymptoms)
+        computeTimelineData(from: filtered)
+        computeSeverityData(from: filtered)
+        computeWeeklyData(from: filtered)
+        computeIngredientData(from: allMeals)
+    }
+
+    // MARK: - Filter
+
+    private func filterSymptoms(_ symptoms: [Symptom]) -> [Symptom] {
+        switch selectedFilter {
+        case .all:
+            return symptoms
+        case .pain:
+            return symptoms.filter { $0.painLevel != .none }
+        case .urgency:
+            return symptoms.filter { $0.urgencyLevel != .none }
+        case .stool:
+            return symptoms.filter {
+                $0.stoolType == .type1 || $0.stoolType == .type2
+                    || $0.stoolType == .type6 || $0.stoolType == .type7
+            }
+        }
+    }
+
+    // MARK: - Timeline Computation
+
+    private func computeTimelineData(from symptoms: [Symptom]) {
+        let calendar = Calendar.current
+
+        let grouped = Dictionary(grouping: symptoms) { symptom in
+            calendar.startOfDay(for: symptom.date)
+        }
+
+        timelineData = grouped.map { (day, daySymptoms) in
+            let maxSeverity = daySymptoms.map { maxSeverityLevel($0) }.max() ?? 0
+            return TimelineDataPoint(
+                date: day,
+                severityLevel: maxSeverity,
+                symptomCount: daySymptoms.count,
+                label: severityLabel(maxSeverity)
+            )
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    // MARK: - Severity Line Computation
+
+    private func computeSeverityData(from symptoms: [Symptom]) {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: symptoms) { symptom in
+            calendar.startOfDay(for: symptom.date)
+        }
+
+        var points: [SeverityLineDataPoint] = []
+
+        for (day, daySymptoms) in grouped {
+            let maxPain = daySymptoms.map { $0.painLevel.rawValue }.max() ?? 0
+            let maxUrgency = daySymptoms.map { $0.urgencyLevel.rawValue }.max() ?? 0
+
+            points.append(SeverityLineDataPoint(
+                date: day, value: maxPain, series: "Pain"
+            ))
+            points.append(SeverityLineDataPoint(
+                date: day, value: maxUrgency, series: "Urgency"
+            ))
+        }
+
+        severityData = points.sorted { $0.date < $1.date }
+    }
+
+    // MARK: - Weekly Bar Computation
+
+    private func computeWeeklyData(from symptoms: [Symptom]) {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+
+        let grouped = Dictionary(grouping: symptoms) { symptom -> Date in
+            let components = calendar.dateComponents(
+                [.yearForWeekOfYear, .weekOfYear], from: symptom.date
+            )
+            return calendar.date(from: components) ?? symptom.date
+        }
+
+        weeklyData = grouped.map { (weekStart, weekSymptoms) in
+            WeeklyBarDataPoint(
+                weekLabel: formatter.string(from: weekStart),
+                weekStart: weekStart,
+                count: weekSymptoms.count
+            )
+        }
+        .sorted { $0.weekStart < $1.weekStart }
+    }
+
+    // MARK: - Ingredient Pie Computation
+
+    private func computeIngredientData(from meals: [Meal]) {
+        var ingredientCounts: [String: Int] = [:]
+
+        for meal in meals {
+            for item in meal.foodItems {
+                if item.ingredients.isEmpty {
+                    ingredientCounts[item.name, default: 0] += 1
+                } else {
+                    for ingredient in item.ingredients {
+                        let normalized = ingredient
+                            .trimmingCharacters(in: .whitespaces)
+                            .capitalized
+                        ingredientCounts[normalized, default: 0] += 1
+                    }
+                }
+            }
+        }
+
+        ingredientData = ingredientCounts
+            .sorted { $0.value > $1.value }
+            .prefix(8)
+            .map { IngredientSliceDataPoint(name: $0.key, count: $0.value) }
+    }
+
+    // MARK: - Helpers
+
+    private func maxSeverityLevel(_ symptom: Symptom) -> Int {
+        max(symptom.painLevel.rawValue, symptom.urgencyLevel.rawValue)
+    }
+
+    private func severityLabel(_ level: Int) -> String {
+        switch level {
+        case 0: return "None"
+        case 1: return "Mild"
+        case 2: return "Moderate"
+        default: return "Severe"
+        }
+    }
+}

--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -35,6 +35,9 @@ struct InsightsView: View {
                 // Symptom Explorer Card
                 symptomExplorerCard
 
+                // Symptom Charts Card
+                symptomChartsCard
+
                 bestDaysCard
 
                 // Recent Insights Section
@@ -70,6 +73,8 @@ struct InsightsView: View {
                 TriggerPatternDetailView(pattern: pattern)
             case .symptomExplorer:
                 SymptomExplorerView()
+            case .symptomCharts:
+                SymptomChartsView()
             }
         }
         .toolbar {
@@ -274,6 +279,37 @@ struct InsightsView: View {
         if score >= 70 { return .red }
         if score >= 40 { return .orange }
         return .yellow
+    }
+
+    // MARK: - Symptom Charts
+
+    private var symptomChartsCard: some View {
+        NavigationLink(value: InsightsRoute.symptomCharts) {
+            HStack(spacing: 12) {
+                Image(systemName: "chart.xyaxis.line")
+                    .font(.title2)
+                    .foregroundStyle(ColorTheme.accent)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Symptom Charts")
+                        .font(.headline)
+                        .foregroundStyle(ColorTheme.primaryText)
+                    Text("Interactive graphs and trends")
+                        .font(.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+            .padding()
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+        }
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomChartsCard)
     }
 
     // MARK: - Symptom Explorer

--- a/GutCheck/GutCheck/Views/Analytics/SymptomChartsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/SymptomChartsView.swift
@@ -1,0 +1,303 @@
+import SwiftUI
+import Charts
+
+struct SymptomChartsView: View {
+    @State private var viewModel = SymptomChartsViewModel()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if viewModel.isLoading {
+                    ProgressView("Loading chart data…")
+                        .padding(.top, 40)
+                } else if let error = viewModel.error {
+                    errorState(error)
+                } else {
+                    filterBar
+                    chartTabPicker
+                    chartContent
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Symptom Charts")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.symptomChartsView)
+        .task {
+            await viewModel.loadData()
+        }
+        .onChange(of: viewModel.selectedTimeRange) { _, _ in
+            Task { await viewModel.loadData() }
+        }
+        .onChange(of: viewModel.selectedFilter) { _, _ in
+            viewModel.recomputeChartData()
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        VStack(spacing: 12) {
+            Picker("Time Range", selection: $viewModel.selectedTimeRange) {
+                ForEach(ChartTimeRange.allCases) { range in
+                    Text(range.displayName).tag(range)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier(AccessibilityIdentifiers.Insights.chartTimeRangePicker)
+
+            Picker("Filter", selection: $viewModel.selectedFilter) {
+                ForEach(SymptomChartFilter.allCases) { filter in
+                    Text(filter.rawValue).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier(AccessibilityIdentifiers.Insights.chartSymptomFilterPicker)
+        }
+    }
+
+    // MARK: - Chart Tab Picker
+
+    private var chartTabPicker: some View {
+        Picker("Chart Type", selection: $viewModel.selectedTab) {
+            ForEach(ChartTab.allCases) { tab in
+                Label(tab.rawValue, systemImage: tab.icon).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Insights.chartTabPicker)
+    }
+
+    // MARK: - Chart Content
+
+    @ViewBuilder
+    private var chartContent: some View {
+        switch viewModel.selectedTab {
+        case .timeline:
+            timelineChart
+        case .severity:
+            severityLineChart
+        case .weekly:
+            weeklyBarChart
+        case .ingredients:
+            ingredientPieChart
+        }
+    }
+
+    // MARK: - Timeline Chart
+
+    private var timelineChart: some View {
+        chartCard(title: "Daily Symptom Timeline", icon: "calendar.day.timeline.left") {
+            if viewModel.timelineData.isEmpty {
+                chartEmptyState("No symptom data for this period")
+            } else {
+                Chart(viewModel.timelineData) { point in
+                    PointMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value("Severity", point.severityLevel)
+                    )
+                    .foregroundStyle(point.severityColor)
+                    .symbolSize(CGFloat(point.symptomCount * 40 + 40))
+                }
+                .chartYScale(domain: 0...3)
+                .chartYAxis {
+                    AxisMarks(values: [0, 1, 2, 3]) { value in
+                        AxisValueLabel {
+                            if let intVal = value.as(Int.self) {
+                                Text(severityAxisLabel(intVal))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine()
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day,
+                        count: viewModel.selectedTimeRange == .last7Days ? 1 : 7)) { _ in
+                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        AxisGridLine()
+                    }
+                }
+                .frame(height: 250)
+            }
+        }
+    }
+
+    // MARK: - Severity Line Chart
+
+    private var severityLineChart: some View {
+        chartCard(title: "Severity Over Time", icon: "chart.xyaxis.line") {
+            if viewModel.severityData.isEmpty {
+                chartEmptyState("No severity data for this period")
+            } else {
+                Chart(viewModel.severityData) { point in
+                    LineMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value("Severity", point.value)
+                    )
+                    .foregroundStyle(by: .value("Type", point.series))
+                    .interpolationMethod(.catmullRom)
+
+                    PointMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value("Severity", point.value)
+                    )
+                    .foregroundStyle(by: .value("Type", point.series))
+                    .symbolSize(30)
+                }
+                .chartYScale(domain: 0...3)
+                .chartYAxis {
+                    AxisMarks(values: [0, 1, 2, 3]) { value in
+                        AxisValueLabel {
+                            if let intVal = value.as(Int.self) {
+                                Text(severityAxisLabel(intVal))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine()
+                    }
+                }
+                .chartForegroundStyleScale([
+                    "Pain": Color.red,
+                    "Urgency": Color.orange
+                ])
+                .chartLegend(position: .bottom)
+                .frame(height: 250)
+            }
+        }
+    }
+
+    // MARK: - Weekly Bar Chart
+
+    private var weeklyBarChart: some View {
+        chartCard(title: "Symptoms Per Week", icon: "chart.bar.fill") {
+            if viewModel.weeklyData.isEmpty {
+                chartEmptyState("No weekly data for this period")
+            } else {
+                Chart(viewModel.weeklyData) { point in
+                    BarMark(
+                        x: .value("Week", point.weekLabel),
+                        y: .value("Count", point.count)
+                    )
+                    .foregroundStyle(ColorTheme.accent.gradient)
+                    .cornerRadius(4)
+                    .annotation(position: .top) {
+                        Text("\(point.count)")
+                            .font(.caption2.bold())
+                            .foregroundStyle(ColorTheme.secondaryText)
+                    }
+                }
+                .frame(height: 250)
+            }
+        }
+    }
+
+    // MARK: - Ingredient Pie Chart
+
+    private var ingredientPieChart: some View {
+        chartCard(title: "Top Ingredients", icon: "chart.pie.fill") {
+            if viewModel.ingredientData.isEmpty {
+                chartEmptyState("No ingredient data for this period")
+            } else {
+                Chart(viewModel.ingredientData) { slice in
+                    SectorMark(
+                        angle: .value("Count", slice.count),
+                        innerRadius: .ratio(0.5),
+                        angularInset: 1.5
+                    )
+                    .foregroundStyle(by: .value("Ingredient", slice.name))
+                    .cornerRadius(4)
+                }
+                .chartLegend(position: .bottom, alignment: .center, spacing: 12)
+                .frame(height: 300)
+
+                // Ingredient list below chart
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(viewModel.ingredientData) { item in
+                        HStack {
+                            Text(item.name)
+                                .font(.subheadline)
+                                .foregroundStyle(ColorTheme.primaryText)
+                            Spacer()
+                            Text("\(item.count)×")
+                                .font(.subheadline.bold())
+                                .foregroundStyle(ColorTheme.secondaryText)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Chart Card Wrapper
+
+    private func chartCard<Content: View>(
+        title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: icon)
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+
+            content()
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+
+    // MARK: - Empty & Error States
+
+    private func chartEmptyState(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.title)
+                .foregroundStyle(ColorTheme.secondaryText)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(ColorTheme.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(ColorTheme.warning)
+            Text("Unable to Load Charts")
+                .font(.headline)
+                .foregroundStyle(ColorTheme.primaryText)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(ColorTheme.secondaryText)
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+    }
+
+    // MARK: - Helpers
+
+    private func severityAxisLabel(_ level: Int) -> String {
+        switch level {
+        case 0: return "None"
+        case 1: return "Mild"
+        case 2: return "Mod"
+        default: return "Sev"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        SymptomChartsView()
+            .environment(AuthService())
+            .environment(AppRouter.shared)
+    }
+}


### PR DESCRIPTION
## Summary
- Add four interactive chart types using Swift Charts: timeline (PointMark), severity line (LineMark), weekly bar (BarMark), and ingredient pie (SectorMark)
- Implement time range (7d/30d/90d) and symptom filter (All/Pain/Urgency/Stool) controls with segmented pickers
- Add "Symptom Charts" entry card to InsightsView with navigation to the new SymptomChartsView

## Test plan
- [ ] Verify build succeeds with zero errors
- [ ] Verify "Symptom Charts" card appears on InsightsView between Symptom Explorer and Best Days
- [ ] Navigate to SymptomChartsView and verify filter controls render
- [ ] Log symptom and meal data, then verify each chart type displays data correctly
- [ ] Switch between time ranges and confirm data reloads
- [ ] Switch symptom filters and confirm charts update without re-fetching
- [ ] Verify empty states display when no data exists
- [ ] Verify accessibility identifiers are set on key elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)