### PR TITLE
Sync main with development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,18 @@ updates:
       time: "08:00"
       timezone: "America/Chicago"
     open-pull-requests-limit: 5
+    # Only direct dependencies. The project declares exactly one package
+    # reference — firebase-ios-sdk — and the other 13 entries in
+    # Package.resolved (promises, googleutilities, nanopb, app-check,
+    # googleappmeasurement, grpc-binary, abseil, …) are transitive, with their
+    # versions decided by Firebase's own manifest.
+    #
+    # Dependabot can edit those lines in the lockfile, but SPM overwrites them
+    # on the next resolve. The result is a PR that appears to upgrade something,
+    # merges green, and leaves Package.resolved inconsistent with what actually
+    # resolves. That happened twice (see #326) before this was scoped.
+    allow:
+      - dependency-type: "direct"
     labels:
       - "dependencies"
       - "swift"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   # Swift Package Manager — Firebase SDK and other Swift dependencies
   - package-ecosystem: "swift"
     directory: "/GutCheck"
+    # Day-to-day work happens on `development`; main is the release branch.
+    # Without this Dependabot targets the repo default (main), so dependency
+    # PRs would land on a branch the feature work never merges through and the
+    # two would silently diverge.
+    target-branch: "development"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,6 +34,11 @@ updates:
   # GitHub Actions — keep workflow action versions up to date
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Day-to-day work happens on `development`; main is the release branch.
+    # Without this Dependabot targets the repo default (main), so dependency
+    # PRs would land on a branch the feature work never merges through and the
+    # two would silently diverge.
+    target-branch: "development"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -100,6 +100,7 @@ jobs:
           -project GutCheck.xcodeproj \
           -scheme GutCheck \
           -sdk iphonesimulator \
+          -onlyUsePackageVersionsFromResolvedFile \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           CODE_SIGNING_ALLOWED=NO \
           ONLY_ACTIVE_ARCH=NO

--- a/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GutCheck/GutCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
       }
     },
     {

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStack.swift
@@ -21,16 +21,28 @@ import Security
     @ObservationIgnored lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "GutCheck")
         
-        // Configure persistent store with encryption
         let description = NSPersistentStoreDescription()
         description.type = NSSQLiteStoreType
-        
-        // Enable encryption for sensitive data
-        // Note: NSPersistentStoreEncryptionKeyOption is not available in all iOS versions
-        // For now, we'll use standard Core Data security features
-        // In production, consider using Data Protection or other encryption methods
-        
-        // Set store options
+
+        // Data Protection for the store file.
+        //
+        // The store holds PII and health data — email, date of birth, weight,
+        // height, meals and symptoms — which CodeQL flags as cleartext storage
+        // in a local database (alerts #9, #10). Without this option the file
+        // gets iOS's default, `completeUntilFirstUserAuthentication`, meaning it
+        // stays readable from the moment the device is first unlocked after
+        // boot until it powers off.
+        //
+        // `.completeUnlessOpen` is used rather than `.complete` deliberately.
+        // `.complete` makes the file unreadable whenever the device is locked,
+        // which would break the BGProcessingTask insight refresh — background
+        // tasks typically run while locked, and it would fail every time.
+        // `.completeUnlessOpen` protects the file at rest but lets a handle
+        // opened before locking keep working, which is the balance this app
+        // needs.
+        description.setOption(FileProtectionType.completeUnlessOpen as NSObject,
+                              forKey: NSPersistentStoreFileProtectionKey)
+
         description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
         
@@ -67,11 +79,15 @@ import Security
     // The key is generated once (random 256-bit), stored in the Keychain, and
     // retrieved on subsequent launches. Never hardcode the key in source.
     //
-    // NOTE: NSPersistentStoreEncryptionKeyOption is not currently wired up
-    // because Core Data's SQLite backend relies on file-system Data Protection
-    // (NSFileProtectionComplete) which iOS enforces automatically when the
-    // device is locked. This method is provided for future use if explicit
-    // at-rest encryption is required.
+    // NOTE: NSPersistentStoreEncryptionKeyOption is not currently wired up.
+    // At-rest protection comes from file-system Data Protection, now set
+    // explicitly as `.completeUnlessOpen` on the store description above.
+    //
+    // This comment previously claimed iOS applied NSFileProtectionComplete
+    // "automatically". It does not — the default for app container files is
+    // `completeUntilFirstUserAuthentication`, which is materially weaker, and
+    // no protection level was being set at all. This method remains available
+    // if explicit at-rest encryption is required later.
 
     private static let keychainService  = "com.gutcheck.coredata"
     private static let keychainAccount  = "CoreDataEncryptionKey"

--- a/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
+++ b/GutCheck/GutCheck/Services/CoreData/CoreDataStorageService.swift
@@ -41,7 +41,9 @@ import CoreData
                 localFoodItem.name = foodItem.name
                 localFoodItem.quantity = Double(foodItem.quantity) ?? 1.0
                 // Note: FoodItem model doesn't have unit property
-                localFoodItem.servingSize = String(foodItem.estimatedWeightInGrams ?? 0)
+                // Empty string rather than "0" when there's no weight, so the read
+                // side can tell "not recorded" from a genuine zero.
+                localFoodItem.servingSize = foodItem.estimatedWeightInGrams.map { "\($0)" } ?? ""
                 localFoodItem.calories = Double(foodItem.nutrition.calories ?? 0)
                 localFoodItem.protein = foodItem.nutrition.protein ?? 0.0
                 localFoodItem.carbohydrates = foodItem.nutrition.carbs ?? 0.0
