### PR TITLE
docs: address Copilot review on #389 and #391

### DIFF
--- a/.github/workflows/update-changelog-after-ci.yml
+++ b/.github/workflows/update-changelog-after-ci.yml
@@ -51,7 +51,6 @@ jobs:
 
           DATE="$(date -u +'%Y-%m-%d')"
           SHA="${{ github.event.workflow_run.head_sha }}"
-          SHORT_SHA="${SHA:0:7}"
 
           # Prevent duplicate entries
           if grep -q "^<!-- changelog:last_sha=${SHA} -->$" CHANGELOG.md; then
@@ -83,7 +82,7 @@ jobs:
             echo
             echo "<!-- changelog:last_sha=${SHA} -->"
             echo
-            echo "## ${DATE} (${SHORT_SHA})"
+            echo "## ${DATE}"
             echo
             echo "${NEW_ENTRIES}"
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,4 @@ before editing this file by hand.
 - CodeQL action pinned to 4.37.3 (#354)
 
 ### Security
-- Founder details, including personal medical history, removed from `docs/VISION.md`, and the commits containing them purged from branch history
+- Personal information removed from `docs/VISION.md`, and the commits containing it purged from branch history

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -286,8 +286,10 @@ struct UnifiedFoodDetailView: View {
         }
     }
 
-    /// Display unit for a parsed micronutrient. Vitamins A, D and K are stored
-    /// in micrograms; the rest of what reaches these sections is milligrams.
+    /// Display unit for a parsed micronutrient.
+    ///
+    /// Micrograms: vitamins A, D and K, plus folate, B12, biotin and selenium.
+    /// Everything else that reaches these sections is milligrams.
     private func unitForMicronutrient(_ key: String) -> String {
         switch key {
         case "Vitamin A", "Vitamin D", "Vitamin K", "Folate", "Vitamin B12", "Biotin", "Selenium":

--- a/GutCheck/GutCheckTests/IngredientTextParserTests.swift
+++ b/GutCheck/GutCheckTests/IngredientTextParserTests.swift
@@ -125,8 +125,9 @@ struct NutritionDetailNumberTests {
 
     @Test("A comma decimal separator is honoured, not stripped")
     func commaDecimal() {
-        // Values persisted by an earlier build in a comma-decimal locale.
-        // Stripping the comma would read this as 4605.
+        // Values persisted by an earlier build in a comma-decimal locale. The
+        // parser distinguishes this from thousands grouping; an earlier version
+        // stripped the comma outright and read it as 4605.
         #expect(NutrientValueParser.number(from: "460,5mg") == 460.5)
     }
 


### PR DESCRIPTION
Four review items, all from Copilot on #389 and #391. One of them should not reach `main`.

## The one that matters

`CHANGELOG.md` named the category of personal data that had been exposed. Restating that in a public file undercuts the entry's own point. Now:

```diff
-- Founder details, including personal medical history, removed from `docs/VISION.md`, …
+- Personal information removed from `docs/VISION.md`, and the commits containing it purged from branch history
```

## The rest

**Changelog heading format.** The workflow wrote `## YYYY-MM-DD (shortsha)`, but CLAUDE.md and every existing entry use plain `## YYYY-MM-DD`. Bot sections would have drifted from hand-written ones from the first run. The bullets already carry `%h`, so the SHA in the heading was redundant — dropped, and the now-unused `SHORT_SHA` removed with it.

**`unitForMicronutrient` doc comment** claimed vitamins A, D and K, but the switch also returns `mcg` for folate, B12, biotin and selenium.

**Comma-decimal test comment** still described the old strip-the-comma behaviour rather than the current grouping-vs-decimal handling.

## Verification

Builds clean for iOS Simulator (iPhone 17 Pro Max / iOS 26.5). YAML revalidated after the workflow edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)