### PR TITLE
fix(#303): remove duplicate .task modifier in CalendarDetailView

### DIFF
--- a/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
@@ -82,9 +82,6 @@ struct CalendarDetailView: View {
         }
         .navigationTitle(date.formatted(.dateTime.month().day().weekday()))
         .navigationBarTitleDisplayMode(.inline)
-        .task {
-            await viewModel.loadData(for: date, authService: authService)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Removes duplicate `.task` modifier in `CalendarDetailView` that was calling `viewModel.loadData(for:authService:)` twice on every navigation — once from `body` and once from the `content` computed property
- Keeps the `.task` on `body` (the view entry point), removes the redundant one on `content`

## Test plan
- [ ] Navigate to a calendar day detail and verify data loads correctly (single load, no flicker)
- [ ] Verify meals, symptoms, and daily analysis sections all populate

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)