### PR TITLE
fix(meals): show the meal name in lists, and stop the save form emptying (#363)

### DIFF
--- a/GutCheck/GutCheck/Services/MealBuilderService.swift
+++ b/GutCheck/GutCheck/Services/MealBuilderService.swift
@@ -140,10 +140,11 @@ import Combine
         
         // Trigger dashboard refresh after successful save
         DataSyncManager.shared.triggerRefreshAfterSave(operation: "Meal builder save", dataType: .meals)
-        
-        // Clear after successful save
-        clearMeal()
-        
+
+        // Deliberately does not clear the builder. Clearing here emptied the
+        // form while the sheet was still on screen, so the "Meal Saved" alert
+        // appeared over a blank meal — which reads as a failure and invites the
+        // user to enter everything again. The caller clears on dismissal.
         return meal
     }
     

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -736,7 +736,9 @@ struct MealCalendarRow: View {
                 // Content
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(alignment: .firstTextBaseline) {
-                        Text(meal.type.rawValue.capitalized)
+                        // The name is what distinguishes two lunches on the same
+                        // day. Fall back to the meal type when there isn't one.
+                        Text(meal.name.isEmpty ? meal.type.rawValue.capitalized : meal.name)
                             .typography(Typography.headline)
                             .foregroundStyle(ColorTheme.primaryText)
 

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -738,7 +738,9 @@ struct MealCalendarRow: View {
                     HStack(alignment: .firstTextBaseline) {
                         // The name is what distinguishes two lunches on the same
                         // day. Fall back to the meal type when there isn't one.
-                        Text(meal.name.isEmpty ? meal.type.rawValue.capitalized : meal.name)
+                        Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                             ? meal.type.rawValue.capitalized
+                             : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
                             .typography(Typography.headline)
                             .foregroundStyle(ColorTheme.primaryText)
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -5,7 +5,9 @@ struct MealSummaryCard: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(meal.type.rawValue)
+            // The name is what distinguishes two lunches on the same day.
+            // Fall back to the meal type when there isn't one.
+            Text(meal.name.isEmpty ? meal.type.rawValue.capitalized : meal.name)
                 .typography(Typography.headline)
                 .foregroundStyle(.primary)
             

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -7,7 +7,9 @@ struct MealSummaryCard: View {
         VStack(alignment: .leading, spacing: 8) {
             // The name is what distinguishes two lunches on the same day.
             // Fall back to the meal type when there isn't one.
-            Text(meal.name.isEmpty ? meal.type.rawValue.capitalized : meal.name)
+            Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                 ? meal.type.rawValue.capitalized
+                 : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
                 .typography(Typography.headline)
                 .foregroundStyle(.primary)
             

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -339,14 +339,18 @@ struct MealBuilderView: View {
             Text("Are you sure you want to discard this meal? All food items will be lost.")
         }
         .alert("Meal Saved", isPresented: $showingConfirmation) {
-            Button("OK") {
-                // Clear here rather than in saveMeal(), so the form stays
-                // intact behind this alert instead of appearing to be lost.
-                mealService.clearMeal()
-                dismiss()
-            }
+            Button("OK") { dismiss() }
         } message: {
             Text("Your meal has been successfully saved.")
+        }
+        // Clearing happens here rather than in saveMeal() or in the OK handler.
+        // saveMeal() emptied the form while the sheet was still on screen, so
+        // the confirmation appeared over a blank meal and read as a failure;
+        // clearing on OK still let that blank frame show before the sheet
+        // finished closing. By onDisappear the sheet is gone, so the emptied
+        // form is never visible either way.
+        .onDisappear {
+            mealService.clearMeal()
         }
     }
     

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -340,6 +340,9 @@ struct MealBuilderView: View {
         }
         .alert("Meal Saved", isPresented: $showingConfirmation) {
             Button("OK") {
+                // Clear here rather than in saveMeal(), so the form stays
+                // intact behind this alert instead of appearing to be lost.
+                mealService.clearMeal()
                 dismiss()
             }
         } message: {


### PR DESCRIPTION
Closes #363. Two problems in the logging flow.

## 1. Meal lists showed the type, not the name

Every lunch read as **"Lunch"**, so two lunches on the same day were indistinguishable. The name was already stored and already correct on the detail screen — the rows just never read it:

```swift
Text(meal.type.rawValue.capitalized)
```

Fixed in `MealCalendarRow` (what the Meals tab actually renders — `AppRoot` points the tab at `CalendarView`) and in `MealSummaryCard`. Falls back to the type when a meal has no name.

## 2. The save form emptied behind the confirmation

`saveMeal()` called `clearMeal()` before returning, so the form went blank while the sheet was still on screen and the "Meal Saved" alert appeared over an empty meal. It reads as a failure and invites re-entering everything.

The clear now happens on dismissal, so the meal stays visible behind the confirmation. Clearing was a side effect that didn't belong in a save function anyway, and `MealBuilderView` is its only caller, so moving it is contained.

## A correction to the original report

I wrote in #363 that the sheet "does not dismiss". Reading the code, it does — on OK. The real defect was the form emptying underneath. Same user-visible problem, different cause, and worth stating since the issue text is misleading.

## Verification

Simulator, iPhone 17 Pro Max / iOS 26.5. Saved a meal named "Cheese Snack Test":

- The alert now appears over the **intact** form — name, food item and calories all still visible
- The Meals list row reads **"Cheese Snack Test"** instead of "Lunch"

Caught one thing by re-checking rather than trusting the first pass: my initial build only fixed `MealSummaryCard`, and the list still showed "Lunch" on device. The Meals tab renders `MealCalendarRow`, which needed the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)