### PR TITLE
feat(#180): add Spotlight search indexing for meals and symptoms

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 import UserNotifications
 import BackgroundTasks
+import CoreSpotlight
 import FirebaseCore
 import FirebaseFirestore
 
@@ -190,6 +191,22 @@ struct GutCheckApp: App {
                     serverStatusService.startMonitoring()
                 } else {
                     serverStatusService.stopMonitoring()
+                    // Clear Spotlight index when user signs out
+                    SpotlightIndexingService.shared.removeAllItems()
+                }
+            }
+            .onContinueUserActivity(CSSearchableItemActionType) { activity in
+                guard let identifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String,
+                      let parsed = SpotlightIndexingService.parseIdentifier(identifier) else {
+                    return
+                }
+                switch parsed.type {
+                case "meal":
+                    AppRouter.shared.viewMealDetails(id: parsed.id)
+                case "symptom":
+                    AppRouter.shared.viewSymptomDetails(id: parsed.id)
+                default:
+                    break
                 }
             }
             .onChange(of: scenePhase) { oldPhase, newPhase in

--- a/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
+++ b/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
@@ -1,0 +1,155 @@
+//
+//  SpotlightIndexingService.swift
+//  GutCheck
+//
+//  Indexes meals and symptoms in iOS Spotlight search for quick retrieval.
+//
+
+import CoreSpotlight
+import MobileCoreServices
+import UIKit
+
+final class SpotlightIndexingService: Sendable {
+    static let shared = SpotlightIndexingService()
+
+    private let index = CSSearchableIndex.default()
+
+    // Domain identifiers for batch operations
+    private static let mealDomain = "com.gutcheck.meals"
+    private static let symptomDomain = "com.gutcheck.symptoms"
+
+    // Expiration: 6 months from indexing
+    private static let expirationInterval: TimeInterval = 60 * 60 * 24 * 180
+
+    private init() {}
+
+    // MARK: - Identifier Helpers
+
+    static func mealIdentifier(for id: String) -> String {
+        "meal_\(id)"
+    }
+
+    static func symptomIdentifier(for id: String) -> String {
+        "symptom_\(id)"
+    }
+
+    /// Parses a Spotlight identifier into a type ("meal" or "symptom") and entity ID.
+    static func parseIdentifier(_ identifier: String) -> (type: String, id: String)? {
+        if identifier.hasPrefix("meal_") {
+            return ("meal", String(identifier.dropFirst(5)))
+        } else if identifier.hasPrefix("symptom_") {
+            return ("symptom", String(identifier.dropFirst(8)))
+        }
+        return nil
+    }
+
+    // MARK: - Meal Indexing
+
+    func indexMeal(_ meal: Meal) {
+        // Only index public data
+        guard meal.privacyLevel == .public else { return }
+
+        let identifier = Self.mealIdentifier(for: meal.id)
+
+        let attributes = CSSearchableItemAttributeSet(contentType: .content)
+        attributes.title = meal.name
+        attributes.displayName = meal.name
+
+        // Build content description from food items and meal type — never include notes
+        var descriptionParts: [String] = []
+        descriptionParts.append(meal.type.rawValue.capitalized)
+
+        let foodNames = meal.foodItems.prefix(5).map(\.name)
+        if !foodNames.isEmpty {
+            descriptionParts.append(foodNames.joined(separator: ", "))
+        }
+
+        attributes.contentDescription = descriptionParts.joined(separator: " — ")
+
+        // Date
+        attributes.contentCreationDate = meal.date
+
+        // Keywords for better search
+        var keywords = ["meal", meal.type.rawValue]
+        keywords.append(contentsOf: meal.foodItems.map(\.name))
+        keywords.append(contentsOf: meal.tags)
+        attributes.keywords = keywords
+
+        // Thumbnail via SF Symbol
+        if let image = UIImage(systemName: "fork.knife.circle.fill") {
+            attributes.thumbnailData = image.pngData()
+        }
+
+        let item = CSSearchableItem(
+            uniqueIdentifier: identifier,
+            domainIdentifier: Self.mealDomain,
+            attributeSet: attributes
+        )
+        item.expirationDate = Date(timeIntervalSinceNow: Self.expirationInterval)
+
+        index.indexSearchableItems([item])
+    }
+
+    // MARK: - Symptom Indexing
+
+    func indexSymptom(_ symptom: Symptom) {
+        // Only index public data
+        guard symptom.privacyLevel == .public else { return }
+
+        let identifier = Self.symptomIdentifier(for: symptom.id)
+
+        let attributes = CSSearchableItemAttributeSet(contentType: .content)
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+        let dateString = dateFormatter.string(from: symptom.date)
+
+        attributes.title = "Symptom Log — \(dateString)"
+        attributes.displayName = "Symptom Log — \(dateString)"
+
+        // Content description from stool type, pain, urgency — never include notes
+        var parts: [String] = []
+        parts.append("Bristol Type \(symptom.stoolType.rawValue)")
+        parts.append("Pain: \(symptom.painLevel.rawValue)")
+        parts.append("Urgency: \(symptom.urgencyLevel.rawValue)")
+        attributes.contentDescription = parts.joined(separator: " · ")
+
+        attributes.contentCreationDate = symptom.date
+
+        // Keywords
+        var keywords = ["symptom", "bowel", "gut"]
+        keywords.append(contentsOf: symptom.tags)
+        attributes.keywords = keywords
+
+        // Thumbnail via SF Symbol
+        if let image = UIImage(systemName: "heart.text.square.fill") {
+            attributes.thumbnailData = image.pngData()
+        }
+
+        let item = CSSearchableItem(
+            uniqueIdentifier: identifier,
+            domainIdentifier: Self.symptomDomain,
+            attributeSet: attributes
+        )
+        item.expirationDate = Date(timeIntervalSinceNow: Self.expirationInterval)
+
+        index.indexSearchableItems([item])
+    }
+
+    // MARK: - Removal
+
+    func removeMeal(id: String) {
+        let identifier = Self.mealIdentifier(for: id)
+        index.deleteSearchableItems(withIdentifiers: [identifier])
+    }
+
+    func removeSymptom(id: String) {
+        let identifier = Self.symptomIdentifier(for: id)
+        index.deleteSearchableItems(withIdentifiers: [identifier])
+    }
+
+    func removeAllItems() {
+        index.deleteAllSearchableItems()
+    }
+}

--- a/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Calendar/CalendarDetailViewModel.swift
@@ -50,6 +50,7 @@ import FirebaseFirestore
     func deleteSymptom(_ symptom: Symptom) async {
         do {
             try await symptomRepository.delete(id: symptom.id)
+            SpotlightIndexingService.shared.removeSymptom(id: symptom.id)
             // Remove from local array
             symptoms.removeAll { $0.id == symptom.id }
         } catch {
@@ -59,6 +60,7 @@ import FirebaseFirestore
     func updateSymptom(_ updatedSymptom: Symptom) async {
         do {
             try await symptomRepository.save(updatedSymptom)
+            SpotlightIndexingService.shared.indexSymptom(updatedSymptom)
             // Update in local array
             if let index = symptoms.firstIndex(where: { $0.id == updatedSymptom.id }) {
                 symptoms[index] = updatedSymptom

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -164,6 +164,9 @@ import FirebaseAuth
                 // Save to repository (using the new repository pattern)
                 try await mealRepository.save(meal)
 
+                // Index in Spotlight for search
+                SpotlightIndexingService.shared.indexMeal(meal)
+
                 // Write nutrition data to HealthKit (respects user preference)
                 if UserDefaults.standard.bool(forKey: "healthKitWriteMeals") {
                     await HealthKitAsyncWrapper.shared.writeMealWithLogging(meal)

--- a/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealDetailViewModel.swift
@@ -88,6 +88,7 @@ import SwiftUI
         
         do {
             try await mealRepository.save(meal)
+            SpotlightIndexingService.shared.indexMeal(meal)
             isSaving = false
             isEditing = false
             return true
@@ -102,6 +103,7 @@ import SwiftUI
     func deleteMeal() async -> Bool {
         do {
             try await mealRepository.delete(id: meal.id)
+            SpotlightIndexingService.shared.removeMeal(id: meal.id)
             return true
         } catch {
             errorMessage = "Failed to delete meal: \(error.localizedDescription)"

--- a/GutCheck/GutCheck/ViewModels/Meal/MealHistoryViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealHistoryViewModel.swift
@@ -176,7 +176,8 @@ enum MealFilter: String, CaseIterable {
     func deleteMeal(_ meal: Meal) async {
         do {
             try await firebaseManager.deleteDocument(from: "meals", documentId: meal.id)
-            
+            SpotlightIndexingService.shared.removeMeal(id: meal.id)
+
             // Remove from grouped meals
             for (date, meals) in groupedMeals {
                 if let index = meals.firstIndex(where: { $0.id == meal.id }) {

--- a/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/LogSymptomViewModel.swift
@@ -130,7 +130,10 @@ import UserNotifications
                 #if DEBUG
                 #endif
                 try await symptomRepository.save(symptom)
-                
+
+                // Index in Spotlight for search
+                SpotlightIndexingService.shared.indexSymptom(symptom)
+
                 // Write to HealthKit
                 await self.writeToHealthKit(symptom)
                 

--- a/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Symptom/SymptomDetailViewModel.swift
@@ -51,6 +51,7 @@ class SymptomDetailViewModel: DetailViewModel<Symptom> {
         await executeWithSaving {
             try await self.repository.save(self.entity)
         } onSuccess: { _ in
+            SpotlightIndexingService.shared.indexSymptom(self.entity)
             self.isEditing = false
         } onError: { _ in
             // Error already handled by base class
@@ -64,6 +65,7 @@ class SymptomDetailViewModel: DetailViewModel<Symptom> {
         await executeWithLoading {
             try await self.repository.delete(id: self.entity.id)
         } onSuccess: { _ in
+            SpotlightIndexingService.shared.removeSymptom(id: self.entity.id)
             self.shouldDismiss = true
         }
         

--- a/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/SymptomHistoryViewModel.swift
@@ -116,7 +116,8 @@ import FirebaseFirestore
     func deleteSymptom(_ symptom: Symptom) async {
         do {
             try await firebaseManager.deleteDocument(from: "symptoms", documentId: symptom.id)
-            
+            SpotlightIndexingService.shared.removeSymptom(id: symptom.id)
+
             // Remove from grouped symptoms
             for (date, symptoms) in groupedSymptoms {
                 if let index = symptoms.firstIndex(where: { $0.id == symptom.id }) {
@@ -135,7 +136,8 @@ import FirebaseFirestore
     func updateSymptom(_ updatedSymptom: Symptom) async {
         do {
             try await symptomRepository.save(updatedSymptom)
-            
+            SpotlightIndexingService.shared.indexSymptom(updatedSymptom)
+
             // Trigger dashboard refresh after successful update
             DataSyncManager.shared.triggerRefreshAfterSave(operation: "Symptom update", dataType: .symptoms)
             


### PR DESCRIPTION
## Summary
- Creates `SpotlightIndexingService` that indexes meals and symptoms in iOS Spotlight search using CoreSpotlight
- Privacy-aware: only items with `privacyLevel == .public` are indexed; notes are never included in the index
- Handles Spotlight result taps via `onContinueUserActivity(CSSearchableItemActionType)` to deep-link into meal/symptom detail views through `AppRouter`
- Hooks indexing into all save/update call sites (MealBuilderModelView, MealDetailViewModel, LogSymptomViewModel, SymptomDetailViewModel, CalendarDetailViewModel, SymptomHistoryViewModel)
- Hooks removal into all delete call sites (MealDetailViewModel, MealHistoryViewModel, SymptomDetailViewModel, CalendarDetailViewModel, SymptomHistoryViewModel)
- Clears the entire Spotlight index on sign-out

Closes #180

## Test plan
- [ ] Build succeeds with no errors
- [ ] Log a new meal with no notes/private tags → verify it appears in Spotlight search
- [ ] Log a meal with notes → verify it does NOT appear in Spotlight (private data)
- [ ] Log a symptom with no notes and non-severe pain/urgency → verify it appears in Spotlight
- [ ] Tap a Spotlight result → verify it navigates to the correct detail view
- [ ] Delete a meal → verify it is removed from Spotlight
- [ ] Sign out → verify all items are cleared from Spotlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)