### PR TITLE
feat(#242): extract Tier 1 service protocols for dependency injection

### DIFF
--- a/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthenticationProtocol.swift
@@ -16,4 +16,16 @@ protocol AuthenticationProtocol: AnyObject {
     func verifyPhoneNumber(_ phoneNumber: String) async throws
     func signInWithPhone(verificationCode: String) async throws
     func signOut() throws
+    
+    // Email verification
+    func resendVerificationEmail() async throws
+    func checkEmailVerification() async throws
+    func cancelEmailVerification() throws
+    
+    // Account deletion
+    func deleteAuthenticatedAccount() async throws
+    
+    // Profile management
+    func updateUserProfile(_ updatedUser: User) async throws
+    func refreshCurrentUser() async
 }

--- a/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/PreviewAuthService.swift
@@ -44,4 +44,28 @@ import FirebaseAuth
     func signOut() throws {
         // Preview implementation - no-op
     }
+    
+    func resendVerificationEmail() async throws {
+        // Preview implementation - no-op
+    }
+    
+    func checkEmailVerification() async throws {
+        // Preview implementation - no-op
+    }
+    
+    func cancelEmailVerification() throws {
+        // Preview implementation - no-op
+    }
+    
+    func deleteAuthenticatedAccount() async throws {
+        // Preview implementation - no-op
+    }
+    
+    func updateUserProfile(_ updatedUser: User) async throws {
+        // Preview implementation - no-op
+    }
+    
+    func refreshCurrentUser() async {
+        // Preview implementation - no-op
+    }
 }

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitManager.swift
@@ -13,7 +13,7 @@ struct UserHealthData {
     var heartRate: Double?               // bpm
 }
 
