### PR TITLE
feat(#182): add background tasks for precomputed insights and data sync

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import UIKit
 import UserNotifications
+import BackgroundTasks
 import FirebaseCore
 import FirebaseFirestore
 
@@ -56,6 +57,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         // Register as the notification delegate so banners appear while the
         // app is in the foreground and taps can be routed to the right screen
         UNUserNotificationCenter.current().delegate = self
+
+        // Register background task handlers for pre-computed insights and data sync
+        BackgroundTaskService.shared.registerBackgroundTasks()
 
         // Test basic Firebase connectivity
         Task {
@@ -193,6 +197,7 @@ struct GutCheckApp: App {
                 case .background:
                     TimeoutManager.shared.applicationDidEnterBackground()
                     serverStatusService.stopMonitoring()
+                    BackgroundTaskService.shared.scheduleAllTasks()
                 case .active:
                     TimeoutManager.shared.applicationWillEnterForeground()
                     Task { await HealthKitSyncManager.shared.syncIfNeeded() }

--- a/GutCheck/GutCheck/Info.plist
+++ b/GutCheck/GutCheck/Info.plist
@@ -8,5 +8,15 @@
 	<string>GutCheck sends you helpful reminders to log meals and symptoms so you can maintain consistent tracking for better health insights.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>GutCheck can add your meal and symptom logging reminders to the Apple Reminders app so you can manage them alongside your other tasks.</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.gutcheck.insights-refresh</string>
+		<string>com.gutcheck.data-sync</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>

--- a/GutCheck/GutCheck/Services/BackgroundTasks/BackgroundTaskService.swift
+++ b/GutCheck/GutCheck/Services/BackgroundTasks/BackgroundTaskService.swift
@@ -1,0 +1,215 @@
+import Foundation
+import BackgroundTasks
+import os.log
+
+/// Manages background task scheduling and execution for pre-computing insights
+/// and performing lightweight data sync while the app is suspended.
+final class BackgroundTaskService {
+    static let shared = BackgroundTaskService()
+
+    // MARK: - Task Identifiers
+
+    static let insightsRefreshIdentifier = "com.gutcheck.insights-refresh"
+    static let dataSyncIdentifier = "com.gutcheck.data-sync"
+
+    // MARK: - Cache Keys
+
+    private enum CacheKey {
+        static let cachedInsights = "backgroundTask.cachedInsights"
+        static let lastInsightsRefresh = "backgroundTask.lastInsightsRefreshDate"
+        static let lastDataSync = "backgroundTask.lastDataSyncDate"
+    }
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.gutcheck",
+        category: "BackgroundTasks"
+    )
+
+    private init() {}
+
+    // MARK: - Registration
+
+    /// Register background task handlers. Must be called during app launch
+    /// (in `application(_:didFinishLaunchingWithOptions:)`) before the app finishes launching.
+    func registerBackgroundTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.insightsRefreshIdentifier,
+            using: nil
+        ) { task in
+            self.handleInsightsRefresh(task: task as! BGProcessingTask)
+        }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.dataSyncIdentifier,
+            using: nil
+        ) { task in
+            self.handleDataSync(task: task as! BGAppRefreshTask)
+        }
+
+        logger.info("Registered background task handlers")
+    }
+
+    // MARK: - Scheduling
+
+    /// Schedule all background tasks. Call when the app enters the background.
+    func scheduleAllTasks() {
+        scheduleInsightsRefresh()
+        scheduleDataSync()
+    }
+
+    /// Schedule the insights refresh processing task.
+    /// Requires external power; targets overnight execution at 2 AM.
+    func scheduleInsightsRefresh() {
+        let request = BGProcessingTaskRequest(identifier: Self.insightsRefreshIdentifier)
+        request.requiresExternalPower = true
+        request.requiresNetworkConnectivity = false
+        request.earliestBeginDate = nextScheduledDate(hour: 2)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logger.info("Scheduled insights refresh task")
+        } catch {
+            logger.error("Failed to schedule insights refresh: \(error.localizedDescription)")
+        }
+    }
+
+    /// Schedule a lightweight data sync refresh task.
+    /// Earliest begin date is 15 minutes from now.
+    func scheduleDataSync() {
+        let request = BGAppRefreshTaskRequest(identifier: Self.dataSyncIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logger.info("Scheduled data sync task")
+        } catch {
+            logger.error("Failed to schedule data sync: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Task Handlers
+
+    private func handleInsightsRefresh(task: BGProcessingTask) {
+        logger.info("Starting insights refresh background task")
+
+        // Schedule the next occurrence immediately
+        scheduleInsightsRefresh()
+
+        let computeTask = Task {
+            await InsightsService.shared.generateRecentInsights()
+
+            let insights = await MainActor.run {
+                InsightsService.shared.recentInsights
+            }
+
+            cacheInsights(insights)
+            logger.info("Insights refresh completed, cached \(insights.count) insights")
+        }
+
+        // Handle expiration — cancel the in-flight computation
+        task.expirationHandler = { [weak self] in
+            self?.logger.warning("Insights refresh task expired, cancelling")
+            computeTask.cancel()
+        }
+
+        // Notify system when complete
+        Task {
+            _ = await computeTask.result
+            task.setTaskCompleted(success: !computeTask.isCancelled)
+        }
+    }
+
+    private func handleDataSync(task: BGAppRefreshTask) {
+        logger.info("Starting data sync background task")
+
+        // Schedule the next occurrence immediately
+        scheduleDataSync()
+
+        let syncTask = Task { @MainActor in
+            try await DataSyncService.shared.performIncrementalSync()
+        }
+
+        // Handle expiration
+        task.expirationHandler = { [weak self] in
+            self?.logger.warning("Data sync task expired, cancelling")
+            syncTask.cancel()
+        }
+
+        // Notify system when complete
+        Task {
+            do {
+                try await syncTask.value
+                UserDefaults.standard.set(
+                    Date.now.timeIntervalSince1970,
+                    forKey: CacheKey.lastDataSync
+                )
+                task.setTaskCompleted(success: true)
+                logger.info("Data sync completed successfully")
+            } catch {
+                logger.error("Data sync failed: \(error.localizedDescription)")
+                task.setTaskCompleted(success: false)
+            }
+        }
+    }
+
+    // MARK: - Cache Management
+
+    private func cacheInsights(_ insights: [HealthInsight]) {
+        do {
+            let data = try JSONEncoder().encode(insights)
+            UserDefaults.standard.set(data, forKey: CacheKey.cachedInsights)
+            UserDefaults.standard.set(
+                Date.now.timeIntervalSince1970,
+                forKey: CacheKey.lastInsightsRefresh
+            )
+        } catch {
+            logger.error("Failed to cache insights: \(error.localizedDescription)")
+        }
+    }
+
+    /// Load previously cached insights from the background task.
+    /// Returns `nil` if no cache exists or decoding fails.
+    func loadCachedInsights() -> [HealthInsight]? {
+        guard let data = UserDefaults.standard.data(forKey: CacheKey.cachedInsights) else {
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode([HealthInsight].self, from: data)
+        } catch {
+            logger.error("Failed to decode cached insights: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// The date when insights were last refreshed by a background task, if ever.
+    var lastInsightsRefreshDate: Date? {
+        let timestamp = UserDefaults.standard.double(forKey: CacheKey.lastInsightsRefresh)
+        guard timestamp > 0 else { return nil }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    /// Clear all cached background task data.
+    func clearCache() {
+        UserDefaults.standard.removeObject(forKey: CacheKey.cachedInsights)
+        UserDefaults.standard.removeObject(forKey: CacheKey.lastInsightsRefresh)
+        UserDefaults.standard.removeObject(forKey: CacheKey.lastDataSync)
+    }
+
+    // MARK: - Helpers
+
+    /// Calculate the next occurrence of a specific hour (today if not yet passed, otherwise tomorrow).
+    private func nextScheduledDate(hour: Int) -> Date {
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month, .day], from: Date.now)
+        components.hour = hour
+        components.minute = 0
+
+        if let date = calendar.date(from: components), date > Date.now {
+            return date
+        }
+
+        // Past the target hour today — schedule for tomorrow
+        components.day = (components.day ?? 0) + 1
+        return calendar.date(from: components) ?? Date(timeIntervalSinceNow: 6 * 3600)
+    }
+}

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -44,7 +44,15 @@ struct RankedItem: Identifiable {
     func loadInsights() async {
         isLoading = true
         error = nil
-        
+
+        // Load cached insights for instant display on fresh launch
+        if recentInsights.isEmpty,
+           let cached = BackgroundTaskService.shared.loadCachedInsights() {
+            recentInsights = cached
+            patterns = convertInsightsToPatterns(cached)
+            recommendations = convertInsightsToRecommendations(cached)
+        }
+
         do {
             // Get current user ID
             let userId = getCurrentUserId()

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -193,8 +193,8 @@ private struct RelatedInsightRow: View {
 
 // MARK: - Supporting Types
 
-struct HealthInsight: Identifiable, Hashable {
-    let id = UUID()
+struct HealthInsight: Identifiable, Hashable, Codable {
+    let id: UUID
     let title: String
     let summary: String
     let detailedDescription: String?
@@ -202,6 +202,26 @@ struct HealthInsight: Identifiable, Hashable {
     let confidenceLevel: Int
     let dateRange: String
     let recommendations: [String]
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        summary: String,
+        detailedDescription: String?,
+        iconName: String,
+        confidenceLevel: Int,
+        dateRange: String,
+        recommendations: [String]
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.detailedDescription = detailedDescription
+        self.iconName = iconName
+        self.confidenceLevel = confidenceLevel
+        self.dateRange = dateRange
+        self.recommendations = recommendations
+    }
 }
 
 struct ContributingFactor: Identifiable {


### PR DESCRIPTION
## Summary
- Adds `BackgroundTaskService` that schedules overnight insights refresh (`BGProcessingTask`) and periodic data sync (`BGAppRefreshTask`) while the app is suspended
- Caches precomputed insights so the Analysis tab loads instantly on launch instead of recomputing every time
- Makes `HealthInsight` conform to `Codable` to support JSON caching, and integrates background task registration/scheduling into `GutCheckApp`

## Test plan
- [ ] Verify background task identifiers are registered in Info.plist (`com.gutcheck.insights-refresh`, `com.gutcheck.data-sync`)
- [ ] Simulate background task execution using Xcode debug commands (`e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.gutcheck.insights-refresh"]`)
- [ ] Confirm cached insights load on app relaunch before network fetch completes
- [ ] Verify tasks are rescheduled when the app enters the background

🤖 Generated with [Claude Code](https://claude.com/claude-code)