### PR TITLE
feat(#244): add meaningful assertions to UI launch tests

### DIFF
--- a/GutCheck/GutCheckUITests/GutCheckUITestsLaunchTests.swift
+++ b/GutCheck/GutCheckUITests/GutCheckUITestsLaunchTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+final class GutCheckUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool { true }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // App should reach either the auth screen (logged out) or main tab bar (logged in)
+        let signInButton = app.buttons["SignInButton"]
+        let tabBar = app.tabBars.firstMatch
+
+        let reachedKnownState = signInButton.waitForExistence(timeout: 10) || tabBar.waitForExistence(timeout: 10)
+        XCTAssertTrue(
+            reachedKnownState,
+            "App should display either the authentication screen or the main tab bar after launch"
+        )
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary
- Create `GutCheckUITestsLaunchTests.swift` with a launch test that verifies the app reaches a known state (auth screen or main tab bar) without the `--uitesting` flag
- Enable `runsForEachTargetApplicationUIConfiguration` to capture screenshots in both light and dark mode
- Attach launch screenshot with `lifetime: .keepAlways` for test result artifacts

## Notes
- Auth test identifiers (`"EmailField"`, `"PasswordField"`, `"SignInButton"`) were left as-is because they correctly match the dynamically generated identifiers from `CustomTextField` and `CustomButton` — the centralized `AccessibilityIdentifiers.Auth` enum uses different values not yet wired into those views

Closes #244

## Test plan
- [ ] Build succeeds with zero errors
- [ ] Launch test runs and captures screenshots in both light and dark mode
- [ ] Launch test passes whether user is logged in or logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)