### PR TITLE
fix(nutrition): route searched foods through the canonical detail builder (#362)

### DIFF
--- a/GutCheck/GutCheck/Services/FoodSearchModels.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchModels.swift
@@ -297,18 +297,21 @@ struct FoodSearchResult: Identifiable, Codable {
     static let storageLocale = Locale(identifier: "en_US_POSIX")
 
     /// Convert to FoodItem for logging meals
-    func toFoodItem(quantity: String? = nil) -> FoodItem {
-        let finalQuantity = quantity ?? {
-            if let servingQty = servingQty, let servingUnit = servingUnit {
-                return "\(servingQty) \(servingUnit)"
-            }
-            return "1 serving"
-        }()
-        
+    /// The canonical `nutritionDetails` dictionary for this result.
+    ///
+    /// Split out of `toFoodItem()` so callers that only want the nutrition
+    /// strings — the search list builds one per result — do not have to
+    /// construct and discard a whole `FoodItem`, ingredient parsing included.
+    ///
+    /// This is the one place that knows the label names, units and gram
+    /// conversions. `NutritionDetailsView` looks these labels up directly, so
+    /// a second hand-rolled dictionary drifts out of sync and silently drops
+    /// nutrients — which is exactly what #362 turned out to be.
+    func nutritionDetailStrings() -> [String: String] {
         var nutritionDetails: [String: String] = [:]
-        
-        // Add detailed nutrition data. Grams stay grams; anything labelled
-        // mg/mcg is converted first so the number and suffix agree.
+
+        // Grams stay grams; anything labelled mg/mcg is converted first so the
+        // number and suffix agree.
         func addDetail(_ label: String, _ value: Double?, unit: String, formatter: (Double) -> String = Self.amount) {
             guard let value else { return }
             nutritionDetails[label] = "\(formatter(value))\(unit)"
@@ -352,6 +355,18 @@ struct FoodSearchResult: Identifiable, Codable {
         addDetail("Biotin", biotinMicrograms, unit: "mcg")
         addDetail("Pantothenic Acid", pantothenicAcidMilligrams, unit: "mg")
         
+        return nutritionDetails
+    }
+
+    /// Convert to FoodItem for logging meals
+    func toFoodItem(quantity: String? = nil) -> FoodItem {
+        let finalQuantity = quantity ?? {
+            if let servingQty = servingQty, let servingUnit = servingUnit {
+                return "\(servingQty) \(servingUnit)"
+            }
+            return "1 serving"
+        }()
+
         return FoodItem(
             name: brand != nil ? "\(brand!) \(name)" : name,
             quantity: finalQuantity,
@@ -368,7 +383,7 @@ struct FoodSearchResult: Identifiable, Codable {
                 sodium: sodiumMilligrams
             ),
             source: .manual,
-            nutritionDetails: nutritionDetails
+            nutritionDetails: nutritionDetailStrings()
         )
     }
 }

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -82,7 +82,7 @@ import Combine
         // Parse ingredients from Nutritionix ingredients string  
         let ingredientList: [String] = parseIngredients(from: nfood.ingredients)
         
-        // Nutrition details come from FoodSearchResult.toFoodItem(), which is
+        // Nutrition details come from FoodSearchResult.nutritionDetailStrings(),
         // the single place that knows the label names, units and conversions.
         //
         // This used to hand-build a parallel dictionary with its own keys, and
@@ -91,7 +91,7 @@ import Combine
         // "Calcium"/"calcium". Nothing matched, so Vitamins & Minerals was
         // always empty for searched foods — and magnesium, zinc, selenium and
         // the B vitamins were never written at all.
-        var nutritionDict = nfood.toFoodItem().nutritionDetails
+        var nutritionDict = nfood.nutritionDetailStrings()
 
         if let brand = nfood.brand {
             nutritionDict["brand"] = brand

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -82,62 +82,21 @@ import Combine
         // Parse ingredients from Nutritionix ingredients string  
         let ingredientList: [String] = parseIngredients(from: nfood.ingredients)
         
-        // Build comprehensive nutrition dictionary from enhanced data
-        var nutritionDict: [String: String] = [:]
-        
-        // Add brand information
+        // Nutrition details come from FoodSearchResult.toFoodItem(), which is
+        // the single place that knows the label names, units and conversions.
+        //
+        // This used to hand-build a parallel dictionary with its own keys, and
+        // they had drifted apart: it wrote "calcium_dv"/"iron_dv"/
+        // "vitamin_a_dv"/"vitamin_c_dv", while NutritionDetailsView looks up
+        // "Calcium"/"calcium". Nothing matched, so Vitamins & Minerals was
+        // always empty for searched foods — and magnesium, zinc, selenium and
+        // the B vitamins were never written at all.
+        var nutritionDict = nfood.toFoodItem().nutritionDetails
+
         if let brand = nfood.brand {
             nutritionDict["brand"] = brand
         }
-        
-        // Add basic nutrition values
-        if let calories = nfood.calories {
-            nutritionDict["calories"] = calories.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let protein = nfood.protein {
-            nutritionDict["protein"] = protein.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let carbs = nfood.carbs {
-            nutritionDict["total_carbohydrate"] = carbs.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let fat = nfood.fat {
-            nutritionDict["total_fat"] = fat.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let fiber = nfood.fiber {
-            nutritionDict["dietary_fiber"] = fiber.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let sugar = nfood.sugar {
-            nutritionDict["sugars"] = sugar.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        // Minerals and vitamins arrive in grams (see the unit note on
-        // FoodSearchResult); this dictionary is displayed as mg/mcg.
-        if let sodium = nfood.sodiumMilligrams {
-            nutritionDict["sodium"] = sodium.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
 
-        // Add detailed nutrition from the specific properties
-        if let saturatedFat = nfood.saturatedFat {
-            nutritionDict["saturated_fat"] = saturatedFat.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let cholesterol = nfood.cholesterolMilligrams {
-            nutritionDict["cholesterol"] = cholesterol.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let potassium = nfood.potassiumMilligrams {
-            nutritionDict["potassium"] = potassium.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let vitaminA = nfood.vitaminAMicrograms {
-            nutritionDict["vitamin_a_dv"] = vitaminA.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let vitaminC = nfood.vitaminCMilligrams {
-            nutritionDict["vitamin_c_dv"] = vitaminC.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let calcium = nfood.calciumMilligrams {
-            nutritionDict["calcium_dv"] = calcium.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let iron = nfood.ironMilligrams {
-            nutritionDict["iron_dv"] = iron.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        
         // Allergens the source declared outright, plus anything keyword matching
         // spots. The declared set is what catches a French ingredient list —
         // "Lait" never matches the English keyword table, but the record's


### PR DESCRIPTION
Closes #362 — the last piece of it.

## Most of #362 was already fixed

#386 reworked the nutrition details, and verifying on simulator before writing code confirmed it had already delivered most of the issue: no duplicated sections, FDA label ordering, % Daily Value, cholesterol/trans fat/added sugars present, and an explicit "Not available" rather than silent omission.

One acceptance criterion was still failing: **Vitamins & Minerals always showed the empty state**, even for foods whose source clearly had the data.

## The cause

The search path builds its `FoodItem` in `FoodSearchViewModel.createEnhancedFoodItem`, which hand-rolled its own `nutritionDetails` dictionary instead of using `FoodSearchResult.toFoodItem()`. The two had drifted:

| | |
|---|---|
| Search path **writes** | `calcium_dv`, `iron_dv`, `vitamin_a_dv`, `vitamin_c_dv` |
| `NutritionDetailsView` **reads** | `Calcium`, `calcium` |

Nothing matched, so those four were silently dropped. Magnesium, zinc, copper, manganese, selenium, vitamin E/K and the B vitamins were **never written by that path at all** — `toFoodItem()` writes all of them, correctly labelled and converted, and nothing in the search flow called it.

## Fix

Use `toFoodItem()`'s dictionary directly, so one place knows the label names, units and conversions. Brand is still layered on top, since that's view metadata rather than nutrition.

Net effect: ~3,500 characters of duplicated formatting logic replaced by one line.

## Verification

Simulator, iPhone 17 Pro Max / iOS 26.5. Almonds, before → after:

| | Before | After |
|---|---|---|
| Vitamins & Minerals | "No vitamin or mineral data available" | **Calcium 110.10 mg (8% DV)**, **Iron 1.26 mg (7% DV)**, Vitamin C 0.00 mg (0% DV) |

Nutrients the source genuinely doesn't carry show "Not available" — correct behaviour, not a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)