### PR TITLE
fix(search): read declared allergens and request English text (#377)

### DIFF
--- a/GutCheck/GutCheck/Models/Nutrition/OpenFoodFactsModels.swift
+++ b/GutCheck/GutCheck/Models/Nutrition/OpenFoodFactsModels.swift
@@ -18,10 +18,21 @@ struct OpenFoodFactsProduct: Codable, Identifiable {
     let nutriments: OpenFoodFactsNutriments?
     let ingredients: [OpenFoodFactsIngredient]?
     let ingredientsText: String?
+    /// English ingredient text where the contributor supplied one. The plain
+    /// `ingredients_text` field is in the product's own language, which for a
+    /// French-registered Big Mac means a French list.
+    let ingredientsTextEn: String?
     let servingSize: String?
     let allergens: String?
     let traces: String?
-    
+    /// Structured allergen identifiers, e.g. `["en:gluten", "en:milk"]`.
+    ///
+    /// Prefer these over the free-text `allergens` field: they carry an `en:`
+    /// prefix regardless of the product's language, so a French record still
+    /// reports `en:milk` rather than `Lait`.
+    let allergensTags: [String]?
+    let tracesTags: [String]?
+
     private enum CodingKeys: String, CodingKey {
         case id = "code"
         case productName = "product_name"
@@ -29,10 +40,62 @@ struct OpenFoodFactsProduct: Codable, Identifiable {
         case nutriments
         case ingredients
         case ingredientsText = "ingredients_text"
+        case ingredientsTextEn = "ingredients_text_en"
         case servingSize = "serving_size"
         case allergens
         case traces
+        case allergensTags = "allergens_tags"
+        case tracesTags = "traces_tags"
     }
+
+    /// Ingredient text in English when available, falling back to whatever
+    /// language the record is written in.
+    var bestIngredientsText: String? {
+        if let english = ingredientsTextEn, !english.trimmingCharacters(in: .whitespaces).isEmpty {
+            return english
+        }
+        return ingredientsText
+    }
+
+    /// Allergens and traces normalised to the app's vocabulary.
+    ///
+    /// OpenFoodFacts tags look like `en:milk` or, on records a contributor
+    /// entered in another language, `fr:lait`. Only the `en:` namespace is
+    /// mapped — a locale-prefixed tag is data we cannot reliably interpret, and
+    /// guessing would be worse than falling through to keyword detection.
+    var normalizedAllergens: [String] {
+        let tags = (allergensTags ?? []) + (tracesTags ?? [])
+        let mapped = tags.compactMap { Self.allergenNames[$0.lowercased()] }
+        return Array(Set(mapped)).sorted()
+    }
+
+    /// Maps OpenFoodFacts allergen tags onto the labels the app already uses
+    /// elsewhere, so tag-derived and keyword-derived allergens read the same.
+    private static let allergenNames: [String: String] = [
+        "en:milk": "Dairy",
+        "en:gluten": "Gluten",
+        "en:soybeans": "Soy",
+        "en:eggs": "Eggs",
+        "en:nuts": "Tree Nuts",
+        "en:tree-nuts": "Tree Nuts",
+        "en:almonds": "Tree Nuts",
+        "en:hazelnuts": "Tree Nuts",
+        "en:walnuts": "Tree Nuts",
+        "en:cashew-nuts": "Tree Nuts",
+        "en:pistachio-nuts": "Tree Nuts",
+        "en:macadamia-nuts": "Tree Nuts",
+        "en:pecan-nuts": "Tree Nuts",
+        "en:brazil-nuts": "Tree Nuts",
+        "en:peanuts": "Peanuts",
+        "en:fish": "Fish",
+        "en:crustaceans": "Shellfish",
+        "en:molluscs": "Shellfish",
+        "en:sesame-seeds": "Sesame",
+        "en:mustard": "Mustard",
+        "en:celery": "Celery",
+        "en:lupin": "Lupin",
+        "en:sulphur-dioxide-and-sulphites": "Sulphites"
+    ]
 }
 
 struct OpenFoodFactsNutriments: Codable {

--- a/GutCheck/GutCheck/Services/FoodSearchModels.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchModels.swift
@@ -34,6 +34,15 @@ struct FoodSearchResult: Identifiable, Codable {
     
     // Ingredients
     let ingredients: String?
+
+    /// Allergens declared by the source, already normalised to the app's
+    /// vocabulary ("Dairy", "Gluten", …).
+    ///
+    /// A declared allergen is authoritative in a way keyword matching is not:
+    /// it survives the ingredient list being in another language. Empty means
+    /// "the source said nothing", not "no allergens" — callers should still run
+    /// keyword detection and take the union.
+    let declaredAllergens: [String]
     
     // Additional macronutrients
     let saturatedFat: Double?
@@ -111,6 +120,7 @@ struct FoodSearchResult: Identifiable, Codable {
         servingQty: Double? = nil,
         servingWeight: Double? = nil,
         ingredients: String? = nil,
+        declaredAllergens: [String] = [],
         saturatedFat: Double? = nil,
         transFat: Double? = nil,
         polyunsaturatedFat: Double? = nil,
@@ -175,6 +185,7 @@ struct FoodSearchResult: Identifiable, Codable {
         self.servingQty = servingQty
         self.servingWeight = servingWeight
         self.ingredients = ingredients
+        self.declaredAllergens = declaredAllergens
         self.saturatedFat = saturatedFat
         self.transFat = transFat
         self.polyunsaturatedFat = polyunsaturatedFat
@@ -311,7 +322,8 @@ struct FoodSearchResult: Identifiable, Codable {
             name: brand != nil ? "\(brand!) \(name)" : name,
             quantity: finalQuantity,
             estimatedWeightInGrams: servingWeight,
-            ingredients: ingredients?.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? [],
+            ingredients: IngredientTextParser.split(ingredients),
+            allergens: declaredAllergens,
             nutrition: NutritionInfo(
                 calories: calories.map { Int($0) },
                 protein: protein,

--- a/GutCheck/GutCheck/Services/FoodSearchService.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchService.swift
@@ -137,16 +137,13 @@ import Foundation
     // MARK: - Ingredient Parsing
 
     private func parseIngredients(from ingredientsString: String) -> [String] {
-        let cleanedString = ingredientsString
-            .replacingOccurrences(of: ".", with: "")
-            .replacingOccurrences(of: ";", with: ",")
+        // Normalise the word separators, then let the parser handle commas so
+        // that brackets are respected rather than split through.
+        let normalized = ingredientsString
             .replacingOccurrences(of: " and ", with: ", ")
             .replacingOccurrences(of: " & ", with: ", ")
 
-        return cleanedString
-            .components(separatedBy: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-            .filter { !$0.isEmpty }
+        return IngredientTextParser.split(normalized).map { $0.lowercased() }
     }
 }
 

--- a/GutCheck/GutCheck/Services/IngredientTextParser.swift
+++ b/GutCheck/GutCheck/Services/IngredientTextParser.swift
@@ -62,13 +62,14 @@ enum IngredientTextParser {
     /// ingredient text.
     private static func stripTrailer(_ text: String) -> String {
         var earliest: String.Index?
-        let lowered = text.lowercased()
 
+        // Search the original string case-insensitively rather than indexing
+        // into a lowercased copy by offset: case folding can change a string's
+        // length, which would put the cut in the wrong place.
         for marker in trailerMarkers {
-            if let range = lowered.range(of: marker) {
-                let index = text.index(text.startIndex, offsetBy: lowered.distance(from: lowered.startIndex, to: range.lowerBound))
-                if earliest == nil || index < earliest! {
-                    earliest = index
+            if let range = text.range(of: marker, options: [.caseInsensitive]) {
+                if earliest == nil || range.lowerBound < earliest! {
+                    earliest = range.lowerBound
                 }
             }
         }

--- a/GutCheck/GutCheck/Services/IngredientTextParser.swift
+++ b/GutCheck/GutCheck/Services/IngredientTextParser.swift
@@ -1,0 +1,160 @@
+//
+//  IngredientTextParser.swift
+//  GutCheck
+//
+//  Splits a label's ingredient string into individual ingredients.
+//
+//  Splitting naively on "," shreds compound entries and leaves unbalanced
+//  fragments behind. A Big Mac came back as 31 "ingredients" including
+//  `Sauce (Eau`, `Épices (Dont Moutarde` and `Edta)` — the second of which hid
+//  a mustard declaration inside a broken fragment.
+//
+
+import Foundation
+
+enum IngredientTextParser {
+
+    /// Placeholder values that upstream data uses in place of a real name.
+    /// These reach the UI capitalized, so a null becomes a listed "Undefined".
+    private static let placeholders: Set<String> = [
+        "undefined", "null", "nil", "none", "n/a", "na", "unknown", "-", "--", "?"
+    ]
+
+    /// Phrases that introduce an allergen or trace declaration rather than more
+    /// ingredients. Everything from here on is a "contains" statement, and the
+    /// structured `allergens_tags` already carry it — leaving it in the text
+    /// turns declarations like `Milk, Eggs, Mustard` into fake ingredients.
+    private static let trailerMarkers = [
+        "in unknown quantities:",
+        "in unknown quantities",
+        "allergens:",
+        "allergen information",
+        "contains:",
+        "may contain",
+        "traces of",
+        "traces:"
+    ]
+
+    /// Splits an ingredient string into trimmed, non-empty ingredients.
+    ///
+    /// Commas inside brackets are treated as part of the ingredient rather than
+    /// as separators, so `Sauce (water, rapeseed oil)` stays one entry instead
+    /// of becoming three fragments and an orphaned bracket.
+    static func split(_ text: String?) -> [String] {
+        guard let text, !text.isEmpty else { return [] }
+
+        let body = stripTrailer(text)
+        guard !body.isEmpty else { return [] }
+
+        let segments = splitRespectingBrackets(body)
+
+        // Real label text is not reliably balanced. When a segment has an
+        // unclosed bracket it has swallowed everything after it, so fall back
+        // to a flat split for that segment rather than emitting a wall of text.
+        return segments.flatMap { segment -> [String] in
+            isBalanced(segment) ? [segment] : flatSplit(segment)
+        }
+        .map { clean($0) }
+        .filter { isUsable($0) }
+    }
+
+    /// Drops the allergen declaration that many records append to the
+    /// ingredient text.
+    private static func stripTrailer(_ text: String) -> String {
+        var earliest: String.Index?
+        let lowered = text.lowercased()
+
+        for marker in trailerMarkers {
+            if let range = lowered.range(of: marker) {
+                let index = text.index(text.startIndex, offsetBy: lowered.distance(from: lowered.startIndex, to: range.lowerBound))
+                if earliest == nil || index < earliest! {
+                    earliest = index
+                }
+            }
+        }
+
+        guard let cut = earliest else { return text }
+        return String(text[text.startIndex..<cut])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ",;("))
+    }
+
+    private static func isBalanced(_ text: String) -> Bool {
+        var depth = 0
+        for character in text {
+            if "([{".contains(character) { depth += 1 }
+            if ")]}".contains(character) {
+                depth -= 1
+                if depth < 0 { return false }
+            }
+        }
+        return depth == 0
+    }
+
+    /// Ignores brackets entirely — used only to rescue malformed input, where
+    /// an unclosed bracket would otherwise swallow the rest of the list. Every
+    /// bracket character is dropped, not just trimmed from the ends, because a
+    /// fragment like `Sauce (Water` carries its orphan in the middle.
+    private static func flatSplit(_ text: String) -> [String] {
+        text.components(separatedBy: CharacterSet(charactersIn: ",;"))
+            .map { $0.filter { !"()[]{}".contains($0) } }
+    }
+
+    private static func splitRespectingBrackets(_ text: String) -> [String] {
+        var ingredients: [String] = []
+        var current = ""
+        var depth = 0
+
+        for character in text {
+            switch character {
+            case "(", "[", "{":
+                depth += 1
+                current.append(character)
+            case ")", "]", "}":
+                depth = max(0, depth - 1)
+                current.append(character)
+            case ",", ";":
+                if depth == 0 {
+                    ingredients.append(current)
+                    current = ""
+                } else {
+                    current.append(character)
+                }
+            default:
+                current.append(character)
+            }
+        }
+        ingredients.append(current)
+
+        return ingredients
+    }
+
+    /// Strips the percentage annotations and stray punctuation that labels carry
+    /// (`"Beef 45%"`, `"* organic"`) without touching the ingredient name.
+    private static func clean(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Leading list markers and footnote symbols.
+        while let first = value.first, "*_•-–—".contains(first) {
+            value.removeFirst()
+            value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // Trailing percentages: "Beef 45%" or "Beef (45%)".
+        if let range = value.range(of: #"\s*\(?\d+([.,]\d+)?\s*%\)?$"#, options: .regularExpression) {
+            value.removeSubrange(range)
+        }
+
+        return value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".:"))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func isUsable(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        guard !placeholders.contains(value.lowercased()) else { return false }
+        // A fragment of pure punctuation carries no information.
+        return value.contains(where: { $0.isLetter || $0.isNumber })
+    }
+}

--- a/GutCheck/GutCheck/Services/OpenFoodFactsService.swift
+++ b/GutCheck/GutCheck/Services/OpenFoodFactsService.swift
@@ -12,7 +12,11 @@ class OpenFoodFactsService {
         try rateLimiter.checkLimit(for: .foodSearchOpenFoodFacts)
 
         let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        let urlString = "\(baseURL)/cgi/search.pl?search_terms=\(encodedQuery)&search_simple=1&action=process&page=\(page)&page_size=\(pageSize)&json=1"
+        // `lc=en` asks OpenFoodFacts for the English field variants where a
+        // record has them. Without it the API returns each product in its own
+        // language, which is how a Big Mac came back with a French ingredient
+        // list the allergen matcher could not read.
+        let urlString = "\(baseURL)/cgi/search.pl?search_terms=\(encodedQuery)&search_simple=1&action=process&page=\(page)&page_size=\(pageSize)&lc=en&json=1"
         
         guard let url = URL(string: urlString) else {
             throw OpenFoodFactsError.invalidURL
@@ -50,7 +54,7 @@ class OpenFoodFactsService {
     func getProduct(by barcode: String) async throws -> OpenFoodFactsProduct? {
         try rateLimiter.checkLimit(for: .foodSearchOpenFoodFacts)
 
-        let urlString = "\(baseURL)/api/v0/product/\(barcode).json"
+        let urlString = "\(baseURL)/api/v0/product/\(barcode).json?lc=en"
         
         guard let url = URL(string: urlString) else {
             throw OpenFoodFactsError.invalidURL
@@ -142,7 +146,8 @@ class OpenFoodFactsService {
             servingUnit: servingUnit,
             servingQty: servingQty,
             servingWeight: servingQty,
-            ingredients: product.ingredientsText,
+            ingredients: product.bestIngredientsText,
+            declaredAllergens: product.normalizedAllergens,
             saturatedFat: saturatedFat,
             potassium: potassium,
             calcium: calcium,

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -138,8 +138,12 @@ import Combine
             nutritionDict["iron_dv"] = iron.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
         }
         
-        // Extract allergens with enhanced detection
-        let allergens = detectAllergens(from: nfood.name, brand: nfood.brand, ingredients: ingredientList)
+        // Allergens the source declared outright, plus anything keyword matching
+        // spots. The declared set is what catches a French ingredient list —
+        // "Lait" never matches the English keyword table, but the record's
+        // `en:milk` tag does.
+        let detected = detectAllergens(from: nfood.name, brand: nfood.brand, ingredients: ingredientList)
+        let allergens = Array(Set(nfood.declaredAllergens + detected)).sorted()
         
         // Create main nutrition info for easy access
         let nutrition = NutritionInfo(
@@ -238,28 +242,15 @@ import Combine
     // MARK: - Ingredient Parsing
     
     private func parseIngredients(from ingredientsString: String?) -> [String] {
-        guard let ingredientsString = ingredientsString, !ingredientsString.isEmpty else {
-            return []
-        }
-        
-        // Clean up the ingredients string and split by common separators
-        let cleanedString = ingredientsString
-            .replacingOccurrences(of: ".", with: "") // Remove periods
-            .replacingOccurrences(of: ";", with: ",") // Normalize separators
-            .replacingOccurrences(of: " and ", with: ", ") // Handle "and" separators
-            .replacingOccurrences(of: " & ", with: ", ") // Handle "&" separators
-        
-        // Split by commas and clean up each ingredient
-        let ingredients = cleanedString
-            .components(separatedBy: ",")
-            .map { ingredient in
-                ingredient
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-            }
-            .filter { !$0.isEmpty }
-        
-        return ingredients
+        guard let ingredientsString, !ingredientsString.isEmpty else { return [] }
+
+        // Normalise the word separators, then let the parser handle commas so
+        // brackets are respected rather than split through.
+        let normalized = ingredientsString
+            .replacingOccurrences(of: " and ", with: ", ")
+            .replacingOccurrences(of: " & ", with: ", ")
+
+        return IngredientTextParser.split(normalized).map { $0.lowercased() }
     }
     
     // MARK: - Recent Items Management

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -276,19 +276,43 @@ struct UnifiedFoodDetailView: View {
 
     /// Parses a `nutritionDetails` string value (e.g. "15.0g", "100mg") into a Double.
     ///
-    /// Writers use a fixed `en_US_POSIX` locale, so the separator should always
-    /// be `.`. A comma is still normalised rather than stripped, because values
-    /// persisted by an earlier build may have been written in the device
-    /// locale — dropping that comma would read `460,5` as `4605`.
+    /// Writers use a fixed `en_US_POSIX` locale with grouping disabled, so new
+    /// values always use `.` and never carry separators. Values persisted by an
+    /// earlier build were written in the device locale and may use either
+    /// convention, so both are handled — see `normalizedNumber`.
     private func parsedDetails(keys: [String]) -> [(String, Double)] {
         keys.compactMap { key in
-            guard let str = foodItem.nutritionDetails[key] else { return nil }
-            let numStr = str
-                .replacingOccurrences(of: ",", with: ".")
-                .filter { $0.isNumber || $0 == "." }
-            guard let val = Double(numStr), val > 0 else { return nil }
+            guard let str = foodItem.nutritionDetails[key],
+                  let val = Self.normalizedNumber(from: str),
+                  val > 0
+            else { return nil }
             return (key, val)
         }
+    }
+
+    /// Reads a number out of a label string, tolerating both comma conventions.
+    ///
+    /// A comma followed by exactly three trailing digits is thousands grouping
+    /// (`1,093` → 1093); anything else is a decimal separator (`460,5` → 460.5).
+    /// Getting this backwards is a factor-of-10 error in either direction.
+    static func normalizedNumber(from raw: String) -> Double? {
+        let digitsAndSeparators = raw.filter { $0.isNumber || $0 == "." || $0 == "," }
+
+        let normalized: String
+        if digitsAndSeparators.contains(","), !digitsAndSeparators.contains(".") {
+            let isGrouping = digitsAndSeparators.range(
+                of: #"^\d{1,3}(,\d{3})+$"#,
+                options: .regularExpression
+            ) != nil
+            normalized = isGrouping
+                ? digitsAndSeparators.replacingOccurrences(of: ",", with: "")
+                : digitsAndSeparators.replacingOccurrences(of: ",", with: ".")
+        } else {
+            // Mixed separators mean the comma is grouping: "1,093.5".
+            normalized = digitsAndSeparators.replacingOccurrences(of: ",", with: "")
+        }
+
+        return Double(normalized)
     }
 
     /// Display unit for a parsed micronutrient. Vitamins A, D and K are stored

--- a/GutCheck/GutCheckTests/IngredientTextParserTests.swift
+++ b/GutCheck/GutCheckTests/IngredientTextParserTests.swift
@@ -114,6 +114,43 @@ struct IngredientTextParserTests {
     }
 }
 
+@Suite("Nutrition detail number parsing")
+struct NutritionDetailNumberTests {
+
+    @Test("Period decimals parse as written")
+    func periodDecimal() {
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "460.5mg") == 460.5)
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "15.0g") == 15.0)
+    }
+
+    @Test("A comma decimal separator is honoured, not stripped")
+    func commaDecimal() {
+        // Values persisted by an earlier build in a comma-decimal locale.
+        // Stripping the comma would read this as 4605.
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "460,5mg") == 460.5)
+    }
+
+    @Test("Thousands grouping is removed rather than read as a decimal")
+    func thousandsGrouping() {
+        // Reading this as 1.093 would be a factor-of-1000 error in the other
+        // direction from the bug that started all this.
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "1,093mg") == 1093)
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "1,093,500mg") == 1_093_500)
+    }
+
+    @Test("Mixed separators treat the comma as grouping")
+    func mixedSeparators() {
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "1,093.5mg") == 1093.5)
+    }
+
+    @Test("Plain integers and unparseable strings")
+    func edgeCases() {
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "100mg") == 100)
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "mg") == nil)
+        #expect(UnifiedFoodDetailView.normalizedNumber(from: "") == nil)
+    }
+}
+
 @Suite("OpenFoodFacts allergen normalisation")
 struct OpenFoodFactsAllergenTests {
 
@@ -179,6 +216,15 @@ struct OpenFoodFactsAllergenTests {
         let item = try JSONDecoder().decode(OpenFoodFactsProduct.self, from: Data(json.utf8))
 
         #expect(item.bestIngredientsText == "Sesame seed bun, beef patty")
+    }
+
+    @Test("Trailer markers are matched case-insensitively without shifting the cut")
+    func trailerMarkerCasing() {
+        // Indexing into a lowercased copy by offset breaks when case folding
+        // changes length. These all cut in the same place.
+        #expect(IngredientTextParser.split("Oats, Sugar, CONTAINS: milk") == ["Oats", "Sugar"])
+        #expect(IngredientTextParser.split("Oats, Sugar, Contains: milk") == ["Oats", "Sugar"])
+        #expect(IngredientTextParser.split("İSTANBUL Oats, Sugar, Contains: milk").count == 2)
     }
 
     @Test("Falls back to the original language when no English text exists")

--- a/GutCheck/GutCheckTests/IngredientTextParserTests.swift
+++ b/GutCheck/GutCheckTests/IngredientTextParserTests.swift
@@ -1,0 +1,197 @@
+//
+//  IngredientTextParserTests.swift
+//  GutCheckTests
+//
+//  Cases drawn from the real OpenFoodFacts Big Mac record that produced 31
+//  "ingredients", several of them unbalanced fragments.
+//
+
+import Foundation
+import Testing
+@testable import GutCheck
+
+@Suite("Ingredient text parsing")
+struct IngredientTextParserTests {
+
+    @Test("Commas inside brackets do not split the ingredient")
+    func bracketsSurviveSplitting() {
+        let parsed = IngredientTextParser.split("Bun, Sauce (water, rapeseed oil, vinegar), Lettuce")
+
+        #expect(parsed == ["Bun", "Sauce (water, rapeseed oil, vinegar)", "Lettuce"])
+    }
+
+    @Test("No unbalanced fragments are emitted")
+    func noOrphanedBrackets() {
+        // The shape that produced "Sauce (Eau", "Épices (Dont Moutarde" and "Edta)".
+        let parsed = IngredientTextParser.split("Spices (including mustard), Firming agent (E509, E433, EDTA)")
+
+        #expect(parsed.count == 2)
+        for ingredient in parsed {
+            let opens = ingredient.filter { $0 == "(" }.count
+            let closes = ingredient.filter { $0 == ")" }.count
+            #expect(opens == closes)
+        }
+    }
+
+    @Test("Mustard stays attached to its ingredient rather than being cut in half")
+    func compoundContentIsPreserved() {
+        let parsed = IngredientTextParser.split("Spices (including mustard), Salt")
+
+        #expect(parsed.first?.lowercased().contains("mustard") == true)
+    }
+
+    @Test("Placeholder values are dropped")
+    func placeholdersAreRemoved() {
+        let parsed = IngredientTextParser.split("undefined, Salt, null, Potatoes, N/A, Oil")
+
+        #expect(parsed == ["Salt", "Potatoes", "Oil"])
+    }
+
+    @Test("Percentage annotations are stripped from the name")
+    func percentagesAreStripped() {
+        let parsed = IngredientTextParser.split("Beef 45%, Cheddar (12%), Onion")
+
+        #expect(parsed == ["Beef", "Cheddar", "Onion"])
+    }
+
+    @Test("Semicolons separate at depth zero but not inside brackets")
+    func semicolonsBehaveLikeCommas() {
+        let parsed = IngredientTextParser.split("Milk; Sugar; Flavouring (vanilla; bourbon)")
+
+        #expect(parsed == ["Milk", "Sugar", "Flavouring (vanilla; bourbon)"])
+    }
+
+    @Test("Empty and nil input produce no ingredients")
+    func emptyInput() {
+        #expect(IngredientTextParser.split(nil).isEmpty)
+        #expect(IngredientTextParser.split("").isEmpty)
+        #expect(IngredientTextParser.split(" , , ").isEmpty)
+    }
+
+    @Test("Punctuation-only fragments are discarded")
+    func punctuationFragments() {
+        #expect(IngredientTextParser.split("Salt, -, *, Water") == ["Salt", "Water"])
+    }
+
+    @Test("The allergen trailer is not treated as ingredients")
+    func allergenTrailerIsDropped() {
+        // OpenFoodFacts appends the "contains" declaration to the ingredient
+        // text. Milk/Eggs/Mustard here are declarations, not ingredients — and
+        // allergens_tags already carries them.
+        let parsed = IngredientTextParser.split(
+            "Bun, Beef, In Unknown Quantities: Sulphur Dioxide, Gluten (Wheat), Milk, Eggs, Mustard"
+        )
+
+        #expect(parsed == ["Bun", "Beef"])
+    }
+
+    @Test("Other trailer phrasings are handled")
+    func otherTrailerPhrasings() {
+        #expect(IngredientTextParser.split("Oats, Sugar, Contains: milk") == ["Oats", "Sugar"])
+        #expect(IngredientTextParser.split("Oats, Sugar, May contain nuts") == ["Oats", "Sugar"])
+        #expect(IngredientTextParser.split("Oats, Sugar, Traces of peanuts") == ["Oats", "Sugar"])
+    }
+
+    @Test("An unclosed bracket does not swallow the rest of the list")
+    func unbalancedInputDoesNotCollapse() {
+        // The real Big Mac text: the sauce's bracket never closes, so a naive
+        // depth-tracking parser folds everything after it into one entry.
+        let parsed = IngredientTextParser.split("Bread, Sauce (Water, Rapeseed Oil, Gherkins, Onions")
+
+        #expect(parsed.count > 2, "expected the tail to stay separate, got \(parsed)")
+        #expect(parsed.contains("Bread"))
+        #expect(parsed.contains("Onions"))
+        for ingredient in parsed {
+            #expect(!ingredient.contains("("), "orphaned bracket in \(ingredient)")
+        }
+    }
+
+    @Test("A long balanced compound still stays intact")
+    func balancedCompoundSurvives() {
+        let parsed = IngredientTextParser.split("Bread, Sauce (Water, Rapeseed Oil, Sugar), Onions")
+
+        #expect(parsed == ["Bread", "Sauce (Water, Rapeseed Oil, Sugar)", "Onions"])
+    }
+}
+
+@Suite("OpenFoodFacts allergen normalisation")
+struct OpenFoodFactsAllergenTests {
+
+    private func product(allergens: [String]?, traces: [String]? = nil) -> OpenFoodFactsProduct {
+        let json = """
+        {
+          "code": "test",
+          "product_name": "Test",
+          "allergens_tags": \(allergens.map { "[\($0.map { "\"\($0)\"" }.joined(separator: ","))]" } ?? "null"),
+          "traces_tags": \(traces.map { "[\($0.map { "\"\($0)\"" }.joined(separator: ","))]" } ?? "null")
+        }
+        """
+        return try! JSONDecoder().decode(OpenFoodFactsProduct.self, from: Data(json.utf8))
+    }
+
+    @Test("English tags map onto the app's allergen vocabulary")
+    func tagsAreMapped() {
+        // The real Big Mac record. Milk, eggs and mustard were the ones the
+        // keyword matcher missed because the ingredients were in French.
+        let big = product(allergens: ["en:gluten", "en:milk", "en:eggs", "en:mustard", "en:sesame-seeds"])
+
+        #expect(big.normalizedAllergens == ["Dairy", "Eggs", "Gluten", "Mustard", "Sesame"])
+    }
+
+    @Test("Traces are included alongside declared allergens")
+    func tracesAreIncluded() {
+        let item = product(allergens: ["en:milk"], traces: ["en:peanuts"])
+
+        #expect(item.normalizedAllergens == ["Dairy", "Peanuts"])
+    }
+
+    @Test("Duplicates across allergens and traces collapse")
+    func duplicatesCollapse() {
+        let item = product(allergens: ["en:milk"], traces: ["en:milk"])
+
+        #expect(item.normalizedAllergens == ["Dairy"])
+    }
+
+    @Test("Unmapped and locale-prefixed tags are ignored rather than guessed")
+    func unknownTagsAreIgnored() {
+        // "fr:lait" is milk, but interpreting arbitrary locale namespaces would
+        // be guesswork; keyword detection remains the fallback for these.
+        let item = product(allergens: ["fr:lait", "en:milk", "en:something-invented"])
+
+        #expect(item.normalizedAllergens == ["Dairy"])
+    }
+
+    @Test("A record with no allergen tags yields an empty list, not a crash")
+    func missingTags() {
+        #expect(product(allergens: nil).normalizedAllergens.isEmpty)
+    }
+
+    @Test("English ingredient text wins over the product's own language")
+    func englishIngredientsPreferred() throws {
+        let json = """
+        {
+          "code": "test",
+          "product_name": "Big Mac",
+          "ingredients_text": "Pain aux graines de sesame, steak haché de boeuf",
+          "ingredients_text_en": "Sesame seed bun, beef patty"
+        }
+        """
+        let item = try JSONDecoder().decode(OpenFoodFactsProduct.self, from: Data(json.utf8))
+
+        #expect(item.bestIngredientsText == "Sesame seed bun, beef patty")
+    }
+
+    @Test("Falls back to the original language when no English text exists")
+    func fallsBackToOriginalLanguage() throws {
+        let json = """
+        {
+          "code": "test",
+          "product_name": "Big Mac",
+          "ingredients_text": "Pain aux graines de sesame"
+        }
+        """
+        let item = try JSONDecoder().decode(OpenFoodFactsProduct.self, from: Data(json.utf8))
+
+        #expect(item.bestIngredientsText == "Pain aux graines de sesame")
+    }
+}


### PR DESCRIPTION
Addresses the allergen and localization half of #377.

## The problem

A McDonald's Big Mac listed **`Lait`**, **`Oeufs`** and **`Moutarde`** in its ingredients while Allergens & Warnings reported only Gluten and Sesame. The app was showing dairy on one screen and denying it on the next.

## Causes and fixes

**1. No language preference sent to OpenFoodFacts.** The search and barcode URLs omitted `lc=en`, so the API returned each product in its own language. Now requests `lc=en` and prefers `ingredients_text_en`, falling back to the original language where no English record exists.

**2. Allergens were re-derived by English keyword matching over free text.** Against a French list that only catches cognates — "gluten" and "sesame" match, "lait" does not.

OpenFoodFacts already publishes `allergens_tags` and `traces_tags` with language-independent `en:` prefixes. Nothing read them, and `FoodSearchResult` had **no allergens field at all** to carry them through. Adds `declaredAllergens`, populated from the tags and unioned with keyword detection so neither source has to be complete on its own. Locale-prefixed tags like `fr:lait` are ignored rather than guessed at — keyword matching remains the fallback there.

**3. Ingredient splitting ignored brackets.** Compound entries were shredded and unbalanced fragments emitted — `Sauce (Eau`, `Épices (Dont Moutarde`, `Edta)` — which is how a mustard declaration ended up cut in half. The allergen trailer was also parsed as ingredients, so Milk/Eggs/Mustard appeared as things the burger *contains* rather than warnings *about* it.

New `IngredientTextParser` splits at bracket depth zero, strips the allergen trailer, drops placeholders like `undefined`, and removes percentage annotations.

## Verification

Simulator, iPhone 17 Pro Max / iOS 26.5. Reproduced the original state first.

| | Before | After |
|---|---|---|
| Allergens | Gluten, Sesame | **Dairy, Eggs, Gluten, Mustard, Sesame, +1** |
| Ingredients | 31, French, with `Sauce (Eau` fragments | **25, English, no fragments** |
| Health indicators | 3 | 7 |

56 tests pass locally (`xcodebuild test`), 22 of them new.

## One honest wart

Real label text is not reliably balanced — this record's sauce bracket never closes. A pure depth-tracking parser swallowed everything after it into a single wall-of-text entry, so an unbalanced segment now falls back to a flat split with brackets stripped. That is why entry 4 reads `Sauce Water` rather than `Sauce (Water, …)`. It is readable and nothing is lost or mis-attributed, but it is a rescue path, not a parse. Improving it means handling malformed source text properly, which is a bigger job than this PR.

Still open in #377: compound attribution across ingredients, which should improve on its own now the text is English — worth re-checking rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)