### PR TITLE
fix: data protection, round-trip loss, index caching and date boundaries

### DIFF
--- a/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
       }
     },
     {

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
@@ -21,16 +21,28 @@ import Security
     @ObservationIgnored lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "GutCheck")
         
-        // Configure persistent store with encryption
         let description = NSPersistentStoreDescription()
         description.type = NSSQLiteStoreType
-        
-        // Enable encryption for sensitive data
-        // Note: NSPersistentStoreEncryptionKeyOption is not available in all iOS versions
-        // For now, we'll use standard Core Data security features
-        // In production, consider using Data Protection or other encryption methods
-        
-        // Set store options
+
+        // Data Protection for the store file.
+        //
+        // The store holds PII and health data — email, date of birth, weight,
+        // height, meals and symptoms — which CodeQL flags as cleartext storage
+        // in a local database (alerts #9, #10). Without this option the file
+        // gets iOS's default, `completeUntilFirstUserAuthentication`, meaning it
+        // stays readable from the moment the device is first unlocked after
+        // boot until it powers off.
+        //
+        // `.completeUnlessOpen` is used rather than `.complete` deliberately.
+        // `.complete` makes the file unreadable whenever the device is locked,
+        // which would break the BGProcessingTask insight refresh — background
+        // tasks typically run while locked, and it would fail every time.
+        // `.completeUnlessOpen` protects the file at rest but lets a handle
+        // opened before locking keep working, which is the balance this app
+        // needs.
+        description.setOption(FileProtectionType.completeUnlessOpen as NSObject,
+                              forKey: NSPersistentStoreFileProtectionKey)
+
         description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
         
@@ -67,11 +79,15 @@ import Security
     // The key is generated once (random 256-bit), stored in the Keychain, and
     // retrieved on subsequent launches. Never hardcode the key in source.
     //
-    // NOTE: NSPersistentStoreEncryptionKeyOption is not currently wired up
-    // because Core Data's SQLite backend relies on file-system Data Protection
-    // (NSFileProtectionComplete) which iOS enforces automatically when the
-    // device is locked. This method is provided for future use if explicit
-    // at-rest encryption is required.
+    // NOTE: NSPersistentStoreEncryptionKeyOption is not currently wired up.
+    // At-rest protection comes from file-system Data Protection, now set
+    // explicitly as `.completeUnlessOpen` on the store description above.
+    //
+    // This comment previously claimed iOS applied NSFileProtectionComplete
+    // "automatically". It does not — the default for app container files is
+    // `completeUntilFirstUserAuthentication`, which is materially weaker, and
+    // no protection level was being set at all. This method remains available
+    // if explicit at-rest encryption is required later.
 
     private static let keychainService  = "com.gutcheck.coredata"
     private static let keychainAccount  = "CoreDataEncryptionKey"

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
@@ -41,7 +41,9 @@ import CoreData
                 localFoodItem.name = foodItem.name
                 localFoodItem.quantity = Double(foodItem.quantity) ?? 1.0
                 // Note: FoodItem model doesn't have unit property
-                localFoodItem.servingSize = String(foodItem.estimatedWeightInGrams ?? 0)
+                // Empty string rather than "0" when there's no weight, so the read
+                // side can tell "not recorded" from a genuine zero.
+                localFoodItem.servingSize = foodItem.estimatedWeightInGrams.map { "\($0)" } ?? ""
                 localFoodItem.calories = Double(foodItem.nutrition.calories ?? 0)
                 localFoodItem.protein = foodItem.nutrition.protein ?? 0.0
                 localFoodItem.carbohydrates = foodItem.nutrition.carbs ?? 0.0
