### PR TITLE
ci: stop the changelog workflow triggering itself

### DIFF
--- a/.github/workflows/update-changelog-after-ci.yml
+++ b/.github/workflows/update-changelog-after-ci.yml
@@ -11,9 +11,20 @@ permissions:
 
 jobs:
   update-changelog:
+    # The last condition is what stops this workflow feeding itself.
+    #
+    # ios.yml runs on every push to main. This job pushes a commit to main, so
+    # without a guard that push starts another build, which succeeds, which
+    # starts this job again — each run adding an entry about the previous run's
+    # commit, indefinitely. The last_sha marker does not help: it records the
+    # triggering commit, which is new every time round.
+    #
+    # The bot's commit also carries [skip ci], so in practice the build is never
+    # started at all. This check is the backstop for when someone removes that.
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+      github.event.workflow_run.head_branch == 'main' &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'docs(changelog):')
     runs-on: ubuntu-latest
 
     steps:
@@ -101,5 +112,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "docs(changelog): update after successful CI on main"
+          # [skip ci] keeps this push from starting another iOS Build & Test,
+          # which would re-trigger this workflow. See the guard on the job.
+          git commit -m "docs(changelog): update after successful CI on main [skip ci]"
           git push origin main


### PR DESCRIPTION
Fixes the self-triggering loop Copilot spotted on #392.

## The loop

1. `ios.yml` runs on every push to `main`
2. This workflow pushes a CHANGELOG commit to `main`
3. That push starts another `iOS Build & Test`
4. It succeeds → this workflow runs again → back to 2

Each iteration adds a changelog entry about the previous iteration's commit.

**The existing `last_sha` marker does not stop it.** That check compares against the *triggering* commit's SHA, which is new on every round, so it never matches.

## Why it hasn't happened yet

`main`'s build has been red since the workflow landed, so the job has been skipping — every run on `18b6187` shows `skipped`. **Restoring the build in #392 is precisely what would have started this**, which makes it worth fixing before the release rather than after.

## Fix

Two guards, because the first is easy to remove by accident:

- The bot's commit now carries `[skip ci]`, so the push doesn't start a build at all.
- The job refuses to run when the triggering commit message starts with `docs(changelog):`.

```yaml
if: >
  github.event.workflow_run.conclusion == 'success' &&
  github.event.workflow_run.head_branch == 'main' &&
  !startsWith(github.event.workflow_run.head_commit.message, 'docs(changelog):')
```

YAML validated; the expression parses as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)