### PR TITLE
Release: nutrition detail keys, meal name in lists, save-form fix

### DIFF
--- a/.github/workflows/update-changelog-after-ci.yml
+++ b/.github/workflows/update-changelog-after-ci.yml
@@ -11,16 +11,18 @@ permissions:
 
 jobs:
   update-changelog:
-    # The last condition is what stops this workflow feeding itself.
+    # Two of these conditions keep the workflow from feeding itself.
     #
-    # ios.yml runs on every push to main. This job pushes a commit to main, so
-    # without a guard that push starts another build, which succeeds, which
-    # starts this job again — each run adding an entry about the previous run's
-    # commit, indefinitely. The last_sha marker does not help: it records the
-    # triggering commit, which is new every time round.
+    # The head_branch check is the load-bearing one. ios.yml runs on pushes to
+    # main *and* development, so the bot's own commit can still start a build —
+    # but that build is on development, and this job only reacts to main. The
+    # loop is broken there.
     #
-    # The bot's commit also carries [skip ci], so in practice the build is never
-    # started at all. This check is the backstop for when someone removes that.
+    # The commit-message check is the backstop for the day someone points this
+    # job back at main. Then the bot's push would trigger a main build whose
+    # success re-runs this job, each round adding an entry about the previous
+    # round's commit. The last_sha marker does not help: it records the
+    # triggering commit, which is new every time.
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
@@ -120,8 +122,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          # [skip ci] keeps this push from starting another iOS Build & Test,
-          # which would re-trigger this workflow. See the guard on the job.
+          # [skip ci] keeps a changelog-only commit from spending a full
+          # iOS Build & Test run on development. It is not what prevents the
+          # loop — the head_branch guard on the job does that. See the comment
+          # there before removing either.
           git commit -m "docs(changelog): update after successful CI on main [skip ci]"
 
           # development is unprotected but can move while this job runs, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-<!-- changelog:last_sha=b0eb6173bb8567a50223120654c6579cff32b2c6 -->
