### PR TITLE
feat: edit medications, rework nutrition detail, fix black backgrounds

### DIFF
--- a/GutCheck/GutCheck/ViewModels/Medication/AddMedicationViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Medication/AddMedicationViewModel.swift
@@ -32,12 +32,49 @@ import SwiftUI
 
     let loadingState = LoadingStateManager()
 
+    // MARK: - Edit Mode
+
+    /// The record being edited, or nil when adding a new one. Held so the save
+    /// can reuse its id (writing the same id updates rather than duplicates) and
+    /// preserve fields the form doesn't expose, like `source` and `healthKitUUID`.
+    private(set) var editingMedication: MedicationRecord?
+
+    var isEditing: Bool { editingMedication != nil }
+
+    /// HealthKit-sourced records are owned by Apple Health. Editing them here
+    /// would be overwritten on the next sync, so the form stays read-only for
+    /// them and the UI hides the edit affordance.
+    var isEditable: Bool {
+        editingMedication.map { $0.source != .healthKit } ?? true
+    }
+
     // MARK: - Dependencies
 
     private let medicationRepository: any MedicationRepositoryProtocol
 
     init(medicationRepository: any MedicationRepositoryProtocol = MedicationRepository.shared) {
         self.medicationRepository = medicationRepository
+    }
+
+    /// Populates the form from an existing record so it can be edited in place.
+    func load(_ medication: MedicationRecord) {
+        editingMedication = medication
+        name         = medication.name
+        dosageAmount = medication.dosage.amount > 0 ? trimmedAmount(medication.dosage.amount) : ""
+        dosageUnit   = medication.dosage.unit
+        frequency    = medication.dosage.frequency
+        startDate    = medication.startDate
+        hasEndDate   = medication.endDate != nil
+        endDate      = medication.endDate ?? Date.now
+        isActive     = medication.isActive
+        notes        = medication.notes ?? ""
+    }
+
+    /// "20" rather than "20.0" so the field round-trips what the user typed.
+    private func trimmedAmount(_ value: Double) -> String {
+        value == value.rounded()
+            ? String(Int(value))
+            : value.formatted(.number.precision(.fractionLength(1)))
     }
 
     // MARK: - Validation
@@ -65,16 +102,25 @@ import SwiftUI
 
         let amount  = Double(dosageAmount) ?? 0.0
         let dosage  = MedicationDosage(amount: amount, unit: dosageUnit, frequency: frequency)
