### PR TITLE
feat(#181): add Focus Filter so GutCheck respects iOS Focus modes

### DIFF
--- a/GutCheck/GutCheck/GutCheckApp.swift
+++ b/GutCheck/GutCheck/GutCheckApp.swift
@@ -221,6 +221,8 @@ struct GutCheckApp: App {
                     if authService.isAuthenticated {
                         serverStatusService.startMonitoring()
                         Task { try? await dataSyncService.performFullSync() }
+                        // Re-evaluate notifications in case Focus Filter state changed
+                        Task { await ReminderSettingsService.shared.rescheduleNotificationsForFocusChange() }
                     }
                 default:
                     break

--- a/GutCheck/GutCheck/Services/FocusFilter/FocusFilterState.swift
+++ b/GutCheck/GutCheck/Services/FocusFilter/FocusFilterState.swift
@@ -1,0 +1,62 @@
+//
+//  FocusFilterState.swift
+//  GutCheck
+//
+//  Tracks which notification categories are suppressed by an active iOS Focus Filter.
+//
+
+import Foundation
+
+struct FocusFilterState {
+
+    // MARK: - UserDefaults Keys
+
+    private enum Keys {
+        static let mealRemindersSuppressed = "focusFilter.mealRemindersSuppressed"
+        static let symptomRemindersSuppressed = "focusFilter.symptomRemindersSuppressed"
+        static let medicationRemindersSuppressed = "focusFilter.medicationRemindersSuppressed"
+        static let weeklyInsightsSuppressed = "focusFilter.weeklyInsightsSuppressed"
+    }
+
+    // MARK: - Read
+
+    static var mealRemindersSuppressed: Bool {
+        UserDefaults.standard.bool(forKey: Keys.mealRemindersSuppressed)
+    }
+
+    static var symptomRemindersSuppressed: Bool {
+        UserDefaults.standard.bool(forKey: Keys.symptomRemindersSuppressed)
+    }
+
+    static var medicationRemindersSuppressed: Bool {
+        UserDefaults.standard.bool(forKey: Keys.medicationRemindersSuppressed)
+    }
+
+    static var weeklyInsightsSuppressed: Bool {
+        UserDefaults.standard.bool(forKey: Keys.weeklyInsightsSuppressed)
+    }
+
+    // MARK: - Write
+
+    static func update(
+        mealRemindersSuppressed: Bool,
+        symptomRemindersSuppressed: Bool,
+        medicationRemindersSuppressed: Bool,
+        weeklyInsightsSuppressed: Bool
+    ) {
+        let defaults = UserDefaults.standard
+        defaults.set(mealRemindersSuppressed, forKey: Keys.mealRemindersSuppressed)
+        defaults.set(symptomRemindersSuppressed, forKey: Keys.symptomRemindersSuppressed)
+        defaults.set(medicationRemindersSuppressed, forKey: Keys.medicationRemindersSuppressed)
+        defaults.set(weeklyInsightsSuppressed, forKey: Keys.weeklyInsightsSuppressed)
+    }
+
+    static func clearAll() {
+        update(
+            mealRemindersSuppressed: false,
+            symptomRemindersSuppressed: false,
+            medicationRemindersSuppressed: false,
+            weeklyInsightsSuppressed: false
+        )
+    }
+}

--- a/GutCheck/GutCheck/Services/FocusFilter/GutCheckFocusFilter.swift
+++ b/GutCheck/GutCheck/Services/FocusFilter/GutCheckFocusFilter.swift
@@ -1,0 +1,64 @@
+//
+//  GutCheckFocusFilter.swift
+//  GutCheck
+//
+//  Focus Filter intent that lets users configure which GutCheck notification
+//  categories to suppress when an iOS Focus mode is active.
+//
+
+import AppIntents
+
+struct GutCheckFocusFilter: SetFocusFilterIntent {
+
+    // MARK: - Metadata
+
+    static var title: LocalizedStringResource = "GutCheck Notifications"
+    static var description: IntentDescription? = IntentDescription(
+        "Choose which GutCheck reminders to silence during this Focus."
+    )
+
+    // MARK: - Parameters
+
+    @Parameter(title: "Suppress Meal Reminders", default: false)
+    var suppressMealReminders: Bool
+
+    @Parameter(title: "Suppress Symptom Reminders", default: false)
+    var suppressSymptomReminders: Bool
+
+    @Parameter(title: "Suppress Medication Reminders", default: false)
+    var suppressMedicationReminders: Bool
+
+    @Parameter(title: "Suppress Weekly Insights", default: false)
+    var suppressWeeklyInsights: Bool
+
+    // MARK: - Display Representation
+
+    var displayRepresentation: DisplayRepresentation {
+        var suppressed: [String] = []
+        if suppressMealReminders { suppressed.append("Meals") }
+        if suppressSymptomReminders { suppressed.append("Symptoms") }
+        if suppressMedicationReminders { suppressed.append("Medication") }
+        if suppressWeeklyInsights { suppressed.append("Weekly Insights") }
+
+        if suppressed.isEmpty {
+            return DisplayRepresentation(stringLiteral: "No reminders suppressed")
+        }
+        return DisplayRepresentation(stringLiteral: "Suppressing: \(suppressed.joined(separator: ", "))")
+    }
+
+    // MARK: - Perform
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        FocusFilterState.update(
+            mealRemindersSuppressed: suppressMealReminders,
+            symptomRemindersSuppressed: suppressSymptomReminders,
+            medicationRemindersSuppressed: suppressMedicationReminders,
+            weeklyInsightsSuppressed: suppressWeeklyInsights
+        )
+
+        await ReminderSettingsService.shared.rescheduleNotificationsForFocusChange()
+
+        return .result()
+    }
+}

--- a/GutCheck/GutCheck/Services/ReminderSettingsService.swift
+++ b/GutCheck/GutCheck/Services/ReminderSettingsService.swift
@@ -92,6 +92,18 @@ import UserNotifications
         isLoading = false
     }
     
