### PR TITLE
fix: keep the newest record when deduplicating, not the oldest

### DIFF
--- a/GutCheck/GutCheck/Models/Symptom.swift
+++ b/GutCheck/GutCheck/Models/Symptom.swift
@@ -75,6 +75,11 @@ struct Symptom: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
     var notes: String?
     var tags: [String] = []
     var createdBy: String = ""  // Firebase UID - required for FirestoreModel
+
+    /// When the record was written, as distinct from `date` (when the symptom
+    /// occurred). Deduplication orders on `updatedAt` to keep the newer copy.
+    var createdAt: Date = Date.now
+    var updatedAt: Date = Date.now
     
     // MARK: - Privacy Classification
     
@@ -168,8 +173,14 @@ struct Symptom: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
             throw RepositoryError.invalidData("Missing or invalid createdBy field")
         }
         self.createdBy = createdBy
+
+        // `createdAt` was already being written but never read back, so
+        // deduplication had no way to tell two copies of the same record apart.
+        // Records predating these fields fall back to `date` for a usable ordering.
+        self.createdAt = (data["createdAt"] as? Timestamp)?.dateValue() ?? self.date
+        self.updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue() ?? self.createdAt
     }
-    
+
     func toFirestoreData() -> [String: Any] {
         var data: [String: Any] = [
             "id": id,
@@ -179,7 +190,10 @@ struct Symptom: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
             "urgencyLevel": urgencyLevel.rawValue,
             "tags": tags,
             "createdBy": createdBy,
-            "createdAt": Timestamp(date: Date.now)
+            // `date` is when the symptom occurred; these track when the record
+            // was written, which is what conflict resolution needs.
+            "createdAt": Timestamp(date: createdAt),
+            "updatedAt": Timestamp(date: Date.now)
         ]
         
         if let notes = notes {
@@ -187,5 +201,35 @@ struct Symptom: Identifiable, Codable, Hashable, Equatable, FirestoreModel {
         }
         
         return data
+    }
+}
+// MARK: - Timestamped Record
+
+/// Records that carry a write timestamp, so duplicates arriving from local
+/// storage and Firestore can be collapsed by keeping the most recent copy.
+protocol TimestampedRecord: Identifiable {
+    var id: String { get }
+    var updatedAt: Date { get }
+}
+
+extension Symptom: TimestampedRecord {}
+extension Meal: TimestampedRecord {}
+
+extension Array where Element: TimestampedRecord {
+    /// Collapses records sharing an id, keeping whichever was written most
+    /// recently. Ordering of the result is left to the caller.
+    ///
+    /// The same record routinely arrives from both local storage and Firestore.
+    /// Resolving on `updatedAt` means a newer edit always wins, rather than
+    /// whichever copy happened to be appended first.
+    func deduplicatedKeepingNewest() -> [Element] {
+        var newestById: [String: Element] = [:]
+        for record in self {
+            if let existing = newestById[record.id], existing.updatedAt >= record.updatedAt {
+                continue
+            }
+            newestById[record.id] = record
+        }
+        return Array(newestById.values)
     }
 }

--- a/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
+++ b/GutCheck/GutCheck/Services/Repository/FirebaseRepository.swift
@@ -350,8 +350,10 @@ class MealRepository: BaseFirebaseRepository<Meal>, MealRepositoryProtocol {
         }
         allMeals.append(contentsOf: firestoreMeals)
         
-        // Sort all meals by date (most recent first) and limit
-        let sortedMeals = allMeals.sorted { $0.date > $1.date }
+        // Collapse records arriving from both local storage and Firestore before
+        // limiting. Without this a meal present in both sources consumed two of
+        // the `limit` slots and appeared twice in the UI.
+        let sortedMeals = allMeals.deduplicatedKeepingNewest().sorted { $0.date > $1.date }
         let limitedMeals = Array(sortedMeals.prefix(limit))
         
         return limitedMeals
@@ -413,30 +415,13 @@ class SymptomRepository: BaseFirebaseRepository<Symptom>, SymptomRepositoryProto
         
         
         
-        // Sort all symptoms by date
-        let sortedSymptoms = allSymptoms.sorted { $0.date < $1.date }
-        
-        // Debug: Check for duplicates
-        let symptomIds = sortedSymptoms.map { $0.id }
-        let uniqueIds = Set(symptomIds)
-        if symptomIds.count != uniqueIds.count {
-            // Remove duplicates by keeping only the first occurrence of each ID
-            var deduplicatedSymptoms: [Symptom] = []
-            var seenIds = Set<String>()
-            
-            for symptom in sortedSymptoms {
-                if !seenIds.contains(symptom.id) {
-                    deduplicatedSymptoms.append(symptom)
-                    seenIds.insert(symptom.id)
-                } else {
-                }
-            }
-            
-            return deduplicatedSymptoms
-        }
-        
-        return sortedSymptoms
+        // The same record can arrive from both local storage and Firestore.
+        // Previously this sorted ascending by `date` and kept the *first*
+        // occurrence, which meant the oldest copy won and newer edits were
+        // silently discarded. Keep the most recently written copy instead.
+        return allSymptoms.deduplicatedKeepingNewest().sorted { $0.date < $1.date }
     }
+
     
     func fetchRecentSymptoms(userId: String, limit: Int = 20) async throws -> [Symptom] {
         var allSymptoms: [Symptom] = []


### PR DESCRIPTION
Closes #300 (Critical — data integrity).

## The bug

Symptom deduplication sorted **ascending** by `date` and then kept the *first* occurrence of each id:

```swift
let sortedSymptoms = allSymptoms.sorted { $0.date < $1.date }   // oldest first
// "Remove duplicates by keeping only the first occurrence of each ID"
```

First-of-ascending is the **oldest**. So whenever the same record arrived from both local storage and Firestore, a newer edit was silently discarded in favour of the stale copy.

Separately, `fetchRecentMeals` had **no deduplication at all** — a meal present in both sources consumed two of the `limit` slots and rendered twice.

## Why it wasn't a one-line sort flip

"Keep the newest" needs a timestamp to compare, and `Symptom` had none.

It *wrote* `createdAt` to Firestore, but declared no property for it and never read it back — so at deduplication time the two copies were genuinely indistinguishable. Flipping the sort would only have swapped one arbitrary winner for another.

So the fix is three parts:

1. **`Symptom` gains `createdAt`/`updatedAt`**, read back in `init(from:)` with a fallback to `date` for documents written before these fields existed. This mirrors what #316 did for `Meal`.
2. **Deduplication resolves on `updatedAt`** via an id-keyed map, replacing the sort-and-keep-first logic.
3. **`fetchRecentMeals` gets deduplication**, applied before the `limit` so duplicates don't eat result slots.

The helper is an `Array where Element: TimestampedRecord` extension rather than a per-call-site reimplementation, since #316 had already given `Meal` matching fields:

```swift
allSymptoms.deduplicatedKeepingNewest().sorted { $0.date < $1.date }
allMeals.deduplicatedKeepingNewest().sorted { $0.date > $1.date }
```

## Also

Removes an empty `else { }` branch left in the old loop — one of the silent-swallow sites tracked in #299.

## Testing

`BUILD SUCCEEDED`, verified on a branch cut from current `main`.

Worth noting there is **no test coverage** for repository deduplication — that's #243/#317, and CI runs no tests at all today, so this was verified by inspection and compilation rather than by an automated check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)