@@ -59,7 +61,10 @@ import CoreData
     func fetchMeals(for dateRange: DateInterval) async throws -> [Meal] {
         return try await coreDataStack.performBackgroundTask { context in
             let fetchRequest: NSFetchRequest<LocalMeal> = LocalMeal.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date <= %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
+            // Half-open [start, end) to match FirebaseRepository. A closed interval
+            // double-counts a record landing exactly on the boundary, so a meal at
+            // midnight appeared in both the day before and the day after.
+            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
             fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
             
             let localMeals = try context.fetch(fetchRequest)
@@ -86,7 +91,10 @@ import CoreData
                             id: foodId,
                             name: foodName,
                             quantity: String(localFoodItem.quantity),
-                            estimatedWeightInGrams: nil,
+                            // Was hardcoded nil, so the weight written on save was
+                            // silently dropped on every read — a meal round-tripped
+                            // through Core Data came back without its portion size.
+                            estimatedWeightInGrams: localFoodItem.servingSize.flatMap { Double($0) },
                             ingredients: [],
                             allergens: [],
                             nutrition: NutritionInfo(
@@ -164,7 +172,10 @@ import CoreData
     func fetchSymptoms(for dateRange: DateInterval) async throws -> [Symptom] {
         return try await coreDataStack.performBackgroundTask { context in
             let fetchRequest: NSFetchRequest<LocalSymptom> = LocalSymptom.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date <= %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
+            // Half-open [start, end) to match FirebaseRepository. A closed interval
+            // double-counts a record landing exactly on the boundary, so a meal at
+            // midnight appeared in both the day before and the day after.
+            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
             fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
             
             let localSymptoms = try context.fetch(fetchRequest)

--- a/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
+++ b/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
@@ -23,6 +23,27 @@ final class SpotlightIndexingService: Sendable {
 
     private init() {}
 
+    // MARK: - Shared, Built Once
+    //
+    // These were previously rebuilt on every index call. DateFormatter
+    // construction is expensive, and pngData() re-encodes a static SF Symbol
+    // from scratch each time — wasted work for two glyphs that never change.
+    // Configured once here and only read afterwards, which DateFormatter
+    // supports safely.
+
+    private static let displayDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static let mealThumbnail: Data? =
+        UIImage(systemName: "fork.knife.circle.fill")?.pngData()
+
+    private static let symptomThumbnail: Data? =
+        UIImage(systemName: "heart.text.square.fill")?.pngData()
+
     // MARK: - Identifier Helpers
 
     static func mealIdentifier(for id: String) -> String {
@@ -76,8 +97,8 @@ final class SpotlightIndexingService: Sendable {
         attributes.keywords = keywords
 
         // Thumbnail via SF Symbol
-        if let image = UIImage(systemName: "fork.knife.circle.fill") {
-            attributes.thumbnailData = image.pngData()
+        if let thumbnail = Self.mealThumbnail {
+            attributes.thumbnailData = thumbnail
         }
 
         let item = CSSearchableItem(
@@ -100,10 +121,7 @@ final class SpotlightIndexingService: Sendable {
 
         let attributes = CSSearchableItemAttributeSet(contentType: .content)
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        dateFormatter.timeStyle = .short
-        let dateString = dateFormatter.string(from: symptom.date)
+        let dateString = Self.displayDateFormatter.string(from: symptom.date)
 
         attributes.title = "Symptom Log — \(dateString)"
         attributes.displayName = "Symptom Log — \(dateString)"
@@ -123,8 +141,8 @@ final class SpotlightIndexingService: Sendable {
         attributes.keywords = keywords
 
         // Thumbnail via SF Symbol
-        if let image = UIImage(systemName: "heart.text.square.fill") {
-            attributes.thumbnailData = image.pngData()
+        if let thumbnail = Self.symptomThumbnail {
+            attributes.thumbnailData = thumbnail
         }
 
         let item = CSSearchableItem(


### PR DESCRIPTION
Closes #313, #315. Addresses CodeQL alerts **#9** and **#10**. Partially addresses #306.

Each finding was verified against current code before changing anything.

## CodeQL #9/#10 — cleartext storage in a local database (high)

`CoreDataStorageService.swift:222/229` — *"stores 'localUser' in a database. It may contain unencrypted sensitive data from .email / .dateOfBirth."*

`CoreDataStack` carried this comment:

> Core Data's SQLite backend relies on file-system Data Protection (`NSFileProtectionComplete`) which iOS enforces automatically

**Neither half was true.** No protection level was set anywhere — the store used iOS's default, `completeUntilFirstUserAuthentication`, which leaves the file readable from the first unlock after boot until the device powers off. That store holds email, date of birth, weight, height, meals and symptoms.

Now sets `NSPersistentStoreFileProtectionKey` explicitly, and the misleading comment is corrected rather than left to mislead the next reader.

**`.completeUnlessOpen` rather than `.complete`, deliberately.** `.complete` makes the file unreadable whenever the device is locked, which would break the `BGProcessingTask` insight refresh from #182 — background tasks typically run while locked, so it would fail every time. `.completeUnlessOpen` protects at rest while letting a handle opened before locking keep working. Flagging it because it's a security/functionality tradeoff, not a free win.

## #313 — Core Data round-trip data loss

`estimatedWeightInGrams` was written to `servingSize` on save (line 44) but **hardcoded to `nil` on read** (line 89). Any meal round-tripping through Core Data came back without its portion size.

The save side now writes an empty string rather than `"0"` when there's no weight, so "not recorded" stays distinguishable from a genuine zero.

## #315 — SpotlightIndexingService allocations

Both halves of the issue held up, and the image one is the larger cost:

- `DateFormatter()` constructed per indexed symptom
- `pngData()` **re-encoding a static SF Symbol on every index call** — for two glyphs that never change

All three are now built once as statics and only read afterwards, which `DateFormatter` supports safely.

## #306 — date range boundaries (partial)

The two Core Data predicates used a **closed** interval while `FirebaseRepository` uses **half-open**, so a record landing exactly on a boundary appeared in *both* adjacent ranges. Converted to `[start, end)`.

**`HealthcareExportService.fetchMealsForDateRange` is deliberately left alone.** Its callers pass arbitrary endpoints — `Date.now` among them — and flipping the operator could silently drop the final day for a caller treating the endpoint as inclusive. Correcting it requires deciding what that API promises, which is worth doing explicitly rather than inferring. Leaving #306 open for that reason.

## Testing

`BUILD SUCCEEDED`, zero errors.

No test coverage for any of this — CI still runs no tests (#243/#317) — so it's verified by inspection and compilation. The Data Protection change in particular is best confirmed on a real locked device, which I can't do from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)