### PR TITLE
fix(deps): restore Package.resolved — the dependency bumps never applied

### DIFF
--- a/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "52548902007e7beda99fcdca31f62eccc4befe38",
-        "version" : "12.11.0"
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "7b722132d1f2ab421c88a2e5c384c984cebd0d00",
-        "version" : "3.4.0"
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "1657f705bc70255ff9d66dfcc697a85db164998f",
-        "version" : "12.11.0"
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
-        "version" : "1.36.1"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     }
   ],


### PR DESCRIPTION
Follow-up to merging #286–#290. Those five PRs left `Package.resolved` inconsistent with the project's actual dependency requirements, **and none of them actually upgraded anything.**

## The lockfile is currently broken

Building with resolution disabled fails outright on `main`:

```
an out-of-date resolved file was detected at .../Package.resolved,
which is not allowed when automatic dependency resolution is disabled
```

CI does **not** catch this — the workflow doesn't pass `-onlyUsePackageVersionsFromResolvedFile`, so SPM silently re-resolves at build time and reports success. `main` can stay green indefinitely while the committed lockfile is wrong, which defeats the point of committing it: clones aren't reproducible.

## Why the bumps couldn't take effect

The project declares exactly **one** package reference — `firebase-ios-sdk`:

```
kind = upToNextMajorVersion;
minimumVersion = 11.15.0;
```

That means `>=11.15.0, <12.0.0`. **Firebase 12.11.0 is outside the allowed range**, so the resolver reverts to 11.15.0.

`GoogleAppMeasurement`, `grpc-binary`, `swift-protobuf` and `google-ads-on-device-conversion` aren't direct references at all — they're **transitive** dependencies of Firebase, so their versions come from Firebase's own manifest, not from this lockfile.

What SPM actually resolves:

| Package | Dependabot wrote | Resolver produces |
|---|---|---|
| firebase-ios-sdk | 12.11.0 | **11.15.0** (reverted) |
| googleappmeasurement | 12.11.0 | **11.15.0** (reverted) |
| google-ads-on-device-conversion | 3.4.0 | **2.3.0** (reverted) |
| swift-protobuf | 1.36.1 | 1.38.1 |

So the net effect of those five merges was a corrupted lockfile and **no upgrade**. `main` is still on Firebase 11.15.0.

## This PR

Commits what SPM actually resolves, so the lockfile is honest and clones are reproducible. Verified locally: **BUILD SUCCEEDED**.

## Follow-ups worth considering

- **Upgrading to Firebase 12.x is a real change**, not a lockfile edit. It needs `minimumVersion` raised in `project.pbxproj` plus a genuine compatibility review of a major version bump — worth its own PR.
- **Dependabot is configured to raise PRs for transitive Swift packages it can't actually control.** That's where these misleading PRs come from; scoping its `swift` ecosystem config to direct dependencies would stop the noise.
- **Consider adding `-onlyUsePackageVersionsFromResolvedFile` to CI** so lockfile drift fails the build instead of being silently papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)