### PR TITLE
feat(#34): add pattern overlay support to calendar view

### DIFF
--- a/GutCheck/GutCheck/Models/CalendarDay.swift
+++ b/GutCheck/GutCheck/Models/CalendarDay.swift
@@ -15,6 +15,7 @@ struct CalendarDay: Identifiable, Codable {
     let entryTypes: Set<EntryType>
     var meals: [Meal] = []
     var symptoms: [Symptom] = []
+    var correlation: DayCorrelation?
     
     enum EntryType: String, Codable, CaseIterable {
         case meals
@@ -29,5 +30,51 @@ struct CalendarDay: Identifiable, Codable {
     
     var hasSymptoms: Bool {
         return !symptoms.isEmpty || entryTypes.contains(.symptom) || entryTypes.contains(.both)
+    }
+    
+    var hasCorrelation: Bool {
+        correlation != nil
+    }
+}
+
+// MARK: - Day Correlation
+
+/// Lightweight summary of detected food-to-symptom correlations for a calendar day
+struct DayCorrelation: Codable {
+    /// Food names from meals that preceded symptoms within the correlation window
+    let triggerFoodNames: [String]
+    /// Number of correlated symptoms
+    let symptomCount: Int
+    /// Highest severity among correlated symptoms
+    let severity: CorrelationSeverity
+}
+
+enum CorrelationSeverity: String, Codable, Comparable {
+    case low
+    case medium
+    case high
+    
+    private var sortOrder: Int {
+        switch self {
+        case .low: return 0
+        case .medium: return 1
+        case .high: return 2
+        }
+    }
+    
+    static func < (lhs: CorrelationSeverity, rhs: CorrelationSeverity) -> Bool {
+        lhs.sortOrder < rhs.sortOrder
+    }
+    
+    /// Determine severity from symptom pain and urgency levels
+    static func from(painLevel: PainLevel, urgencyLevel: UrgencyLevel) -> CorrelationSeverity {
+        switch (painLevel, urgencyLevel) {
+        case (.severe, _), (_, .urgent):
+            return .high
+        case (.moderate, _), (_, .moderate):
+            return .medium
+        default:
+            return .low
+        }
     }
 }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -373,7 +373,9 @@ struct EmptyStateCard: View {
     var isLoadingSymptoms = false
     var calendarDays: [CalendarDay] = []
     
-
+    // Month-wide data for pattern overlay correlations
+    private var monthMeals: [Meal] = []
+    private var monthSymptoms: [Symptom] = []
     
     // Computed property for formatted date string
     var formattedDate: String {
@@ -475,6 +477,123 @@ struct EmptyStateCard: View {
             self.loadMeals()
             self.loadSymptoms()
             self.generateCalendarDays(for: date)
+        }
+        await loadMonthData(for: date)
+    }
+    
+    // MARK: - Month-Wide Pattern Overlay
+    
+    /// Fetch all meals and symptoms for the visible month, then compute correlations
+    private func loadMonthData(for date: Date) async {
+        let calendar = Calendar.current
+        guard let userId = AuthenticationManager.shared.currentUserId,
+              let monthInterval = calendar.dateInterval(of: .month, for: date) else {
+            return
+        }
+        
+        let startDate = monthInterval.start
+        let endDate = monthInterval.end
+        
+        do {
+            async let mealsTask = MealRepository.shared.fetchMealsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+            async let symptomsTask = SymptomRepository.shared.fetchSymptomsForDateRange(
+                startDate: startDate, endDate: endDate, userId: userId
+            )
+            
+            let (loadedMeals, loadedSymptoms) = try await (mealsTask, symptomsTask)
+            
+            self.monthMeals = loadedMeals
+            self.monthSymptoms = loadedSymptoms
+            
+            computeCorrelations()
+        } catch {
+            // Correlation overlay is non-critical; fail silently
+        }
+    }
+    
+    /// Compute lightweight meal-to-symptom correlations for each calendar day
+    private func computeCorrelations() {
+        let calendar = Calendar.current
+        
+        // Group meals and symptoms by day
+        let mealsByDay = Dictionary(grouping: monthMeals) { meal in
+            calendar.startOfDay(for: meal.date)
+        }
+        let symptomsByDay = Dictionary(grouping: monthSymptoms) { symptom in
+            calendar.startOfDay(for: symptom.date)
+        }
+        
+        for index in calendarDays.indices {
+            let dayStart = calendar.startOfDay(for: calendarDays[index].date)
+            
+            // Update entry type indicators from month-wide data
+            let dayMeals = mealsByDay[dayStart] ?? []
+            let daySymptoms = symptomsByDay[dayStart] ?? []
+            
+            if !dayMeals.isEmpty || !daySymptoms.isEmpty {
+                var entryTypes: Set<CalendarDay.EntryType> = []
+                if !dayMeals.isEmpty { entryTypes.insert(.meals) }
+                if !daySymptoms.isEmpty { entryTypes.insert(.symptom) }
+                if !dayMeals.isEmpty && !daySymptoms.isEmpty { entryTypes.insert(.both) }
+                
+                calendarDays[index] = CalendarDay(
+                    date: calendarDays[index].date,
+                    isCurrentMonth: calendarDays[index].isCurrentMonth,
+                    hasEntries: true,
+                    entryTypes: entryTypes,
+                    meals: calendarDays[index].meals,
+                    symptoms: calendarDays[index].symptoms,
+                    correlation: nil
+                )
+            }
+            
+            // Find meals on this day that were followed by symptoms within 2-8 hours
+            guard !dayMeals.isEmpty else { continue }
+            
+            // Collect all symptoms that could be correlated (same day + next day for late meals)
+            let nextDayStart = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+            let candidateSymptoms = daySymptoms + (symptomsByDay[nextDayStart] ?? [])
+            guard !candidateSymptoms.isEmpty else { continue }
+            
+            var triggerFoods: Set<String> = []
+            var correlatedSymptoms: [Symptom] = []
+            
+            for meal in dayMeals {
+                let related = candidateSymptoms.filter { symptom in
+                    let hours = symptom.date.timeIntervalSince(meal.date) / 3600
+                    return hours >= 2 && hours <= 8
+                }
+                
+                if !related.isEmpty {
+                    for foodItem in meal.foodItems {
+                        triggerFoods.insert(foodItem.name)
+                    }
+                    correlatedSymptoms.append(contentsOf: related)
+                }
+            }
+            
+            guard !triggerFoods.isEmpty else { continue }
+            
+            // Deduplicate symptoms by id
+            let uniqueSymptoms = Dictionary(grouping: correlatedSymptoms, by: \.id)
+                .compactMap { $0.value.first }
+            
+            // Compute max severity
+            let maxSeverity = uniqueSymptoms.reduce(CorrelationSeverity.low) { current, symptom in
+                let severity = CorrelationSeverity.from(
+                    painLevel: symptom.painLevel,
+                    urgencyLevel: symptom.urgencyLevel
+                )
+                return max(current, severity)
+            }
+            
+            calendarDays[index].correlation = DayCorrelation(
+                triggerFoodNames: Array(triggerFoods).sorted(),
+                symptomCount: uniqueSymptoms.count,
+                severity: maxSeverity
+            )
         }
     }
     

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -131,6 +131,14 @@ private struct DayCell: View {
     let day: CalendarDay
     let isSelected: Bool
     
+    private var correlationColor: Color {
+        guard let severity = day.correlation?.severity else { return .clear }
+        switch severity {
+        case .high: return .red
+        case .medium, .low: return .orange
+        }
+    }
+    
     var body: some View {
         VStack(spacing: 4) {
             Text("\(Calendar.current.component(.day, from: day.date))")
@@ -148,6 +156,11 @@ private struct DayCell: View {
                         Circle()
                             .fill(ColorTheme.bowelTracking)
                             .frame(width: 6, height: 6)
+                    }
+                    if day.hasCorrelation {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 8))
+                            .foregroundStyle(correlationColor)
                     }
                 }
             }
@@ -190,10 +203,63 @@ private struct DailySummaryCard: View {
                     }
                 }
             }
+            
+            if let correlation = day.correlation {
+                CorrelationSummaryView(correlation: correlation)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .roundedCard()
+    }
+}
+
+private struct CorrelationSummaryView: View {
+    let correlation: DayCorrelation
+    
+    private var severityColor: Color {
+        switch correlation.severity {
+        case .high: return .red
+        case .medium: return .orange
+        case .low: return .yellow
+        }
+    }
+    
+    private var severityLabel: String {
+        switch correlation.severity {
+        case .high: return "High"
+        case .medium: return "Moderate"
+        case .low: return "Low"
+        }
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Possible Triggers", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(severityColor)
+            
+            Text("\(correlation.symptomCount) symptom\(correlation.symptomCount == 1 ? "" : "s") detected 2–8 hours after eating")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            
+            HStack(spacing: 4) {
+                Text("Severity:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(severityLabel)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(severityColor)
+            }
+            
+            Text(correlation.triggerFoodNames.joined(separator: ", "))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(severityColor.opacity(0.08))
+        .clipShape(.rect(cornerRadius: 10))
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds food-to-symptom correlation detection to the month calendar grid in `UnifiedCalendarView`
- Fetches all meals and symptoms for the visible month, runs a lightweight 2–8 hour correlation window check, and marks days with possible triggers
- Displays a warning triangle indicator (orange/red by severity) on correlated days in the calendar grid
- Shows trigger food names, symptom count, and severity details in the `DailySummaryCard` when a correlated day is selected
- Adds `DayCorrelation` and `CorrelationSeverity` models to `CalendarDay` for lightweight per-day correlation data

## Test plan
- [ ] Navigate to the month calendar view and verify days with both meals and symptoms (within 2–8 hours) show a warning triangle indicator
- [ ] Verify indicator color: orange for low/medium severity, red for high severity
- [ ] Tap a day with a correlation indicator and confirm the daily summary card shows the "Possible Triggers" section with food names, symptom count, and severity
- [ ] Switch months and verify correlations update for the new month
- [ ] Verify days without correlations do not show the indicator

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)