### PR TITLE
fix(#301): replace fatalError with thrown error in nonce generation

### DIFF
--- a/GutCheck/GutCheck/Services/Firebase/AuthService.swift
+++ b/GutCheck/GutCheck/Services/Firebase/AuthService.swift
@@ -504,8 +504,8 @@ import os.log
     
     /// Prepares the Apple Sign-In request by generating and storing a nonce.
     /// Returns the SHA256-hashed nonce to include in the ASAuthorizationAppleIDRequest.
-    func prepareAppleSignIn() -> String {
-        let nonce = randomNonceString()
+    func prepareAppleSignIn() throws -> String {
+        let nonce = try randomNonceString()
         currentNonce = nonce
         return sha256(nonce)
     }
@@ -573,12 +573,12 @@ import os.log
         }
     }
     
-    private func randomNonceString(length: Int = 32) -> String {
+    private func randomNonceString(length: Int = 32) throws -> String {
         precondition(length > 0)
         var randomBytes = [UInt8](repeating: 0, count: length)
         let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
-        if errorCode != errSecSuccess {
-            fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+        guard errorCode == errSecSuccess else {
+            throw AuthError.custom("Failed to generate secure nonce (OSStatus \(errorCode))")
         }
         
         let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")

--- a/GutCheck/GutCheck/Views/AuthenticationView.swift
+++ b/GutCheck/GutCheck/Views/AuthenticationView.swift
@@ -243,9 +243,13 @@ struct AuthenticationView: View {
         VStack(spacing: 12) {
             AppleSignInButtonView(
                 onRequest: { request in
-                    let hashedNonce = authService.prepareAppleSignIn()
-                    request.requestedScopes = [.fullName, .email]
-                    request.nonce = hashedNonce
+                    do {
+                        let hashedNonce = try authService.prepareAppleSignIn()
+                        request.requestedScopes = [.fullName, .email]
+                        request.nonce = hashedNonce
+                    } catch {
+                        authService.errorMessage = "Failed to prepare Apple Sign-In: \(error.localizedDescription)"
+                    }
                 },
                 onCompletion: { result in
                     switch result {


### PR DESCRIPTION
## Summary
- Replaces `fatalError()` in `randomNonceString()` with a thrown `AuthError`, preventing an app crash if `SecRandomCopyBytes` fails
- Makes `prepareAppleSignIn()` throwing to propagate the error
- Updates the call site in `AuthenticationView` to catch the error and display it to the user via `authService.errorMessage`

## Test plan
- [ ] Tap "Continue with Apple" — verify sign-in flow works normally
- [ ] Verify no crash on nonce generation (previously would `fatalError` on failure)

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)