### PR TITLE
fix(ci): fix xcodebuild destination and update deprecated actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
       time: "08:00"
       timezone: "America/Chicago"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "swift"
 
   # GitHub Actions — keep workflow action versions up to date
   - package-ecosystem: "github-actions"
@@ -23,6 +20,3 @@ updates:
       time: "08:00"
       timezone: "America/Chicago"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # ── Swift-only setup ────────────────────────────────────────────────────
       - name: Set up Xcode
@@ -98,7 +98,7 @@ jobs:
           xcodebuild build \
             -project GutCheck.xcodeproj \
             -scheme GutCheck \
-            -destination "generic/platform=iOS Simulator" \
+            -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=NO
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
@@ -87,7 +87,7 @@ jobs:
         xcodebuild clean build \
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
-          -destination "generic/platform=iOS Simulator" \
+          -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO
@@ -95,7 +95,7 @@ jobs:
 
     - name: Upload Build Artifacts on Failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-logs
         path: ~/Library/Developer/Xcode/DerivedData/Build/Logs/


### PR DESCRIPTION
- Fix xcodebuild destination: "generic/platform=iOS Simulator" fails on macos-15/Xcode 16.2 because iOS 18.2 is not pre-installed. Changed to "platform=iOS Simulator,name=iPhone 16,OS=latest" which uses the available simulator runtime.
- Update actions/checkout@v4 -> @v5 (v4 uses deprecated Node.js 20)
- Update actions/upload-artifact@v4 -> @v7 (v4 uses deprecated Node.js 20)