### PR TITLE
fix: concurrency, thread-safety and sync-timestamp audit findings

### DIFF
--- a/GutCheck/GutCheck/Models/Meal.swift
+++ b/GutCheck/GutCheck/Models/Meal.swift
@@ -29,7 +29,12 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
     var notes: String?
     var tags: [String] = []
     var createdBy: String = ""
-    
+
+    /// When the record was written, as distinct from `date` (when the meal was
+    /// eaten). Sync conflict resolution orders on these, matching Symptom.
+    var createdAt: Date = Date.now
+    var updatedAt: Date = Date.now
+
     // MARK: - Privacy Classification
     
     /// Determines the privacy level of this meal data
@@ -122,8 +127,13 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
         } else {
             self.foodItems = []
         }
+
+        // Records written before these fields existed fall back to `date`, so
+        // conflict resolution has a usable ordering rather than nil.
+        self.createdAt = (data["createdAt"] as? Timestamp)?.dateValue() ?? self.date
+        self.updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue() ?? self.createdAt
     }
-    
+
     func toFirestoreData() -> [String: Any] {
         var data: [String: Any] = [
             "name": name,
@@ -131,16 +141,20 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
             "type": type.rawValue,
             "source": source.rawValue,
             "createdBy": createdBy,
-            "tags": tags
+            "tags": tags,
+            // `date` is when the meal was eaten; these are when the record was
+            // written. Sync conflict resolution needs the latter to pick a winner.
+            "createdAt": Timestamp(date: createdAt),
+            "updatedAt": Timestamp(date: Date.now)
         ]
-        
+
         if let notes = notes {
             data["notes"] = notes
         }
-        
+
         // Convert food items to dictionaries
         data["foodItems"] = foodItems.map { $0.toDictionary() }
-        
+
         return data
     }
 }

--- a/GutCheck/GutCheck/Services/FocusFilter/FocusFilterState.swift
+++ b/GutCheck/GutCheck/Services/FocusFilter/FocusFilterState.swift
@@ -18,23 +18,50 @@ struct FocusFilterState {
         static let weeklyInsightsSuppressed = "focusFilter.weeklyInsightsSuppressed"
     }
 
+    /// Serializes access to the four keys.
+    ///
+    /// UserDefaults is already thread-safe for an individual key, so the risk
+    /// isn't a corrupt read — it's a torn one. iOS can invoke
+    /// `GutCheckFocusFilter.perform()` on a background thread while
+    /// ReminderSettingsService reads these on the main thread, and because
+    /// `update` writes four keys in sequence a reader could otherwise observe a
+    /// half-applied filter (meals suppressed, symptoms not yet written) and
+    /// schedule notifications the Focus was meant to silence.
+    private static let lock = NSLock()
+
+    // MARK: - Snapshot
+
+    /// All four flags read together under one lock.
+    /// Prefer this when acting on more than one flag, so the values are
+    /// guaranteed to come from the same update.
+    struct Snapshot {
+        let mealRemindersSuppressed: Bool
+        let symptomRemindersSuppressed: Bool
+        let medicationRemindersSuppressed: Bool
+        let weeklyInsightsSuppressed: Bool
+    }
+
+    static var current: Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        let defaults = UserDefaults.standard
+        return Snapshot(
+            mealRemindersSuppressed: defaults.bool(forKey: Keys.mealRemindersSuppressed),
+            symptomRemindersSuppressed: defaults.bool(forKey: Keys.symptomRemindersSuppressed),
+            medicationRemindersSuppressed: defaults.bool(forKey: Keys.medicationRemindersSuppressed),
+            weeklyInsightsSuppressed: defaults.bool(forKey: Keys.weeklyInsightsSuppressed)
+        )
+    }
+
     // MARK: - Read
 
-    static var mealRemindersSuppressed: Bool {
-        UserDefaults.standard.bool(forKey: Keys.mealRemindersSuppressed)
-    }
+    static var mealRemindersSuppressed: Bool { current.mealRemindersSuppressed }
 
-    static var symptomRemindersSuppressed: Bool {
-        UserDefaults.standard.bool(forKey: Keys.symptomRemindersSuppressed)
-    }
+    static var symptomRemindersSuppressed: Bool { current.symptomRemindersSuppressed }
 
-    static var medicationRemindersSuppressed: Bool {
-        UserDefaults.standard.bool(forKey: Keys.medicationRemindersSuppressed)
-    }
+    static var medicationRemindersSuppressed: Bool { current.medicationRemindersSuppressed }
 
-    static var weeklyInsightsSuppressed: Bool {
-        UserDefaults.standard.bool(forKey: Keys.weeklyInsightsSuppressed)
-    }
+    static var weeklyInsightsSuppressed: Bool { current.weeklyInsightsSuppressed }
 
     // MARK: - Write
 
