### PR TITLE
ci: write the changelog to development, since main rejects direct pushes

### DIFF
--- a/.github/workflows/update-changelog-after-ci.yml
+++ b/.github/workflows/update-changelog-after-ci.yml
@@ -28,10 +28,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
+      # The entry describes what reached main, but it is written to
+      # development: main's ruleset requires changes to arrive by pull request,
+      # so a direct push from this job is rejected outright
+      # ("GH013: Changes must be made through a pull request"). development is
+      # unprotected, and the entry reaches main with the next release.
+      - name: Checkout development
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: development
           fetch-depth: 0
 
       - name: Ensure CHANGELOG.md exists
@@ -62,10 +67,14 @@ jobs:
           LAST_SHA="$(grep -m1 -E '^<!-- changelog:last_sha=[0-9a-f]{40} -->$' CHANGELOG.md \
             | sed -E 's/^<!-- changelog:last_sha=([0-9a-f]{40}) -->$/\1/' || true)"
 
+          # The commits being described live on main, and the checkout is
+          # development, so make sure main's history is present.
+          git fetch --no-tags origin main
+
           if [ -n "${LAST_SHA:-}" ]; then
             RANGE="${LAST_SHA}..${SHA}"
           else
-            FIRST_COMMIT="$(git rev-list --max-parents=0 main | tail -n1)"
+            FIRST_COMMIT="$(git rev-list --max-parents=0 origin/main | tail -n1)"
             RANGE="${FIRST_COMMIT}..${SHA}"
           fi
 
@@ -114,4 +123,8 @@ jobs:
           # [skip ci] keeps this push from starting another iOS Build & Test,
           # which would re-trigger this workflow. See the guard on the job.
           git commit -m "docs(changelog): update after successful CI on main [skip ci]"
-          git push origin main
+
+          # development is unprotected but can move while this job runs, so
+          # rebase rather than failing the run on a race.
+          git pull --rebase origin development
+          git push origin development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- changelog:last_sha=18b6187fb775a99ce269ca64cbf7a30cd15cd725 -->
+<!-- changelog:last_sha=b0eb6173bb8567a50223120654c6579cff32b2c6 -->
 
 All notable changes to GutCheck, newest first. Each section is dated by the day
 the work reached `main`.
@@ -8,6 +8,20 @@ the work reached `main`.
 New sections are prepended automatically after every successful CI run on
 `main`; the marker above records where the bot last read from. See CLAUDE.md
 before editing this file by hand.
+
+## 2026-08-05
+
+### Fixed
+- The app did not compile on either branch. `NutritionDetailsView` called `Self.normalizedNumber`, which lives on the sibling `UnifiedFoodDetailView`; extracted to `NutrientValueParser` so both can reach it (#392)
+- Full nutrition details reworked to show complete, non-duplicated nutrient data (#386)
+
+### Changed
+- `main` and `development` reconciled after diverging in both directions (#392)
+- `CHANGELOG.md` is now a real changelog — newest first, dated by when work reached `main` — and the convention is documented in CLAUDE.md (#391, #394)
+- Bumped `github/codeql-action` 4.37.3 → 4.37.4 (#390)
+
+### Security
+- Changelog automation no longer triggers itself. `ios.yml` runs on every push to `main`, so the bot's own commit started a build whose success re-ran the bot, indefinitely. Guarded with `[skip ci]` and a commit-message check (#393)
 
 ## 2026-08-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,14 +80,18 @@ Group entries under **Added**, **Changed**, **Fixed**, **Removed**, **Deprecated
 
 ### The CI writes it
 
-`.github/workflows/update-changelog-after-ci.yml` prepends a dated section after every successful `iOS Build & Test` run on `main`, and pushes straight to `main`. So:
+`.github/workflows/update-changelog-after-ci.yml` prepends a dated section after every successful `iOS Build & Test` run on `main`, and commits it to **`development`**.
+
+It describes what reached `main`, but it cannot write there: `main`'s ruleset requires changes to arrive by pull request, so a direct push is rejected with `GH013: Changes must be made through a pull request`. `development` is unprotected, and the entry reaches `main` with the next release — so `main`'s changelog is current as of its previous release, not the one that just shipped. That is the trade-off for keeping the automation without a ruleset bypass.
+
+So:
 
 - **Don't hand-edit `CHANGELOG.md` in a feature branch** expecting it to survive — you will conflict with the bot on the next green build.
 - **The bot's entries are raw commit subjects.** Tidying them into proper Added/Changed/Fixed groupings afterwards is fine and expected; that is editing history *prose*, not history.
 - `<!-- changelog:last_sha=… -->` near the top is the bot's bookmark for where it last read. **Do not delete it** — without it the next run walks the entire history from the first commit and dumps it into one section.
 - The bot matches the title `# Changelog` exactly. Changing the title case breaks its de-duplication and leaves two headings in the file.
 
-Because the bot pushes to `main` directly, `development` falls behind by one commit after each release. That is the same reconciliation the "push dev to main" step already ends with — fast-forward `development` and confirm both branches report the same SHA.
+Because the bot commits to `development`, a release will usually carry a changelog entry describing the *previous* release. That is expected. What is not expected is the bot pushing to `main` — if you find yourself adding that, check the ruleset first.
 
 ## Verification
 


### PR DESCRIPTION
The changelog workflow **failed on its first real run** (`b0eb617`), and would fail on every green build.

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

`main`'s ruleset requires changes to arrive by pull request, and has **no bypass actors**:

```json
{"bypass": [], "rules": ["deletion", "non_fast_forward", "pull_request"]}
```

So a job that pushes directly to `main` can never succeed. The workflow was written against an assumption the repo doesn't hold.

## Fix

Retarget the commit at `development`, which is unprotected. The entry still describes what reached `main` — the trigger and commit range are unchanged — it just travels to `main` with the next release instead of landing there directly.

**Trade-off, stated plainly:** `main`'s changelog is current as of its *previous* release. Documented in CLAUDE.md so nobody re-adds the direct push.

The alternatives, for the record:

- **Add `github-actions[bot]` to the ruleset's bypass list.** Keeps `main` current, but needs an admin change outside the repo — say the word and I'll write up exactly what to click.
- **Have the bot open a PR.** Also keeps `main` current, but adds PR churn per build and reintroduces loop risk on merge, since the merge commit is created by GitHub and won't carry `[skip ci]`.

## Also in here

- Fetches `main` explicitly — the checkout is now `development`, but the commits being described live on `main`.
- Rebases before pushing, so a race with other work on `development` retries rather than failing the run.
- **Backfills the `2026-08-05` entry** the failed run should have written, and advances `last_sha` to `b0eb617` so the next run doesn't repeat it.

## Verification

YAML parses; `grep` confirms no write to `main` remains (only a read-only fetch); simulating a bot run against the updated `CHANGELOG.md` yields one title, one marker, and sections in newest-first order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)