### PR TITLE
fix(ci): stop CodeQL Swift analysis running on every PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+    # Documentation and metadata changes can't introduce a code vulnerability,
+    # and the Swift analysis rebuilds the whole app regardless of what changed.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/dependabot.yml'
   schedule:
     # Run every Monday at 08:00 UTC for ongoing security coverage
     - cron: '0 8 * * 1'
@@ -14,6 +20,17 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # Swift requires macOS; all other languages run on ubuntu for speed
     runs-on: ${{ matrix.language == 'swift' && 'macos-15' || 'ubuntu-latest' }}
+
+    # The Swift leg builds the entire app (Firebase, gRPC, abseil) so CodeQL can
+    # trace compilation, and has measured 48-107 minutes. Build and Test covers
+    # the same commit in about 5. Running it on every PR push made it the
+    # dominant cost of shipping anything - a markdown-only PR paid 48 minutes.
+    #
+    # It still runs on every push to main and development, so nothing reaches
+    # either branch unanalysed, plus the Monday schedule. What's given up is
+    # pre-merge notice on a PR branch; what's gained is PRs that complete in
+    # minutes instead of over an hour.
+    if: matrix.language != 'swift' || github.event_name != 'pull_request'
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,17 +21,6 @@ jobs:
     # Swift requires macOS; all other languages run on ubuntu for speed
     runs-on: ${{ matrix.language == 'swift' && 'macos-15' || 'ubuntu-latest' }}
 
-    # The Swift leg builds the entire app (Firebase, gRPC, abseil) so CodeQL can
-    # trace compilation, and has measured 48-107 minutes. Build and Test covers
-    # the same commit in about 5. Running it on every PR push made it the
-    # dominant cost of shipping anything - a markdown-only PR paid 48 minutes.
-    #
-    # It still runs on every push to main and development, so nothing reaches
-    # either branch unanalysed, plus the Monday schedule. What's given up is
-    # pre-merge notice on a PR branch; what's gained is PRs that complete in
-    # minutes instead of over an hour.
-    if: matrix.language != 'swift' || github.event_name != 'pull_request'
-
     permissions:
       security-events: write
       packages: read
@@ -41,13 +30,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Primary language — Swift/iOS app
-          - language: swift
-            build-mode: manual
-          # GitHub Actions workflow files
-          - language: actions
-            build-mode: none
+        # The Swift leg rebuilds the entire app (Firebase, gRPC, abseil) so
+        # CodeQL can trace compilation, and has measured 48-107 minutes against
+        # about 5 for Build and Test. Dropping it from pull_request leaves PRs
+        # completing in minutes; it still runs on every push to main and
+        # development, plus the Monday schedule, so nothing reaches either
+        # branch unanalysed.
+        #
+        # Filtered here rather than with a job-level `if`, because the matrix
+        # context isn't available in job-level conditions - doing that produced
+        # a workflow that failed to start at all.
+        include: ${{ github.event_name == 'pull_request'
+          && fromJSON('[{"language":"actions","build-mode":"none"}]')
+          || fromJSON('[{"language":"swift","build-mode":"manual"},{"language":"actions","build-mode":"none"}]') }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes #329.

## The cost

`Analyze (swift)` on recent successful runs:

| Duration | Branch |
|---|---|
| 49 min | development |
| **48 min** | **chore/claude-instructions — a markdown-only PR** |
| 96 min | development |
| 107 min | dependabot |
| 88 min | dependabot |

`Build and Test` covers the same commit in about **5 minutes**.

The Swift leg rebuilds the entire app — Firebase, gRPC, abseil — so CodeQL can trace compilation, and it did that on every PR push regardless of what changed. It was the dominant cost of shipping anything.

It also fails in expensive ways. On #326 the job ran **42 minutes**, completed its analysis, then died uploading results:

```
##[error]Connect Timeout Error (attempted address: api.github.com:443, timeout: 10000ms)
```

Forty-two minutes discarded, and a red X visually indistinguishable from a real failure.

## Changes

**1. Swift leg no longer runs on `pull_request`.**

It still runs on every push to `main` and `development`, so nothing reaches either branch unanalysed, plus the existing Monday schedule.

The tradeoff, stated plainly: you lose pre-merge notice on a PR branch. A finding now surfaces on the push to `development` rather than on the PR. For a solo, pre-launch project where the alternative is ~80 minutes on every iteration, that seems the right trade — but it *is* a reduction in when you hear about things, not just a speedup.

**2. `paths-ignore` skips documentation and metadata changes** — markdown, `docs/`, `dependabot.yml`. Those can't introduce a code vulnerability, and the analysis rebuilds everything regardless.

**Untouched:** the `actions` leg still runs on every PR, on ubuntu, in ~45 seconds — so workflow files stay analysed.

## Expected effect

PRs go from ~50–107 minutes to a few minutes. `main` and `development` keep full Swift coverage on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)