### PR TITLE
fix: move navigationDestination inside NavigationStack in UserProfileView

### DIFF
--- a/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
+++ b/GutCheck/GutCheck/Views/Profile/UserProfileView.swift
@@ -288,9 +288,9 @@ struct UserProfileView: View {
                     SettingsView()
                         .environment(settingsVM)
                         .environment(authService)
-                }
-                .navigationDestination(for: SettingsRoute.self) { route in
-                    SettingsRoute.destinationView(for: route)
+                        .navigationDestination(for: SettingsRoute.self) { route in
+                            SettingsRoute.destinationView(for: route)
+                        }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes a misplaced `.navigationDestination(for: SettingsRoute.self)` modifier in `UserProfileView` that was placed outside the `NavigationStack`, causing it to be ignored at runtime
- This meant tapping settings sub-screens (language, units, appearance, etc.) from the profile sheet did nothing
- Moved the modifier inside the `NavigationStack` onto `SettingsView()` so navigation works correctly

## Test plan
- [ ] Open profile → tap Settings → tap any sub-screen (Language, Units, Appearance, etc.) → verify it navigates correctly
- [ ] Verify no more "misplaced navigationDestination" runtime warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)