### PR TITLE
fix: align Recommendations section and close accessibility gaps

### DIFF
--- a/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
+++ b/GutCheck/GutCheck/Views/Analytics/InsightsView.swift
@@ -14,7 +14,9 @@ struct InsightsView: View {
     
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            // Leading alignment so any section narrower than the screen lines up
+            // with the rest rather than being centred.
+            VStack(alignment: .leading, spacing: 24) {
                 // Weekly Stats Row
                 weeklyStatsRow
 
@@ -682,6 +684,11 @@ private struct RecommendationCard: View {
                 }
             }
         }
+        // Without this the card hugs its content instead of filling the width.
+        // PatternRow fills via a Spacer in its HStack, so the two sections
+        // rendered at different widths — and since the parent VStack centres by
+        // default, the narrower Recommendations block looked indented.
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(ColorTheme.surface)
         .clipShape(.rect(cornerRadius: 12))

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -331,17 +331,23 @@ struct EmptyStateCard: View {
             Image(systemName: icon)
                 .font(.system(size: 40))
                 .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
-            
+                // Decorative. The title and message already say everything the
+                // glyph does, so describing it would make VoiceOver announce the
+                // same thing twice.
+                .accessibilityHidden(true)
+
             Text(title)
                 .typography(Typography.headline)
                 .foregroundStyle(ColorTheme.secondaryText)
-            
+
             Text(message)
                 .typography(Typography.subheadline)
                 .foregroundStyle(ColorTheme.secondaryText.opacity(0.8))
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
+        // Read as one announcement instead of two separate text fragments.
+        .accessibilityElement(children: .combine)
         .padding(.vertical, 40)
         .background(
             RoundedRectangle(cornerRadius: 16)

--- a/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/UnifiedCalendarView.swift
@@ -163,6 +163,10 @@ private struct DayCell: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 8))
                             .foregroundStyle(correlationColor)
+                            // An 8pt glyph is the only signal that this day has a
+                            // possible trigger — without a label it's invisible to
+                            // VoiceOver, and colour alone can't carry it either.
+                            .accessibilityLabel("Possible food trigger")
                     }
                 }
             }
@@ -262,6 +266,17 @@ private struct CorrelationSummaryView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(severityColor.opacity(0.08))
         .clipShape(.rect(cornerRadius: 10))
+        // Read as one statement rather than five disconnected fragments
+        // ("Possible Triggers" / "2 symptoms detected…" / "Severity:" / "High" /
+        // the food list), which is how VoiceOver would otherwise announce it.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Possible triggers. "
+            + "\(correlation.symptomCount) symptom\(correlation.symptomCount == 1 ? "" : "s") "
+            + "detected 2 to 8 hours after eating. "
+            + "Severity \(severityLabel). "
+            + "Foods: \(correlation.triggerFoodNames.joined(separator: ", "))."
+        )
     }
 }
 


### PR DESCRIPTION
Closes #314.

## Insights layout

The Recommendations section rendered inset from Patterns and Categories — heading and card both pushed inward.

It wasn't a styling difference. Both cards already use identical `.padding()`, `ColorTheme.surface` and corner radius. The actual cause:

- `PatternRow` contains a `Spacer()` in its `HStack`, so it **fills** the available width
- `RecommendationCard` had **no width-filling element** — a `VStack` hugging its content
- The parent `VStack(spacing: 24)` had **no alignment**, so it defaulted to `.center`

Result: the narrower section got centred, and its heading came along with it.

Fixed at both ends — the card now fills width, and the stack is explicitly `.leading` so a future narrow section can't drift the same way.

## Accessibility (#314)

Each of the four claims was verified against current code before changing anything. Two didn't hold up:

| Claim | Verdict |
|---|---|
| `ProgressView` has no label | **Stale** — both instances already carry `"Loading meals"` / `"Loading symptoms"` |
| EmptyStateCard icons need descriptions | **Wrong fix prescribed** — see below |
| DayCell correlation indicator needs a label | **Real** — fixed |
| CorrelationSummaryView needs combining | **Real** — fixed |

**On the EmptyStateCard task:** the issue asks to add accessibility *descriptions* to those icons. That's the wrong treatment. The glyph sits directly above "No meals logged" / "Tap Log Meal below to get started" — text that already conveys everything it does. Describing it would make VoiceOver announce the same information twice. The correct handling for a decorative image is `.accessibilityHidden(true)`, plus combining the card so it reads as one announcement rather than two fragments.

**The DayCell fix is the one that matters most.** An 8pt `exclamationmark.triangle.fill` was the *only* indicator that a day had a possible food trigger — invisible to VoiceOver, and unreachable by colour alone. On a symptom-tracking app that's arguably the most important thing on the calendar.

`CorrelationSummaryView` now reads as a single composed statement instead of five disconnected fragments ("Possible Triggers" / "2 symptoms detected…" / "Severity:" / "High" / the food list).

## Testing

`BUILD SUCCEEDED`. Verified on device that Recommendations now shares the left edge and width of the sections above it.

VoiceOver behaviour is verified by inspection rather than execution — driving the screen reader isn't something I can do from here, so the labels are correct by construction but haven't been heard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)