+        let existing = editingMedication
+
+        // Reusing the existing id makes this an update rather than a duplicate.
+        // `source`, `healthKitUUID` and `createdAt` are carried over because the
+        // form doesn't expose them and they'd otherwise be reset on every edit.
         let medication = MedicationRecord(
-            createdBy:    userId,
-            name:         name.trimmingCharacters(in: .whitespacesAndNewlines),
-            dosage:       dosage,
-            startDate:    startDate,
-            endDate:      hasEndDate ? endDate : nil,
-            isActive:     isActive,
-            notes:        notes.isEmpty ? nil : notes,
-            source:       .manual,
-            privacyLevel: .private
+            id:            existing?.id ?? UUID().uuidString,
+            createdBy:     existing?.createdBy ?? userId,
+            name:          name.trimmingCharacters(in: .whitespacesAndNewlines),
+            dosage:        dosage,
+            startDate:     startDate,
+            endDate:       hasEndDate ? endDate : nil,
+            isActive:      isActive,
+            notes:         notes.isEmpty ? nil : notes,
+            source:        existing?.source ?? .manual,
+            privacyLevel:  existing?.privacyLevel ?? .private,
+            healthKitUUID: existing?.healthKitUUID,
+            createdAt:     existing?.createdAt ?? Date.now,
+            updatedAt:     Date.now
         )
 
         Task {

--- a/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
+++ b/GutCheck/GutCheck/Views/Analysis/InsightDetailView.swift
@@ -94,6 +94,8 @@ struct InsightDetailView: View {
             }
             .padding()
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Insight Details")
         .navigationBarTitleDisplayMode(.inline)
         .task {

--- a/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomExplanationView.swift
@@ -82,6 +82,8 @@ struct SymptomExplanationView: View {
                 }
                 .padding()
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle(symptomType.rawValue)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
+++ b/GutCheck/GutCheck/Views/Bowel/SymptomHistoryView.swift
@@ -43,6 +43,8 @@ struct SymptomHistoryView: View {
             
             symptomsList
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Symptom History")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarDetailView.swift
@@ -80,6 +80,8 @@ struct CalendarDetailView: View {
             }
             .padding(.vertical)
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle(date.formatted(.dateTime.month().day().weekday()))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -1193,9 +1193,19 @@ struct DailyNutritionDetailView: View {
     var body: some View {
         NavigationStack {
             List {
+                // MARK: Hero — calories and macro split
+                if nutrition.calories != nil || nutrition.protein != nil
+                    || nutrition.carbs != nil || nutrition.fat != nil {
+                    Section {
+                        NutritionSummaryHeader(nutrition: nutrition, mealCount: meals.count)
+                            .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                            .listRowBackground(Color.clear)
+                    }
+                }
+
                 // MARK: Macronutrients
                 Section(header: Text("Macronutrients")) {
-                    NutritionDetailRow(label: "Calories",     value: nutrition.calories.map { Double($0) }, unit: "kcal",  color: .orange)
+                    // Calories are shown in the header above, so they're not repeated here.
                     NutritionDetailRow(label: "Protein",      value: nutrition.protein,   unit: "g",    color: .blue)
                     NutritionDetailRow(label: "Carbohydrates",value: nutrition.carbs,     unit: "g",    color: .green)
                     NutritionDetailRow(label: "Total Fat",    value: nutrition.fat,       unit: "g",    color: .red)
@@ -1293,6 +1303,11 @@ struct DailyNutritionDetailView: View {
                     }
                 }
             }
+            // Without this the sheet falls through to the system background and
+            // renders black instead of the app's navy — same gap that affected
+            // InsightsView.
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle(dateTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -1413,4 +1428,107 @@ private struct NutritionDetailFoodRow: View {
     CalendarView(selectedTab: Tab.meals)
         .environment(AppRouter())
         .environment(AuthService())
+}
+
+// MARK: - Nutrition Summary Header
+
+/// Hero for the nutrition detail sheet: total calories, and a bar showing how
+/// the day's energy splits across protein, carbs and fat.
+///
+/// Grams alone don't convey balance — 9g protein next to 17g fat reads as
+/// "less fat" when by energy it's the opposite. The bar is weighted by calories
+/// (4/4/9 per gram) so proportion reflects what actually drove the total.
+private struct NutritionSummaryHeader: View {
+    let nutrition: NutritionInfo
+    let mealCount: Int
+
+    private struct Macro: Identifiable {
+        let id = UUID()
+        let name: String
+        let grams: Double
+        let calories: Double
+        let color: Color
+    }
+
+    private var macros: [Macro] {
+        [
+            Macro(name: "Protein", grams: nutrition.protein ?? 0,
+                  calories: (nutrition.protein ?? 0) * 4, color: .blue),
+            Macro(name: "Carbs", grams: nutrition.carbs ?? 0,
+                  calories: (nutrition.carbs ?? 0) * 4, color: .green),
+            Macro(name: "Fat", grams: nutrition.fat ?? 0,
+                  calories: (nutrition.fat ?? 0) * 9, color: .red)
+        ].filter { $0.grams > 0 }
+    }
+
+    private var macroCalorieTotal: Double {
+        macros.reduce(0) { $0 + $1.calories }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Calories — the headline figure, not just another row.
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("\(nutrition.calories ?? 0)")
+                    .font(.system(size: 44, weight: .bold, design: .rounded))
+                    .foregroundStyle(ColorTheme.primaryText)
+                Text("kcal")
+                    .typography(Typography.headline)
+                    .foregroundStyle(ColorTheme.secondaryText)
+
+                Spacer()
+
+                Text("\(mealCount) meal\(mealCount == 1 ? "" : "s")")
+                    .typography(Typography.subheadline)
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+
+            if macroCalorieTotal > 0 {
+                // Proportional split bar
+                GeometryReader { geo in
+                    HStack(spacing: 2) {
+                        ForEach(macros) { macro in
+                            Capsule()
+                                .fill(macro.color)
+                                .frame(width: max(2, geo.size.width * (macro.calories / macroCalorieTotal)))
+                        }
+                    }
+                }
+                .frame(height: 10)
+
+                // Legend: grams plus share of energy, so the bar is readable
+                // without having to interpret color alone.
+                HStack(spacing: 16) {
+                    ForEach(macros) { macro in
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(macro.color)
+                                .frame(width: 8, height: 8)
+                            Text(macro.name)
+                                .typography(Typography.caption)
+                                .foregroundStyle(ColorTheme.secondaryText)
+                            Text("\(Int(macro.grams.rounded()))g")
+                                .typography(Typography.caption)
+                                .foregroundStyle(ColorTheme.primaryText)
+                            Text("\(Int((macro.calories / macroCalorieTotal * 100).rounded()))%")
+                                .typography(Typography.caption)
+                                .foregroundStyle(ColorTheme.secondaryText)
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var accessibilitySummary: String {
+        var parts = ["\(nutrition.calories ?? 0) calories from \(mealCount) meal\(mealCount == 1 ? "" : "s")"]
+        for macro in macros {
+            let share = Int((macro.calories / max(macroCalorieTotal, 1) * 100).rounded())
+            parts.append("\(macro.name) \(Int(macro.grams.rounded())) grams, \(share) percent of energy")
+        }
+        return parts.joined(separator: ". ")
+    }
 }

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -43,6 +43,8 @@ struct UnifiedCalendarView: View {
                 
                 Spacer()
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Calendar")
             .navigationDestination(for: CalendarRoute.self) { route in
                 switch route {

--- a/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
+++ b/GutCheck/GutCheck/Views/Insights/InsightsDashboardView.swift
@@ -50,6 +50,8 @@ struct InsightsDashboardView: View {
                 }
                 .padding()
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Health Insights")
             .navigationBarTitleDisplayMode(.large)
             .refreshable {

--- a/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
+++ b/GutCheck/GutCheck/Views/Medication/AddMedicationView.swift
@@ -14,7 +14,11 @@ struct AddMedicationView: View {
     /// Called after a successful save so the parent list can refresh.
     var onSave: (() -> Void)?
 
-    init(onSave: (() -> Void)? = nil) {
+    /// Existing record to edit. Nil adds a new medication.
+    private let medicationToEdit: MedicationRecord?
+
+    init(medication: MedicationRecord? = nil, onSave: (() -> Void)? = nil) {
+        self.medicationToEdit = medication
         self.onSave = onSave
     }
 
@@ -29,16 +33,27 @@ struct AddMedicationView: View {
                 statusSection
                 notesSection
             }
-            .navigationTitle("Add Medication")
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
+            .navigationTitle(viewModel.isEditing ? "Edit Medication" : "Add Medication")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbarItems }
-            .alert("Medication Added", isPresented: $viewModel.showingSuccessAlert) {
+            .task {
+                // Populate once; re-running would discard in-progress edits.
+                if let medicationToEdit, !viewModel.isEditing {
+                    viewModel.load(medicationToEdit)
+                }
+            }
+            .alert(viewModel.isEditing ? "Medication Updated" : "Medication Added",
+                   isPresented: $viewModel.showingSuccessAlert) {
                 Button("Done") {
                     onSave?()
                     dismiss()
                 }
             } message: {
-                Text("\(viewModel.name) has been saved to your medications.")
+                Text(viewModel.isEditing
+                     ? "\(viewModel.name) has been updated."
+                     : "\(viewModel.name) has been saved to your medications.")
             }
             .alert("Error", isPresented: $viewModel.showingErrorAlert) {
                 Button("OK", role: .cancel) {}

--- a/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
+++ b/GutCheck/GutCheck/Views/Medication/LogMedicationDoseView.swift
@@ -27,6 +27,8 @@ struct LogMedicationDoseView: View {
                     logForm
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Log Medication")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbarItems }

--- a/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationListView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct MedicationListView: View {
     @State private var viewModel = MedicationViewModel()
 
+    /// Record currently open in the edit sheet.
+    @State private var medicationToEdit: MedicationRecord?
+
     // MARK: - Body
 
     var body: some View {
@@ -23,6 +26,8 @@ struct MedicationListView: View {
                 medicationList
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("My Medications")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
@@ -37,6 +42,11 @@ struct MedicationListView: View {
         }
         .sheet(isPresented: $viewModel.showingAddMedication) {
             AddMedicationView {
+                Task { await viewModel.loadMedications() }
+            }
+        }
+        .sheet(item: $medicationToEdit) { medication in
+            AddMedicationView(medication: medication) {
                 Task { await viewModel.loadMedications() }
             }
         }
@@ -76,8 +86,11 @@ struct MedicationListView: View {
                 Section(header: Text("Current")) {
                     ForEach(viewModel.activeMedications) { med in
                         MedicationRowView(medication: med)
+                            .contentShape(Rectangle())
+                            .onTapGesture { beginEditing(med) }
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 deleteButton(for: med)
+                                editButton(for: med)
                             }
                     }
                 }
@@ -88,8 +101,11 @@ struct MedicationListView: View {
                 Section(header: Text("Past Medications")) {
                     ForEach(viewModel.inactiveMedications) { med in
                         MedicationRowView(medication: med)
+                            .contentShape(Rectangle())
+                            .onTapGesture { beginEditing(med) }
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 deleteButton(for: med)
+                                editButton(for: med)
                             }
                     }
                 }
@@ -129,6 +145,25 @@ struct MedicationListView: View {
     }
 
     // MARK: - Helpers
+
+    /// HealthKit records are owned by Apple Health — editing them here would be
+    /// silently overwritten on the next sync, so the affordance is hidden.
+    private func beginEditing(_ medication: MedicationRecord) {
+        guard medication.source != .healthKit else { return }
+        medicationToEdit = medication
+    }
+
+    @ViewBuilder
+    private func editButton(for medication: MedicationRecord) -> some View {
+        if medication.source != .healthKit {
+            Button {
+                beginEditing(medication)
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(ColorTheme.accent)
+        }
+    }
 
     @ViewBuilder
     private func deleteButton(for medication: MedicationRecord) -> some View {

--- a/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
+++ b/GutCheck/GutCheck/Views/Medication/MedicationsView.swift
@@ -28,6 +28,8 @@ struct MedicationsView: View {
             .padding(.top, 8)
             .padding(.bottom, 100) // clear tab bar
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Medications")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {

--- a/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
+++ b/GutCheck/GutCheck/Views/Profile/DeleteAccountView.swift
@@ -99,6 +99,8 @@ struct DeleteAccountView: View {
             }
             .padding()
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Delete Account")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showingReauthentication) {

--- a/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
+++ b/GutCheck/GutCheck/Views/Profile/HealthDataIntegrationView.swift
@@ -224,6 +224,8 @@ struct HealthDataIntegrationView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Apple Health")
             .navigationDestination(for: SettingsRoute.self) { route in
                 switch route {

--- a/GutCheck/GutCheck/Views/Profile/SettingsView.swift
+++ b/GutCheck/GutCheck/Views/Profile/SettingsView.swift
@@ -301,6 +301,8 @@ struct SettingsView: View {
                     }
                 }
             }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Settings")
         .navigationDestination(for: SettingsRoute.self) { route in
             SettingsRoute.destinationView(for: route)

--- a/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
+++ b/GutCheck/GutCheck/Views/Settings/DataDeletionRequestView.swift
@@ -102,6 +102,8 @@ struct DataDeletionRequestView: View {
                     .tint(.red)
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Data Deletion")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
+++ b/GutCheck/GutCheck/Views/Settings/HealthcareExportView.swift
@@ -44,6 +44,8 @@ struct HealthcareExportView: View {
                 }
                 .padding()
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Healthcare Export")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {

--- a/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
+++ b/GutCheck/GutCheck/Views/Settings/PrivacyPolicyView.swift
@@ -41,6 +41,8 @@ struct PrivacyPolicyView: View {
                 .padding(.vertical, 8)
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ColorTheme.background)
         .navigationTitle("Privacy Policy")
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(for: PrivacyPolicyRoute.self) { route in

--- a/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
+++ b/GutCheck/GutCheck/Views/Shared/ProfileMenuSheet.swift
@@ -30,6 +30,8 @@ struct ProfileMenuSheet: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(ColorTheme.background)
             .navigationTitle("Account")
             .navigationBarTitleDisplayMode(.inline)
             .navigationDestination(for: ProfileMenuRoute.self) { route in


### PR DESCRIPTION
Three related pieces of work, all verified running on device.

## 1. Medication editing

Medications could only be **added and deleted** — there was no way to correct a name or dosage.

Rows are now tappable, and carry an **Edit** swipe action. Both open the existing `AddMedicationView` in edit mode rather than a second parallel form.

Details that matter:
- **Saving updates rather than duplicates** — reuses the record's `id`
- **Carries over `source`, `healthKitUUID`, `createdAt`, `createdBy`** — fields the form doesn't expose, which would otherwise be silently reset on every edit
- **Dosage round-trips as `20`, not `20.0`**
- **HealthKit records are excluded.** Apple Health owns them, so a local edit would be silently overwritten on the next sync. An edit button that quietly loses your changes is worse than no edit button. Manual, pharmacy and doctor entries are all editable.

## 2. Nutrition detail rework

The screen was a flat list of label/value rows — the headline calorie figure carried the same visual weight as sodium, and nothing conveyed proportion.

Adds a hero calorie figure and a macro split bar.

**The bar is weighted by calories, not grams**, and that distinction is the point. On the test day: 9g protein / 25g carbs / 17g fat. By mass fat looks like the middle value. By energy — 9 kcal/g against 4 — it's **53% of the day's calories**. A grams-proportional bar would have actively misled about what drove the total.

The legend shows grams *and* percentage of energy, so the split is readable without relying on colour alone.

## 3. Black background sweep

The nutrition sheet rendered black rather than navy — the same missing root-background gap fixed earlier in `InsightsView`. Auditing found it affects **23 views**.

Applied to the **17 user-facing** ones. Deliberately skipped: `DebugView`, `HealthKitTestView`, `ReminderSettingsTestView`, `LocalStorageSettingsView`, `DataDeletionAdminView`, `ReauthenticationView` — debug/admin surfaces not worth regression risk for a cosmetic fix.

Both `.scrollContentBackground(.hidden)` **and** `.background(...)` are required together: `List` and `Form` paint their own system background over anything underneath, which is exactly why setting the background alone didn't fix `InsightsView` originally.

## Testing

`BUILD SUCCEEDED`. Verified on device:
- Edit sheet opens titled "Edit Medication" with name, dosage, unit, frequency, dates and status all pre-populated
- Macro bar reports 53% energy from fat on a day that looks fat-light by grams
- My Medications renders navy instead of black

A compile isn't sufficient for the sweep — a wrong insertion point builds fine and looks wrong — so the changed screens were checked visually rather than assumed.

## Not addressed

- **`Fiber —`** still shows an em-dash for missing data. Defensible (it genuinely isn't recorded, versus zero) but undiscoverable. Wanted your call before inventing copy.
- **`28 grm`** serving units — bad data from the food database, not a display bug. Fixing it means normalising units at ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)