### PR TITLE
feat(#68): add severity prediction for new meals with risk assessment card

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -61,6 +61,11 @@ enum AccessibilityIdentifiers {
         static func deleteFoodItem(_ index: Int) -> String {
             "mealBuilder.foodItem.\(index).delete"
         }
+        
+        // Risk Assessment
+        static let riskAssessmentCard = "mealBuilder.riskAssessment.card"
+        static let riskAssessmentHeader = "mealBuilder.riskAssessment.header"
+        static let riskAssessmentNoHistory = "mealBuilder.riskAssessment.noHistory"
     }
     
     // MARK: - Food Search

--- a/GutCheck/GutCheck/Models/Core/MealRiskModels.swift
+++ b/GutCheck/GutCheck/Models/Core/MealRiskModels.swift
@@ -1,0 +1,77 @@
+//
+//  MealRiskModels.swift
+//  GutCheck
+//
+//  Data models for meal risk prediction and severity assessment.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Risk Level
+
+enum MealRiskLevel: String, Hashable, CaseIterable {
+    case low
+    case moderate
+    case high
+
+    var displayName: String {
+        rawValue.capitalized
+    }
+
+    var icon: String {
+        switch self {
+        case .low: return "checkmark.shield.fill"
+        case .moderate: return "exclamationmark.triangle.fill"
+        case .high: return "xmark.shield.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .low: return ColorTheme.success
+        case .moderate: return ColorTheme.warning
+        case .high: return ColorTheme.error
+        }
+    }
+}
+
+// MARK: - Risk Data Source
+
+enum RiskDataSource: String, Hashable {
+    case historicalCorrelation
+    case compoundAnalysis
+    case combined
+}
+
+// MARK: - Food Item Risk Detail
+
+struct FoodItemRiskDetail: Identifiable, Hashable {
+    let id: UUID
+    let foodName: String
+    let riskScore: Int
+    let riskLevel: MealRiskLevel
+    let explanation: String
+    let matchedTriggerPattern: TriggerPattern?
+    let flaggedCompounds: [FoodCompound]
+    let dataSource: RiskDataSource
+}
+
+// MARK: - Meal Risk Assessment
+
+struct MealRiskAssessment: Hashable {
+    let overallRiskScore: Int
+    let overallRiskLevel: MealRiskLevel
+    let foodItemRisks: [FoodItemRiskDetail]
+    let overallExplanation: String
+    let assessedAt: Date
+    let hasHistoricalData: Bool
+
+    var highRiskItems: [FoodItemRiskDetail] {
+        foodItemRisks.filter { $0.riskLevel == .high }
+    }
+
+    var moderateRiskItems: [FoodItemRiskDetail] {
+        foodItemRisks.filter { $0.riskLevel == .moderate }
+    }
+}

--- a/GutCheck/GutCheck/Services/FoodCompoundDatabase.swift
+++ b/GutCheck/GutCheck/Services/FoodCompoundDatabase.swift
@@ -23,7 +23,7 @@ enum HealthSeverity: Int, CaseIterable {
     }
 }
 