-final class HealthKitManager {
+final class HealthKitManager: HealthKitManagerProtocol {
     static let shared = HealthKitManager()
     private let healthStore = HKHealthStore()
 

--- a/GutCheck/GutCheck/Services/HealthKit/HealthKitManagerProtocol.swift
+++ b/GutCheck/GutCheck/Services/HealthKit/HealthKitManagerProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  HealthKitManagerProtocol.swift
+//  GutCheck
+//
+//  Protocol for HealthKitManager to enable dependency injection and testability.
+//
+
+import Foundation
+import HealthKit
+
+protocol HealthKitManagerProtocol {
+    func requestAuthorization(completion: @escaping (Bool, Error?) -> Void)
+    func fetchUserHealthData(completion: @escaping (UserHealthData?) -> Void)
+    func writeMealToHealthKit(_ meal: Meal, completion: @escaping (Bool, Error?) -> Void)
+    func writeSymptomToHealthKit(_ symptom: Symptom, completion: @escaping (Bool, Error?) -> Void)
+    func writeWaterIntakeToHealthKit(amount: Double, date: Date, completion: @escaping (Bool, Error?) -> Void)
+    func fetchGutHealthData(from startDate: Date, to endDate: Date, completion: @escaping (GutHealthData) -> Void)
+    func writeAuthorizationStatus(for quantityTypeID: HKQuantityTypeIdentifier) -> HKAuthorizationStatus
+    func writeAuthorizationStatus(for categoryTypeID: HKCategoryTypeIdentifier) -> HKAuthorizationStatus
+}

--- a/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
+++ b/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
@@ -280,7 +280,7 @@ class BaseFirebaseRepository<T: FirestoreModel & DataClassifiable>: FirebaseRepo
 
 // MARK: - Specific Repository Implementations
 
-class MealRepository: BaseFirebaseRepository<Meal> {
+class MealRepository: BaseFirebaseRepository<Meal>, MealRepositoryProtocol {
     static let shared = MealRepository()
     
     private init() {
@@ -358,7 +358,7 @@ class MealRepository: BaseFirebaseRepository<Meal> {
     }
 }
 
-class SymptomRepository: BaseFirebaseRepository<Symptom> {
+class SymptomRepository: BaseFirebaseRepository<Symptom>, SymptomRepositoryProtocol {
     static let shared = SymptomRepository()
     
     private init() {
@@ -480,7 +480,7 @@ class SymptomRepository: BaseFirebaseRepository<Symptom> {
     }
 }
 
-class MedicationRepository: BaseFirebaseRepository<MedicationRecord> {
+class MedicationRepository: BaseFirebaseRepository<MedicationRecord>, MedicationRepositoryProtocol {
     static let shared = MedicationRepository()
 
     private init() {
@@ -557,7 +557,7 @@ class MedicationRepository: BaseFirebaseRepository<MedicationRecord> {
     }
 }
 
-class MedicationDoseRepository: BaseFirebaseRepository<MedicationDoseLog> {
+class MedicationDoseRepository: BaseFirebaseRepository<MedicationDoseLog>, MedicationDoseRepositoryProtocol {
     static let shared = MedicationDoseRepository()
 
     private init() {
@@ -641,10 +641,10 @@ class RepositoryManager {
 
     private init() {}
 
-    lazy var mealRepository: MealRepository = MealRepository.shared
-    lazy var symptomRepository: SymptomRepository = SymptomRepository.shared
+    lazy var mealRepository: any MealRepositoryProtocol = MealRepository.shared
+    lazy var symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared
     lazy var reminderSettingsRepository: ReminderSettingsRepository = ReminderSettingsRepository.shared
-    lazy var medicationRepository: MedicationRepository = MedicationRepository.shared
-    lazy var medicationDoseRepository: MedicationDoseRepository = MedicationDoseRepository.shared
+    lazy var medicationRepository: any MedicationRepositoryProtocol = MedicationRepository.shared
+    lazy var medicationDoseRepository: any MedicationDoseRepositoryProtocol = MedicationDoseRepository.shared
 }
 

--- a/GutCheck/GutCheck/Services/Repository/RepositoryProtocols.swift
+++ b/GutCheck/GutCheck/Services/Repository/RepositoryProtocols.swift
@@ -1,0 +1,57 @@
+//
+//  RepositoryProtocols.swift
+//  GutCheck
+//
+//  Concrete, non-generic protocols for each repository type.
+//  These enable dependency injection in ViewModels without
+//  the associatedtype constraint of the generic FirebaseRepository protocol.
+//
+
+import Foundation
+
+// MARK: - MealRepositoryProtocol
+
+@MainActor
+protocol MealRepositoryProtocol {
+    func save(_ item: Meal) async throws
+    func fetch(id: String) async throws -> Meal?
+    func delete(id: String) async throws
+    func fetchMealsForDate(_ date: Date, userId: String) async throws -> [Meal]
+    func fetchRecentMeals(userId: String, limit: Int) async throws -> [Meal]
+    func fetchMealsForDateRange(startDate: Date, endDate: Date, userId: String) async throws -> [Meal]
+}
+
+// MARK: - SymptomRepositoryProtocol
+
+@MainActor
+protocol SymptomRepositoryProtocol {
+    func save(_ item: Symptom) async throws
+    func fetch(id: String) async throws -> Symptom?
+    func delete(id: String) async throws
+    func getSymptoms(for date: Date) async throws -> [Symptom]
+    func fetchSymptomsForDate(_ date: Date, userId: String) async throws -> [Symptom]
+    func fetchRecentSymptoms(userId: String, limit: Int) async throws -> [Symptom]
+    func fetchSymptomsForDateRange(startDate: Date, endDate: Date, userId: String) async throws -> [Symptom]
+}
+
+// MARK: - MedicationRepositoryProtocol
+
+@MainActor
+protocol MedicationRepositoryProtocol {
+    func save(_ item: MedicationRecord) async throws
+    func fetch(id: String) async throws -> MedicationRecord?
+    func delete(id: String) async throws
+    func fetchActiveMedications(userId: String) async throws -> [MedicationRecord]
+    func fetchAllMedications(userId: String) async throws -> [MedicationRecord]
+}
+
+// MARK: - MedicationDoseRepositoryProtocol
+
+@MainActor
+protocol MedicationDoseRepositoryProtocol {
+    func save(_ item: MedicationDoseLog) async throws
+    func fetch(id: String) async throws -> MedicationDoseLog?
+    func delete(id: String) async throws
+    func fetchDosesForDate(_ date: Date, userId: String) async throws -> [MedicationDoseLog]
+    func fetchRecentDoses(userId: String, limit: Int) async throws -> [MedicationDoseLog]
+}

--- a/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/CategoryInsightsViewModel.swift
@@ -8,9 +8,15 @@ import Foundation
     var error: String?
     
     private let insightsService = InsightsService.shared
-    private let mealRepository = MealRepository.shared
-    private let symptomRepository = SymptomRepository.shared
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
     private let authService = AuthService()
+    
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
+    }
     
     func loadInsights(for category: InsightCategory) async {
         isLoading = true

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -28,10 +28,18 @@ struct RankedItem: Identifiable {
     var mealSuggestions: [MealSuggestion] = []
 
     private let insightsService = InsightsService.shared
-    private let mealRepository = MealRepository.shared
-    private let symptomRepository = SymptomRepository.shared
-    private let healthKitManager = HealthKitManager.shared
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
+    private let healthKitManager: any HealthKitManagerProtocol
     private let authService = AuthService()
+    
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared,
+         healthKitManager: any HealthKitManagerProtocol = HealthKitManager.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
+        self.healthKitManager = healthKitManager
+    }
     
     func loadInsights() async {
         isLoading = true

--- a/GutCheck/GutCheck/ViewModels/Analysis/SymptomChartsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/SymptomChartsViewModel.swift
@@ -19,9 +19,15 @@ import Foundation
 
     // MARK: - Dependencies
 
-    private let mealRepository = MealRepository.shared
-    private let symptomRepository = SymptomRepository.shared
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
     private let authService = AuthService()
+    
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
+    }
 
     // Cached raw data for re-filtering without re-fetching
     private var allSymptoms: [Symptom] = []

--- a/GutCheck/GutCheck/ViewModels/Analysis/SymptomExplorerViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/SymptomExplorerViewModel.swift
@@ -14,10 +14,16 @@ import Foundation
 
     // MARK: - Dependencies
 
-    private let mealRepository = MealRepository.shared
-    private let symptomRepository = SymptomRepository.shared
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
     private let authService = AuthService()
     private let compoundDatabase = FoodCompoundDatabase.shared
+    
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
+    }
 
     // Cached data for quick re-computation on symptom change
     private var triggerPatterns: [TriggerPattern] = []

--- a/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
@@ -8,6 +8,15 @@ import FirebaseFirestore
     var patterns: [String]?
     var potentialTriggers: [String]?
     
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
+    
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
+    }
+    
     var hasAnalysis: Bool {
         (patterns != nil && !patterns!.isEmpty) || (potentialTriggers != nil && !potentialTriggers!.isEmpty)
     }
@@ -19,13 +28,13 @@ import FirebaseFirestore
     func loadData(for date: Date, authService: AuthService) async {
         do {
             // Load meals for the day using MealRepository
-            meals = try await MealRepository.shared.fetchMealsForDate(
+            meals = try await mealRepository.fetchMealsForDate(
                 date, 
                 userId: authService.currentUser?.id ?? ""
             )
             
             // Load symptoms for the day using SymptomRepository
-            symptoms = try await SymptomRepository.shared.fetchSymptomsForDate(
+            symptoms = try await symptomRepository.fetchSymptomsForDate(
                 date,
                 userId: authService.currentUser?.id ?? ""
             )
@@ -40,7 +49,7 @@ import FirebaseFirestore
     
     func deleteSymptom(_ symptom: Symptom) async {
         do {
-            try await SymptomRepository.shared.delete(id: symptom.id)
+            try await symptomRepository.delete(id: symptom.id)
             // Remove from local array
             symptoms.removeAll { $0.id == symptom.id }
         } catch {
@@ -49,7 +58,7 @@ import FirebaseFirestore
     
     func updateSymptom(_ updatedSymptom: Symptom) async {
         do {
-            try await SymptomRepository.shared.save(updatedSymptom)
+            try await symptomRepository.save(updatedSymptom)
             // Update in local array
             if let index = symptoms.firstIndex(where: { $0.id == updatedSymptom.id }) {
                 symptoms[index] = updatedSymptom

--- a/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/DashboardDataStore.swift
@@ -82,11 +82,19 @@ enum AIInsightSeverity {
     /// Authentication service for getting current user ID
     private var authService: AuthService?
     
+    /// Repository dependencies
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
+    
     // MARK: - Initialization
     
     /// Initialize the dashboard data store
     /// - Parameter preview: If true, loads mock data for SwiftUI previews
-    init(preview: Bool = false) {
+    init(preview: Bool = false,
+         mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.mealRepository = mealRepository
+        self.symptomRepository = symptomRepository
         if preview {
             loadPreviewData()
         } else {
@@ -269,11 +277,11 @@ enum AIInsightSeverity {
         Task {
             do {
                 // Load today's symptoms
-                let symptoms = try await SymptomRepository.shared.getSymptoms(for: selectedDate)
+                let symptoms = try await symptomRepository.getSymptoms(for: selectedDate)
                 
                 // Load today's meals using the current user ID
                 if let currentUser = await authService?.currentUser {
-                    let userMeals = try await MealRepository.shared.fetchMealsForDate(
+                    let userMeals = try await mealRepository.fetchMealsForDate(
                         selectedDate,
                         userId: currentUser.id
                     )

--- a/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Dashboard/RecentActivityViewModel.swift
@@ -9,14 +9,14 @@ import HealthKit
     var errorMessage: String?
     
     // Repository dependencies
-    private let mealRepository: MealRepository
-    private let symptomRepository: SymptomRepository
-    private let medicationDoseRepository: MedicationDoseRepository
+    private let mealRepository: any MealRepositoryProtocol
+    private let symptomRepository: any SymptomRepositoryProtocol
+    private let medicationDoseRepository: any MedicationDoseRepositoryProtocol
     private var medicationService: HealthKitMedicationService?
 
-    init(mealRepository: MealRepository = MealRepository.shared,
-         symptomRepository: SymptomRepository = SymptomRepository.shared,
-         medicationDoseRepository: MedicationDoseRepository = MedicationDoseRepository.shared) {
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared,
+         symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared,
+         medicationDoseRepository: any MedicationDoseRepositoryProtocol = MedicationDoseRepository.shared) {
         self.mealRepository = mealRepository
         self.symptomRepository = symptomRepository
         self.medicationDoseRepository = medicationDoseRepository

--- a/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Health/HealthKitViewModel.swift
@@ -34,15 +34,18 @@ import HealthKit
     // Inject settings and auth service for unit preferences and profile updates
     private var settingsViewModel: SettingsViewModel
     private var authService: AuthService
+    private let healthKitManager: any HealthKitManagerProtocol
     
-    init() {
+    init(healthKitManager: any HealthKitManagerProtocol = HealthKitManager.shared) {
         self.settingsViewModel = SettingsViewModel()
         self.authService = AuthService()
+        self.healthKitManager = healthKitManager
     }
     
-    init(settingsViewModel: SettingsViewModel, authService: AuthService) {
+    init(settingsViewModel: SettingsViewModel, authService: AuthService, healthKitManager: any HealthKitManagerProtocol = HealthKitManager.shared) {
         self.settingsViewModel = settingsViewModel
         self.authService = authService
+        self.healthKitManager = healthKitManager
     }
     
     // Allow updating dependencies after initialization (for environment objects)
@@ -77,7 +80,7 @@ import HealthKit
     /// Reads the current authorization status for every write type from HealthKit.
     /// Call this on appear and after any authorization request.
     func refreshWriteStatuses() {
-        let manager = HealthKitManager.shared
+        let manager = healthKitManager
 
         let mealTypes: [HKQuantityTypeIdentifier] = [
             .dietaryEnergyConsumed,

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -26,10 +26,10 @@ import FirebaseAuth
     var editingFoodItem: FoodItem?
     
     // Repository dependency
-    private let mealRepository: MealRepository
+    private let mealRepository: any MealRepositoryProtocol
     
     // Dependency injection for easier testing
-    init(mealRepository: MealRepository = MealRepository.shared) {
+    init(mealRepository: any MealRepositoryProtocol = MealRepository.shared) {
         self.mealRepository = mealRepository
     }
     

--- a/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
@@ -17,10 +17,10 @@ import SwiftUI
     var shouldDismiss = false
     
     // Repository dependency
-    private let mealRepository: MealRepository
+    private let mealRepository: any MealRepositoryProtocol
     
     // Initialize with a Meal object
-    init(meal: Meal, mealRepository: MealRepository = MealRepository.shared) {
+    init(meal: Meal, mealRepository: any MealRepositoryProtocol = MealRepository.shared) {
         self.meal = meal
         self.mealId = meal.id
         self.notes = meal.notes ?? ""
@@ -28,7 +28,7 @@ import SwiftUI
     }
     
     // Initialize with a meal ID
-    init(mealId: String, mealRepository: MealRepository = MealRepository.shared) {
+    init(mealId: String, mealRepository: any MealRepositoryProtocol = MealRepository.shared) {
         self.mealId = mealId
         self.meal = Meal.emptyMeal()
         self.mealRepository = mealRepository

--- a/GutCheck/GutCheck/ViewModels/Medication/AddMedicationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/AddMedicationViewModel.swift
@@ -34,9 +34,9 @@ import SwiftUI
 
     // MARK: - Dependencies
 
-    private let medicationRepository: MedicationRepository
+    private let medicationRepository: any MedicationRepositoryProtocol
 
-    init(medicationRepository: MedicationRepository = MedicationRepository.shared) {
+    init(medicationRepository: any MedicationRepositoryProtocol = MedicationRepository.shared) {
         self.medicationRepository = medicationRepository
     }
 

--- a/GutCheck/GutCheck/ViewModels/Medication/LogMedicationDoseViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/LogMedicationDoseViewModel.swift
@@ -34,12 +34,12 @@ import SwiftUI
 
     // MARK: - Dependencies
 
-    private let medicationRepository:     MedicationRepository
-    private let medicationDoseRepository: MedicationDoseRepository
+    private let medicationRepository:     any MedicationRepositoryProtocol
+    private let medicationDoseRepository: any MedicationDoseRepositoryProtocol
 
     init(
-        medicationRepository:     MedicationRepository     = MedicationRepository.shared,
-        medicationDoseRepository: MedicationDoseRepository = MedicationDoseRepository.shared
+        medicationRepository:     any MedicationRepositoryProtocol     = MedicationRepository.shared,
+        medicationDoseRepository: any MedicationDoseRepositoryProtocol = MedicationDoseRepository.shared
     ) {
         self.medicationRepository     = medicationRepository
         self.medicationDoseRepository = medicationDoseRepository

--- a/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/MedicationViewModel.swift
@@ -31,9 +31,9 @@ import SwiftUI
 
     // MARK: - Dependencies
 
-    private let medicationRepository: MedicationRepository
+    private let medicationRepository: any MedicationRepositoryProtocol
 
-    init(medicationRepository: MedicationRepository = MedicationRepository.shared) {
+    init(medicationRepository: any MedicationRepositoryProtocol = MedicationRepository.shared) {
         self.medicationRepository = medicationRepository
     }
 

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -35,9 +35,9 @@ import UserNotifications
     ]
     
     // Repository dependency
-    private let symptomRepository: SymptomRepository
+    private let symptomRepository: any SymptomRepositoryProtocol
     
-    init(symptomRepository: SymptomRepository = SymptomRepository.shared) {
+    init(symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
         self.symptomRepository = symptomRepository
     }
     

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
@@ -4,17 +4,17 @@ import Foundation
 class SymptomDetailViewModel: DetailViewModel<Symptom> {
     var symptomId: String?
     
-    private let repository: SymptomRepository
+    private let repository: any SymptomRepositoryProtocol
     
     // Initialize with a Symptom object
-    init(entity: Symptom, repository: SymptomRepository = SymptomRepository.shared) {
+    init(entity: Symptom, repository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
         self.symptomId = entity.id
         self.repository = repository
         super.init(entity: entity)
     }
     
     // Initialize with a symptom ID
-    init(symptomId: String, repository: SymptomRepository = SymptomRepository.shared) {
+    init(symptomId: String, repository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
         self.symptomId = symptomId
         self.repository = repository
         super.init(entity: Symptom.emptySymptom())

--- a/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
@@ -13,8 +13,13 @@ import FirebaseFirestore
     var selectedFilter: SymptomFilter = .all
     
     private let firebaseManager = FirebaseManager.shared
+    private let symptomRepository: any SymptomRepositoryProtocol
     private var lastDocument: DocumentSnapshot?
     private let pageSize = 20
+    
+    init(symptomRepository: any SymptomRepositoryProtocol = SymptomRepository.shared) {
+        self.symptomRepository = symptomRepository
+    }
     
     func loadSymptoms(filter: SymptomFilter = .all, refresh: Bool = false) async {
         if refresh {
@@ -129,7 +134,7 @@ import FirebaseFirestore
     
     func updateSymptom(_ updatedSymptom: Symptom) async {
         do {
-            try await SymptomRepository.shared.save(updatedSymptom)
+            try await symptomRepository.save(updatedSymptom)
             
             // Trigger dashboard refresh after successful update
             DataSyncManager.shared.triggerRefreshAfterSave(operation: "Symptom update", dataType: .symptoms)

--- a/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
+++ b/GutCheck/GutCheck/Views/Authentication/WelcomeView.swift
@@ -123,4 +123,10 @@ private struct WelcomePageView: View {
     func verifyPhoneNumber(_ phoneNumber: String) async throws {}
     func signInWithPhone(verificationCode: String) async throws {}
     func signOut() throws {}
+    func resendVerificationEmail() async throws {}
+    func checkEmailVerification() async throws {}
+    func cancelEmailVerification() throws {}
+    func deleteAuthenticatedAccount() async throws {}
+    func updateUserProfile(_ updatedUser: User) async throws {}
+    func refreshCurrentUser() async {}
 }


### PR DESCRIPTION
## Summary
- Introduces 6 new protocols (`MealRepositoryProtocol`, `SymptomRepositoryProtocol`, `MedicationRepositoryProtocol`, `MedicationDoseRepositoryProtocol`, `HealthKitManagerProtocol`, and expanded `AuthenticationProtocol`) to decouple ViewModels from concrete singleton services
- Updates all 16 ViewModels that reference these services to accept `any ProtocolType` via init parameters with concrete defaults, enabling mock injection for unit tests
- Adds conformances to existing concrete classes (`MealRepository`, `SymptomRepository`, `MedicationRepository`, `MedicationDoseRepository`, `HealthKitManager`) and updates `PreviewAuthService`/`MockAuthService` stubs

## Test plan
- [x] Project builds with zero errors
- [x] No new warnings introduced (existing Swift 6 concurrency warnings unchanged)
- [x] All existing call sites continue to work via default parameter values
- [ ] Verify previews render correctly in Xcode
- [ ] Run full test suite on simulator

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)