@@ -44,6 +71,8 @@ struct FocusFilterState {
         medicationRemindersSuppressed: Bool,
         weeklyInsightsSuppressed: Bool
     ) {
+        lock.lock()
+        defer { lock.unlock() }
         let defaults = UserDefaults.standard
         defaults.set(mealRemindersSuppressed, forKey: Keys.mealRemindersSuppressed)
         defaults.set(symptomRemindersSuppressed, forKey: Keys.symptomRemindersSuppressed)

--- a/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Analysis/InsightsViewModel.swift
@@ -113,11 +113,19 @@ struct RankedItem: Identifiable {
     }
     
     private func fetchHealthData(for timeRange: DateInterval) async -> GutHealthData? {
+        // HealthKit's callback is not guaranteed to fire exactly once, and if the
+        // enclosing Task is cancelled the completion can still arrive afterwards.
+        // Resuming a checked continuation twice traps, so the guard below makes
+        // the resume idempotent. `hasResumed` is only touched inside the callback,
+        // which HealthKit delivers serially.
         return await withCheckedContinuation { continuation in
+            var hasResumed = false
             healthKitManager.fetchGutHealthData(
                 from: timeRange.start,
                 to: timeRange.end
             ) { healthData in
+                guard !hasResumed else { return }
+                hasResumed = true
                 continuation.resume(returning: healthData)
             }
         }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -427,10 +427,18 @@ struct EmptyStateCard: View {
         return details
     }
 
+    // In-flight load tasks. loadMeals/loadSymptoms are driven by onAppear, two
+    // onChange handlers and refreshable, so without cancellation a burst of date
+    // taps leaves several fetches racing — and a slow earlier one can resolve
+    // after a newer one, leaving the list showing another day's data.
+    private var mealsLoadTask: Task<Void, Never>?
+    private var symptomsLoadTask: Task<Void, Never>?
+
     // Public method to load meals from Firebase
     func loadMeals() {
+        mealsLoadTask?.cancel()
         isLoadingMeals = true
-        Task {
+        mealsLoadTask = Task {
             do {
                 guard let userId = AuthenticationManager.shared.currentUserId else {
                     await MainActor.run {
@@ -440,11 +448,13 @@ struct EmptyStateCard: View {
                     return
                 }
                 let loadedMeals = try await MealRepository.shared.fetchMealsForDate(selectedDate, userId: userId)
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     self.meals = loadedMeals
                     self.isLoadingMeals = false
                 }
             } catch {
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     self.meals = []
                     self.isLoadingMeals = false
@@ -455,15 +465,18 @@ struct EmptyStateCard: View {
 
     // Public method to load symptoms from Firebase
     func loadSymptoms() {
+        symptomsLoadTask?.cancel()
         isLoadingSymptoms = true
-        Task {
+        symptomsLoadTask = Task {
             do {
                 let loadedSymptoms = try await SymptomRepository.shared.getSymptoms(for: selectedDate)
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     self.symptoms = loadedSymptoms
                     self.isLoadingSymptoms = false
                 }
             } catch {
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     self.symptoms = []
                     self.isLoadingSymptoms = false


### PR DESCRIPTION
Closes #305, #307, #309, #316.

Part of working through the #299–#318 code-quality batch. Each issue was **verified against current code first** — several in that batch turned out to be stale, so these are only the ones that are still real.

## #305 — CalendarViewModel task races

`loadMeals`/`loadSymptoms` are driven by `onAppear`, two `onChange` handlers *and* `refreshable`, each spawning a bare `Task` with no cancellation.

Rapid date-tapping left several fetches racing, and a slow earlier one could resolve **after** a newer one — leaving the list showing another day's data. Now stores task handles, cancels the previous, and checks `Task.isCancelled` before applying results.

## #307 — FocusFilterState torn reads

The issue described this as "unguarded UserDefaults access". That framing isn't quite right — `UserDefaults` is already thread-safe per key.

The actual bug is that `update` writes **four keys in sequence**, so a reader can observe a half-applied filter. iOS can invoke `GutCheckFocusFilter.perform()` on a background thread while `ReminderSettingsService` reads on the main thread, and the app could then schedule notifications the Focus was meant to silence.

Added an `NSLock` plus a `Snapshot` type so all four flags are read together from the same update.

## #309 — Continuation double-resume

`InsightsViewModel.fetchHealthData` bridges a callback-based HealthKit API with `withCheckedContinuation`. A callback arriving after task cancellation resumes an already-invalidated continuation, which **traps at runtime**. Added a `hasResumed` guard to make the resume idempotent.

## #316 — Meal missing sync timestamps

`Meal` had no `createdAt`/`updatedAt`, so sync conflict resolution had no basis for picking the newer of two versions — `date` is when the meal was *eaten*, not when the record was written.

Both fields added, persisted in `toFirestoreData()` and read back in `init(from:)` with a fallback to `date`, so documents written before these fields existed still order correctly rather than arriving nil.

This one is worth more than its "Medium" label: the CloudKit migration (#282) will need exactly this.

## Testing

`BUILD SUCCEEDED`, verified standalone on a branch cut from `main` (not just on top of other in-flight work).

## Note on the audit batch

Worth flagging for whoever picks up the rest: **these issues can't be taken at face value.** Of six verified in depth, two were entirely stale (#304, #312 — both now closed with evidence) and two were materially mis-described (#311, #299 — both rescoped). Working the batch top-to-bottom would mean real time spent on already-fixed code.

Still unverified: #300, #308, #310, #313, #314, #315, #317, #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)