+<!-- changelog:last_sha=3d555b7b16af2d6a6574f9cb3ea20f30f79f380c -->
+
+## 2026-08-05
+
+- ci: write the changelog to development, since main rejects direct pushes (#395) (3ff680b)
+
+
 
 All notable changes to GutCheck, newest first. Each section is dated by the day
 the work reached `main`.

--- a/GutCheck/GutCheck/Services/FoodSearchModels.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchModels.swift
@@ -297,18 +297,21 @@ struct FoodSearchResult: Identifiable, Codable {
     static let storageLocale = Locale(identifier: "en_US_POSIX")
 
     /// Convert to FoodItem for logging meals
-    func toFoodItem(quantity: String? = nil) -> FoodItem {
-        let finalQuantity = quantity ?? {
-            if let servingQty = servingQty, let servingUnit = servingUnit {
-                return "\(servingQty) \(servingUnit)"
-            }
-            return "1 serving"
-        }()
-        
+    /// The canonical `nutritionDetails` dictionary for this result.
+    ///
+    /// Split out of `toFoodItem()` so callers that only want the nutrition
+    /// strings — the search list builds one per result — do not have to
+    /// construct and discard a whole `FoodItem`, ingredient parsing included.
+    ///
+    /// This is the one place that knows the label names, units and gram
+    /// conversions. `NutritionDetailsView` looks these labels up directly, so
+    /// a second hand-rolled dictionary drifts out of sync and silently drops
+    /// nutrients — which is exactly what #362 turned out to be.
+    func nutritionDetailStrings() -> [String: String] {
         var nutritionDetails: [String: String] = [:]
-        
-        // Add detailed nutrition data. Grams stay grams; anything labelled
-        // mg/mcg is converted first so the number and suffix agree.
+
+        // Grams stay grams; anything labelled mg/mcg is converted first so the
+        // number and suffix agree.
         func addDetail(_ label: String, _ value: Double?, unit: String, formatter: (Double) -> String = Self.amount) {
             guard let value else { return }
             nutritionDetails[label] = "\(formatter(value))\(unit)"
@@ -352,6 +355,18 @@ struct FoodSearchResult: Identifiable, Codable {
         addDetail("Biotin", biotinMicrograms, unit: "mcg")
         addDetail("Pantothenic Acid", pantothenicAcidMilligrams, unit: "mg")
         
+        return nutritionDetails
+    }
+
+    /// Convert to FoodItem for logging meals
+    func toFoodItem(quantity: String? = nil) -> FoodItem {
+        let finalQuantity = quantity ?? {
+            if let servingQty = servingQty, let servingUnit = servingUnit {
+                return "\(servingQty) \(servingUnit)"
+            }
+            return "1 serving"
+        }()
+
         return FoodItem(
             name: brand != nil ? "\(brand!) \(name)" : name,
             quantity: finalQuantity,
@@ -368,7 +383,7 @@ struct FoodSearchResult: Identifiable, Codable {
                 sodium: sodiumMilligrams
             ),
             source: .manual,
-            nutritionDetails: nutritionDetails
+            nutritionDetails: nutritionDetailStrings()
         )
     }
 }

--- a/GutCheck/GutCheck/Services/MealBuilderService.swift
+++ b/GutCheck/GutCheck/Services/MealBuilderService.swift
@@ -140,10 +140,11 @@ import Combine
         
         // Trigger dashboard refresh after successful save
         DataSyncManager.shared.triggerRefreshAfterSave(operation: "Meal builder save", dataType: .meals)
-        
-        // Clear after successful save
-        clearMeal()
-        
+
+        // Deliberately does not clear the builder. Clearing here emptied the
+        // form while the sheet was still on screen, so the "Meal Saved" alert
+        // appeared over a blank meal — which reads as a failure and invites the
+        // user to enter everything again. The caller clears on dismissal.
         return meal
     }
     

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -82,62 +82,21 @@ import Combine
         // Parse ingredients from Nutritionix ingredients string  
         let ingredientList: [String] = parseIngredients(from: nfood.ingredients)
         
-        // Build comprehensive nutrition dictionary from enhanced data
-        var nutritionDict: [String: String] = [:]
-        
-        // Add brand information
+        // Nutrition details come from FoodSearchResult.nutritionDetailStrings(),
+        // the single place that knows the label names, units and conversions.
+        //
+        // This used to hand-build a parallel dictionary with its own keys, and
+        // they had drifted apart: it wrote "calcium_dv"/"iron_dv"/
+        // "vitamin_a_dv"/"vitamin_c_dv", while NutritionDetailsView looks up
+        // "Calcium"/"calcium". Nothing matched, so Vitamins & Minerals was
+        // always empty for searched foods — and magnesium, zinc, selenium and
+        // the B vitamins were never written at all.
+        var nutritionDict = nfood.nutritionDetailStrings()
+
         if let brand = nfood.brand {
             nutritionDict["brand"] = brand
         }
-        
-        // Add basic nutrition values
-        if let calories = nfood.calories {
-            nutritionDict["calories"] = calories.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let protein = nfood.protein {
-            nutritionDict["protein"] = protein.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let carbs = nfood.carbs {
-            nutritionDict["total_carbohydrate"] = carbs.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let fat = nfood.fat {
-            nutritionDict["total_fat"] = fat.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let fiber = nfood.fiber {
-            nutritionDict["dietary_fiber"] = fiber.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let sugar = nfood.sugar {
-            nutritionDict["sugars"] = sugar.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        // Minerals and vitamins arrive in grams (see the unit note on
-        // FoodSearchResult); this dictionary is displayed as mg/mcg.
-        if let sodium = nfood.sodiumMilligrams {
-            nutritionDict["sodium"] = sodium.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
 
-        // Add detailed nutrition from the specific properties
-        if let saturatedFat = nfood.saturatedFat {
-            nutritionDict["saturated_fat"] = saturatedFat.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let cholesterol = nfood.cholesterolMilligrams {
-            nutritionDict["cholesterol"] = cholesterol.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let potassium = nfood.potassiumMilligrams {
-            nutritionDict["potassium"] = potassium.formatted(.number.precision(.fractionLength(1)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let vitaminA = nfood.vitaminAMicrograms {
-            nutritionDict["vitamin_a_dv"] = vitaminA.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let vitaminC = nfood.vitaminCMilligrams {
-            nutritionDict["vitamin_c_dv"] = vitaminC.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let calcium = nfood.calciumMilligrams {
-            nutritionDict["calcium_dv"] = calcium.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        if let iron = nfood.ironMilligrams {
-            nutritionDict["iron_dv"] = iron.formatted(.number.precision(.fractionLength(0)).grouping(.never).locale(FoodSearchResult.storageLocale))
-        }
-        
         // Allergens the source declared outright, plus anything keyword matching
         // spots. The declared set is what catches a French ingredient list —
         // "Lait" never matches the English keyword table, but the record's

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -736,7 +736,11 @@ struct MealCalendarRow: View {
                 // Content
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(alignment: .firstTextBaseline) {
-                        Text(meal.type.rawValue.capitalized)
+                        // The name is what distinguishes two lunches on the same
+                        // day. Fall back to the meal type when there isn't one.
+                        Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                             ? meal.type.rawValue.capitalized
+                             : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
                             .typography(Typography.headline)
                             .foregroundStyle(ColorTheme.primaryText)
 

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -5,7 +5,11 @@ struct MealSummaryCard: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(meal.type.rawValue)
+            // The name is what distinguishes two lunches on the same day.
+            // Fall back to the meal type when there isn't one.
+            Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                 ? meal.type.rawValue.capitalized
+                 : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
                 .typography(Typography.headline)
                 .foregroundStyle(.primary)
             

--- a/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealBuilderView.swift
@@ -339,11 +339,18 @@ struct MealBuilderView: View {
             Text("Are you sure you want to discard this meal? All food items will be lost.")
         }
         .alert("Meal Saved", isPresented: $showingConfirmation) {
-            Button("OK") {
-                dismiss()
-            }
+            Button("OK") { dismiss() }
         } message: {
             Text("Your meal has been successfully saved.")
+        }
+        // Clearing happens here rather than in saveMeal() or in the OK handler.
+        // saveMeal() emptied the form while the sheet was still on screen, so
+        // the confirmation appeared over a blank meal and read as a failure;
+        // clearing on OK still let that blank frame show before the sheet
+        // finished closing. By onDisappear the sheet is gone, so the emptied
+        // form is never visible either way.
+        .onDisappear {
+            mealService.clearMeal()
         }
     }
     


### PR DESCRIPTION
\`main\` has one commit — the merge commit from the last release itself — that \`development\` doesn't; its content is identical to what's already in \`development\`, confirmed by diff. Nothing to reconcile.

## Landing

- #399 — closes #362: searched foods route through the canonical nutrition-details builder. Vitamins & Minerals always showed "No vitamin or mineral data available" for search results; the search path wrote \`calcium_dv\`/\`iron_dv\`/\`vitamin_a_dv\`/\`vitamin_c_dv\` while the detail view read \`Calcium\`/\`Iron\`. Also extracts \`nutritionDetailStrings()\` so a search result no longer builds and discards a full \`FoodItem\` just to read its nutrition strings.
- #398 — closes #363: meal lists showed the meal type ("Lunch") instead of the name, and the save confirmation appeared over a form that had already been cleared. Clearing now happens in \`onDisappear\`, after the sheet is gone, so there's no blank-form frame at all.
- #397 — corrects stale comments in the changelog workflow describing loop prevention that changed in #395.

## Verification

Both functional PRs verified on simulator, iPhone 17 Pro Max / iOS 26.5, with before/after comparisons:

| | Before | After |
|---|---|---|
| Almonds, Vitamins & Minerals | "No vitamin or mineral data available" | Calcium 110.10 mg (8% DV), Iron 1.26 mg (7% DV) |
| Meals list row | "Lunch" | "Yogurt Save Flow Check" |
| Save confirmation | over a blank form | over the intact form, clean dismiss |

\`NutrientUnitConversionTests\` re-run after the extraction in #399 to confirm it didn't change behaviour — same values, byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)