+    /// Re-schedules notifications using current settings and Focus Filter state.
+    /// Called by GutCheckFocusFilter.perform() when a Focus activates or deactivates.
+    func rescheduleNotificationsForFocusChange() async {
+        guard let settings = reminderSettings else {
+            await loadReminderSettings()
+            guard let settings = reminderSettings else { return }
+            await scheduleNotifications(for: settings)
+            return
+        }
+        await scheduleNotifications(for: settings)
+    }
+
     func updateReminderSettings(update: @escaping (inout ReminderSettings) -> Void) async {
         guard var settings = reminderSettings else {
             await createDefaultSettings()
@@ -165,7 +177,7 @@ import UserNotifications
              "dinnerReminder",    "Time to Log Your Dinner")
         ]
 
-        for meal in mealReminders where meal.enabled {
+        for meal in mealReminders where meal.enabled && !FocusFilterState.mealRemindersSuppressed {
             let content = UNMutableNotificationContent()
             content.title = meal.title
             content.body  = "Don't forget to track what you ate. Consistent logging leads to better insights."
@@ -187,7 +199,7 @@ import UserNotifications
         }
 
         // Schedule symptom reminders
-        if settings.symptomReminderEnabled {
+        if settings.symptomReminderEnabled && !FocusFilterState.symptomRemindersSuppressed {
             let content = UNMutableNotificationContent()
             content.title = "Symptom Check-In"
             content.body = "How's your gut feeling today? Tap to log your symptoms."
@@ -207,7 +219,7 @@ import UserNotifications
         }
 
         // Schedule medication reminders
-        if settings.medicationReminderEnabled {
+        if settings.medicationReminderEnabled && !FocusFilterState.medicationRemindersSuppressed {
             let content = UNMutableNotificationContent()
             content.title = "Medication Reminder"
             content.body = "Time to take your medication. Tap to log your dose."
@@ -227,7 +239,7 @@ import UserNotifications
         }
 
         // Schedule weekly summary reminders
-        if settings.weeklyInsightEnabled {
+        if settings.weeklyInsightEnabled && !FocusFilterState.weeklyInsightsSuppressed {
             let content = UNMutableNotificationContent()
             content.title = "Your Weekly Gut Health Summary"
             content.body = "Your report for the past 7 days is ready. See your trends and patterns."


### PR DESCRIPTION
## Summary
- Adds a `SetFocusFilterIntent` (`GutCheckFocusFilter`) that appears in Settings > Focus > [Focus] > Focus Filters > GutCheck
- Users can toggle suppression of 4 notification categories per Focus mode: Meal Reminders, Symptom Reminders, Medication Reminders, and Weekly Insights
- `FocusFilterState` persists suppression flags to UserDefaults; `ReminderSettingsService.scheduleNotifications()` checks these flags before scheduling each category
- On Focus activation, suppressed categories are removed from pending notifications; on deactivation, all enabled notifications resume
- Safety net: notifications are re-evaluated on foreground resume in case Focus state changed while backgrounded

Closes #181

## Test plan
- [ ] Build succeeds with no errors
- [ ] On device: Settings > Focus > Do Not Disturb > Focus Filters > Add Filter > verify "GutCheck Notifications" appears
- [ ] Toggle "Suppress Meal Reminders" on, activate the Focus > verify breakfast/lunch/dinner notifications don't fire
- [ ] Deactivate the Focus > verify meal notifications resume on next schedule
- [ ] Toggle multiple categories and verify each is independently controlled

🤖 Generated with [Claude Code](https://claude.com/claude-code)