-struct FoodCompound {
+struct FoodCompound: Hashable {
     let name: String
     let category: CompoundCategory
     let severity: HealthSeverity

--- a/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
+++ b/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
@@ -1,0 +1,228 @@
+//
+//  MealRiskPredictionService.swift
+//  GutCheck
+//
+//  Predicts meal risk using historical trigger patterns and compound analysis.
+//
+
+import Foundation
+
+@MainActor
+@Observable class MealRiskPredictionService {
+    static let shared = MealRiskPredictionService()
+
+    // MARK: - Cached State
+
+    private(set) var cachedTriggerPatterns: [TriggerPattern] = []
+    private(set) var isLoaded: Bool = false
+    private(set) var isLoading: Bool = false
+
+    private let patternService = PatternRecognitionService.shared
+    private let compoundDatabase = FoodCompoundDatabase.shared
+    private let mealRepository = MealRepository.shared
+    private let symptomRepository = SymptomRepository.shared
+
+    private init() {}
+
+    // MARK: - Data Loading
+
+    /// Load user's 30-day history and compute trigger patterns.
+    /// Call once when MealBuilderView appears.
+    func loadHistoricalData() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let userId = AuthenticationManager.shared.currentUserId ?? "default_user"
+            let endDate = Date.now
+            let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
+
+            async let mealsTask = mealRepository.fetchMealsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+            async let symptomsTask = symptomRepository.fetchSymptomsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+
+            let meals = try await mealsTask
+            let symptoms = try await symptomsTask
+
+            cachedTriggerPatterns = await patternService.analyzeTriggerPatterns(
+                meals: meals, symptoms: symptoms
+            )
+            isLoaded = true
+        } catch {
+            // Gracefully degrade — compound analysis still works
+            cachedTriggerPatterns = []
+            isLoaded = true
+        }
+    }
+
+    /// Reset cached data
+    func resetCache() {
+        cachedTriggerPatterns = []
+        isLoaded = false
+    }
+
+    // MARK: - Prediction
+
+    /// Predict risk for the given food items. Returns nil if no food items provided.
+    func predictRisk(for foodItems: [FoodItem]) -> MealRiskAssessment? {
+        guard !foodItems.isEmpty else { return nil }
+
+        var itemRisks: [FoodItemRiskDetail] = []
+
+        for item in foodItems {
+            let detail = assessFoodItem(item)
+            itemRisks.append(detail)
+        }
+
+        let overallScore = computeOverallScore(from: itemRisks)
+        let overallLevel = riskLevel(for: overallScore)
+        let explanation = generateOverallExplanation(itemRisks: itemRisks, overallLevel: overallLevel)
+
+        return MealRiskAssessment(
+            overallRiskScore: overallScore,
+            overallRiskLevel: overallLevel,
+            foodItemRisks: itemRisks,
+            overallExplanation: explanation,
+            assessedAt: Date.now,
+            hasHistoricalData: !cachedTriggerPatterns.isEmpty
+        )
+    }
+
+    // MARK: - Per-Food Assessment
+
+    private func assessFoodItem(_ item: FoodItem) -> FoodItemRiskDetail {
+        let key = item.name.lowercased().trimmingCharacters(in: .whitespaces)
+
+        // 1. Look for a matching TriggerPattern from user's history
+        let matchedPattern = cachedTriggerPatterns.first { pattern in
+            pattern.foodName.lowercased().trimmingCharacters(in: .whitespaces) == key
+        }
+
+        // 2. Get compound risk from FoodCompoundDatabase
+        let compounds = compoundDatabase.getCompoundsForFood(
+            name: item.name, ingredients: item.ingredients
+        )
+        let highCompounds = compounds.filter { $0.severity == .high }
+        let medCompounds = compounds.filter { $0.severity == .medium }
+
+        // 3. Compute score
+        var score: Int
+        var explanation: String
+        var dataSource: RiskDataSource
+
+        if let pattern = matchedPattern {
+            let historicalScore = pattern.triggerScore.overall
+            let compoundScore = computeCompoundOnlyScore(high: highCompounds.count, med: medCompounds.count)
+
+            if compoundScore > 0 {
+                score = Int(Double(historicalScore) * 0.7 + Double(compoundScore) * 0.3)
+                dataSource = .combined
+            } else {
+                score = historicalScore
+                dataSource = .historicalCorrelation
+            }
+
+            explanation = generateHistoricalExplanation(
+                foodName: item.name,
+                pattern: pattern
+            )
+        } else if !compounds.isEmpty {
+            score = computeCompoundOnlyScore(high: highCompounds.count, med: medCompounds.count)
+            dataSource = .compoundAnalysis
+            explanation = generateCompoundExplanation(
+                foodName: item.name,
+                highCount: highCompounds.count,
+                medCount: medCompounds.count,
+                compounds: compounds
+            )
+        } else {
+            score = 0
+            dataSource = .compoundAnalysis
+            explanation = "No known risk factors for \(item.name)"
+        }
+
+        score = min(100, max(0, score))
+
+        return FoodItemRiskDetail(
+            id: UUID(),
+            foodName: item.name,
+            riskScore: score,
+            riskLevel: riskLevel(for: score),
+            explanation: explanation,
+            matchedTriggerPattern: matchedPattern,
+            flaggedCompounds: compounds,
+            dataSource: dataSource
+        )
+    }
+
+    // MARK: - Score Computation
+
+    private func computeCompoundOnlyScore(high: Int, med: Int) -> Int {
+        let raw = high * 15 + med * 8
+        return min(75, raw)
+    }
+
+    private func computeOverallScore(from itemRisks: [FoodItemRiskDetail]) -> Int {
+        guard !itemRisks.isEmpty else { return 0 }
+        let maxScore = itemRisks.map(\.riskScore).max() ?? 0
+        let avgScore = itemRisks.map(\.riskScore).reduce(0, +) / itemRisks.count
+        return min(100, Int(Double(maxScore) * 0.6 + Double(avgScore) * 0.4))
+    }
+
+    private func riskLevel(for score: Int) -> MealRiskLevel {
+        switch score {
+        case 0..<30: return .low
+        case 30..<60: return .moderate
+        default: return .high
+        }
+    }
+
+    // MARK: - Explanation Generation
+
+    private func generateHistoricalExplanation(foodName: String, pattern: TriggerPattern) -> String {
+        let triggeringPct = pattern.totalObservations > 0
+            ? Int(Double(pattern.triggeringObservations) / Double(pattern.totalObservations) * 100)
+            : 0
+
+        let painDesc: String
+        switch pattern.severityPrediction.mostLikelyPainLevel {
+        case .severe: painDesc = "severe pain"
+        case .moderate: painDesc = "moderate pain"
+        case .mild: painDesc = "mild discomfort"
+        case .none: painDesc = "symptoms"
+        }
+
+        return "\(foodName) caused \(painDesc) in \(pattern.triggeringObservations) of \(pattern.totalObservations) meals (\(triggeringPct)%)"
+    }
+
+    private func generateCompoundExplanation(foodName: String, highCount: Int, medCount: Int, compounds: [FoodCompound]) -> String {
+        if highCount > 0 {
+            let names = compounds.filter { $0.severity == .high }.prefix(2).map(\.name).joined(separator: ", ")
+            return "\(foodName) contains \(names) which may cause digestive issues"
+        } else if medCount > 0 {
+            return "\(foodName) contains \(medCount) compound(s) with moderate sensitivity risk"
+        }
+        return "\(foodName) has low compound risk"
+    }
+
+    private func generateOverallExplanation(itemRisks: [FoodItemRiskDetail], overallLevel: MealRiskLevel) -> String {
+        let highCount = itemRisks.filter { $0.riskLevel == .high }.count
+        let modCount = itemRisks.filter { $0.riskLevel == .moderate }.count
+
+        switch overallLevel {
+        case .high:
+            return "\(highCount) high-risk item(s) detected. Consider alternatives."
+        case .moderate:
+            if highCount > 0 {
+                return "\(highCount) high-risk and \(modCount) moderate-risk item(s) in this meal."
+            }
+            return "\(modCount) item(s) with moderate risk based on your history."
+        case .low:
+            return "This meal looks safe based on your history."
+        }
+    }
+}

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -21,6 +21,7 @@ struct MealBuilderView: View {
     @State private var showingFoodOptions = false
     @State private var editingFoodItem: FoodItem?
 @State private var loadError: String? = nil
+    @State private var riskService = MealRiskPredictionService.shared
     
     var body: some View {
         VStack(spacing: 0) {
@@ -124,6 +125,13 @@ struct MealBuilderView: View {
                         .padding(.horizontal)
                         .padding(.top)
                         .accessibilityIdentifier(AccessibilityIdentifiers.MealBuilder.nutritionSummary)
+                    
+                    // Risk assessment card
+                    if !mealService.currentMeal.isEmpty,
+                       let assessment = riskService.predictRisk(for: mealService.currentMeal) {
+                        MealRiskAssessmentCard(assessment: assessment)
+                            .padding(.horizontal)
+                    }
                     
                     // Food items
                     if mealService.currentMeal.isEmpty {
@@ -282,12 +290,14 @@ struct MealBuilderView: View {
         .navigationTitle(mealId == nil ? "Build Your Meal" : "Edit Meal")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            guard let id = mealId else { return }
-            do {
-                try await mealService.loadMeal(id: id)
-            } catch {
-                loadError = error.localizedDescription
+            if let id = mealId {
+                do {
+                    try await mealService.loadMeal(id: id)
+                } catch {
+                    loadError = error.localizedDescription
+                }
             }
+            await riskService.loadHistoricalData()
         }
         .alert("Failed to Load Meal", isPresented: .constant(loadError != nil)) {
             Button("OK") { loadError = nil; dismiss() }

--- a/GutCheck/GutCheck/Views/Meal/MealRiskAssessmentCard.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealRiskAssessmentCard.swift
@@ -1,0 +1,173 @@
+//
+//  MealRiskAssessmentCard.swift
+//  GutCheck
+//
+//  Collapsible card showing meal risk assessment with per-food breakdowns.
+//
+
+import SwiftUI
+
+struct MealRiskAssessmentCard: View {
+    let assessment: MealRiskAssessment
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // MARK: - Header (always visible, tappable to expand)
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    isExpanded.toggle()
+                }
+                HapticManager.shared.light()
+            }) {
+                headerContent
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityIdentifiers.MealBuilder.riskAssessmentHeader)
+
+            // MARK: - Expanded Details
+            if isExpanded {
+                Divider()
+                    .padding(.horizontal)
+
+                expandedContent
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding()
+        .background(cardBackgroundColor)
+        .clipShape(.rect(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(borderColor, lineWidth: 1.5)
+        )
+        .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+        .accessibilityIdentifier(AccessibilityIdentifiers.MealBuilder.riskAssessmentCard)
+        .accessibleGroup(
+            label: "Risk Assessment: \(assessment.overallRiskLevel.displayName) risk, score \(assessment.overallRiskScore). \(assessment.overallExplanation)",
+            hint: "Tap to \(isExpanded ? "collapse" : "expand") risk details"
+        )
+    }
+
+    // MARK: - Header
+
+    private var headerContent: some View {
+        HStack(spacing: 12) {
+            Image(systemName: assessment.overallRiskLevel.icon)
+                .font(.title2)
+                .foregroundStyle(assessment.overallRiskLevel.color)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Risk Assessment")
+                    .typography(Typography.headline)
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                Text(assessment.overallExplanation)
+                    .typography(Typography.caption)
+                    .foregroundStyle(ColorTheme.secondaryText)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            riskScoreBadge
+
+            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                .font(.caption)
+                .foregroundStyle(ColorTheme.secondaryText)
+        }
+    }
+
+    private var riskScoreBadge: some View {
+        Text("\(assessment.overallRiskScore)")
+            .font(.headline)
+            .foregroundStyle(.white)
+            .frame(width: 40, height: 40)
+            .background(assessment.overallRiskLevel.color)
+            .clipShape(Circle())
+    }
+
+    // MARK: - Expanded Content
+
+    private var expandedContent: some View {
+        VStack(spacing: 12) {
+            if !assessment.hasHistoricalData {
+                noHistoryBanner
+            }
+
+            ForEach(assessment.foodItemRisks) { itemRisk in
+                foodItemRiskRow(itemRisk)
+            }
+        }
+        .padding(.top, 12)
+    }
+
+    private var noHistoryBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle.fill")
+                .foregroundStyle(ColorTheme.info)
+            Text("Risk based on food compound analysis. Log more meals to get personalized predictions.")
+                .typography(Typography.caption)
+                .foregroundStyle(ColorTheme.secondaryText)
+        }
+        .padding(10)
+        .background(ColorTheme.info.opacity(0.1))
+        .clipShape(.rect(cornerRadius: 8))
+        .accessibilityIdentifier(AccessibilityIdentifiers.MealBuilder.riskAssessmentNoHistory)
+    }
+
+    private func foodItemRiskRow(_ itemRisk: FoodItemRiskDetail) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(itemRisk.riskLevel.color)
+                .frame(width: 10, height: 10)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(itemRisk.foodName)
+                        .typography(Typography.subheadline)
+                        .foregroundStyle(ColorTheme.primaryText)
+
+                    Spacer()
+
+                    if itemRisk.dataSource == .historicalCorrelation || itemRisk.dataSource == .combined {
+                        Image(systemName: "person.fill")
+                            .font(.caption2)
+                            .foregroundStyle(ColorTheme.primary)
+                    }
+
+                    Text("\(itemRisk.riskScore)")
+                        .typography(Typography.caption)
+                        .foregroundStyle(itemRisk.riskLevel.color)
+                        .bold()
+                }
+
+                Text(itemRisk.explanation)
+                    .typography(Typography.caption)
+                    .foregroundStyle(ColorTheme.secondaryText)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(itemRisk.foodName): \(itemRisk.riskLevel.displayName) risk, score \(itemRisk.riskScore). \(itemRisk.explanation)")
+    }
+
+    // MARK: - Styling
+
+    private var cardBackgroundColor: Color {
+        switch assessment.overallRiskLevel {
+        case .low: return ColorTheme.surface
+        case .moderate: return ColorTheme.warning.opacity(0.05)
+        case .high: return ColorTheme.error.opacity(0.05)
+        }
+    }
+
+    private var borderColor: Color {
+        switch assessment.overallRiskLevel {
+        case .low: return ColorTheme.border
+        case .moderate: return ColorTheme.warning.opacity(0.3)
+        case .high: return ColorTheme.error.opacity(0.3)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add real-time meal risk prediction service that scores food items using historical trigger patterns (70%) and food compound analysis (30%)
- Display a collapsible risk assessment card in MealBuilderView between nutrition summary and food items, with per-food risk breakdowns and explanations
- Risk levels (Low/Moderate/High) with color-coded UI, score badges, and data source indicators (personalized vs compound-only)

## Test plan
- [ ] Verify build succeeds with zero errors
- [ ] Add food items in MealBuilderView and verify risk card appears
- [ ] Verify card is hidden when no food items are present
- [ ] Test expand/collapse toggle on the risk card
- [ ] Add a known trigger food (e.g., dairy) and verify compound-based risk scoring
- [ ] Verify "no history" info banner appears when user has no meal/symptom history
- [ ] Remove all food items and verify card disappears
- [ ] Verify accessibility identifiers and VoiceOver labels are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)