@@ -59,7 +61,10 @@ import CoreData
     func fetchMeals(for dateRange: DateInterval) async throws -> [Meal] {
         return try await coreDataStack.performBackgroundTask { context in
             let fetchRequest: NSFetchRequest<LocalMeal> = LocalMeal.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date <= %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
+            // Half-open [start, end) to match FirebaseRepository. A closed interval
+            // double-counts a record landing exactly on the boundary, so a meal at
+            // midnight appeared in both the day before and the day after.
+            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
             fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
             
             let localMeals = try context.fetch(fetchRequest)
@@ -86,7 +91,10 @@ import CoreData
                             id: foodId,
                             name: foodName,
                             quantity: String(localFoodItem.quantity),
-                            estimatedWeightInGrams: nil,
+                            // Was hardcoded nil, so the weight written on save was
+                            // silently dropped on every read — a meal round-tripped
+                            // through Core Data came back without its portion size.
+                            estimatedWeightInGrams: localFoodItem.servingSize.flatMap { Double($0) },
                             ingredients: [],
                             allergens: [],
                             nutrition: NutritionInfo(
@@ -164,7 +172,10 @@ import CoreData
     func fetchSymptoms(for dateRange: DateInterval) async throws -> [Symptom] {
         return try await coreDataStack.performBackgroundTask { context in
             let fetchRequest: NSFetchRequest<LocalSymptom> = LocalSymptom.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date <= %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
+            // Half-open [start, end) to match FirebaseRepository. A closed interval
+            // double-counts a record landing exactly on the boundary, so a meal at
+            // midnight appeared in both the day before and the day after.
+            fetchRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", dateRange.start as CVarArg, dateRange.end as CVarArg)
             fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
             
             let localSymptoms = try context.fetch(fetchRequest)

--- a/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
+++ b/GutCheck/GutCheck/Services/Spotlight/SpotlightIndexingService.swift
@@ -23,6 +23,27 @@ final class SpotlightIndexingService: Sendable {
 
     private init() {}
 
+    // MARK: - Shared, Built Once
+    //
+    // These were previously rebuilt on every index call. DateFormatter
+    // construction is expensive, and pngData() re-encodes a static SF Symbol
+    // from scratch each time — wasted work for two glyphs that never change.
+    // Configured once here and only read afterwards, which DateFormatter
+    // supports safely.
+
+    private static let displayDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static let mealThumbnail: Data? =
+        UIImage(systemName: "fork.knife.circle.fill")?.pngData()
+
+    private static let symptomThumbnail: Data? =
+        UIImage(systemName: "heart.text.square.fill")?.pngData()
+
     // MARK: - Identifier Helpers
 
     static func mealIdentifier(for id: String) -> String {
@@ -76,8 +97,8 @@ final class SpotlightIndexingService: Sendable {
         attributes.keywords = keywords
 
         // Thumbnail via SF Symbol
-        if let image = UIImage(systemName: "fork.knife.circle.fill") {
-            attributes.thumbnailData = image.pngData()
+        if let thumbnail = Self.mealThumbnail {
+            attributes.thumbnailData = thumbnail
         }
 
         let item = CSSearchableItem(
@@ -100,10 +121,7 @@ final class SpotlightIndexingService: Sendable {
 
         let attributes = CSSearchableItemAttributeSet(contentType: .content)
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        dateFormatter.timeStyle = .short
-        let dateString = dateFormatter.string(from: symptom.date)
+        let dateString = Self.displayDateFormatter.string(from: symptom.date)
 
         attributes.title = "Symptom Log — \(dateString)"
         attributes.displayName = "Symptom Log — \(dateString)"
@@ -123,8 +141,8 @@ final class SpotlightIndexingService: Sendable {
         attributes.keywords = keywords
 
         // Thumbnail via SF Symbol
-        if let image = UIImage(systemName: "heart.text.square.fill") {
-            attributes.thumbnailData = image.pngData()
+        if let thumbnail = Self.symptomThumbnail {
+            attributes.thumbnailData = thumbnail
         }
 
         let item = CSSearchableItem(


### PR DESCRIPTION
Brings `main` up to date with `development`. Fast-forward — `main` is a direct ancestor, so there is no divergence to reconcile.

Direct push was rejected by branch protection on `main` (`pull_request` rule), hence this PR.

## What's included

**#340 — lockfile drift prevention**
- `Package.resolved` repaired (`googleappmeasurement` back to what SPM actually resolves)
- CI now passes `-onlyUsePackageVersionsFromResolvedFile`, so drift fails the build instead of passing silently
- Dependabot scoped to direct dependencies only, and retargeted at `development`

**#341 — data protection and audit cleanup**
- **CodeQL #9/#10:** `CoreDataStack` claimed it relied on `NSFileProtectionComplete` "which iOS enforces automatically". Neither was true — no protection level was set at all, so a store holding email, date of birth, weight, height, meals and symptoms sat at the weaker default. Now sets `.completeUnlessOpen` explicitly.
- **#313:** `estimatedWeightInGrams` was written on save but hardcoded `nil` on read, so meals lost their portion size on every Core Data round-trip.
- **#315:** `DateFormatter` and two SF Symbol PNGs were rebuilt on every Spotlight index call; now built once.
- **#306 (partial):** Core Data date predicates aligned to half-open `[start, end)`, matching `FirebaseRepository`.

Every check passed on both PRs before they merged into `development`.

## Note on branching

This is the first sync since `development` was created. Both branches are identical after this merge.

Going forward: feature work → `development` → periodic sync to `main`. Dependabot now targets `development`, so dependency PRs follow the same path rather than landing on `main` and drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)