### PR TITLE
fix: address Copilot review on #400 and repair CHANGELOG.md structure

### DIFF
--- a/.github/workflows/update-changelog-after-ci.yml
+++ b/.github/workflows/update-changelog-after-ci.yml
@@ -1,4 +1,3 @@
-
 name: Update CHANGELOG after successful CI on main
 
 on:
@@ -87,27 +86,73 @@ jobs:
             exit 0
           fi
 
-          TMP="$(mktemp)"
-          {
-            echo "# Changelog"
-            echo
-            echo "<!-- changelog:last_sha=${SHA} -->"
-            echo
-            echo "## ${DATE}"
-            echo
-            echo "${NEW_ENTRIES}"
-            echo
-            awk '
-              BEGIN { skipped_title=0; skipped_marker=0 }
-              {
-                if (!skipped_title && $0 == "# Changelog") { skipped_title=1; next }
-                if (!skipped_marker && $0 ~ /^<!-- changelog:last_sha=[0-9a-f]{40} -->$/) { skipped_marker=1; next }
-                print
-              }
-            ' CHANGELOG.md
-          } > "$TMP"
+          # Rewritten in Python rather than awk/sed: the previous version always
+          # spliced a brand-new "## DATE" header above whatever was left of the
+          # old file, verbatim. Two releases landing the same day produced two
+          # adjacent headers for that date, and the preamble paragraph — which
+          # lived below the marker in the original hand-written file — got
+          # pushed one section further down on every single run, eventually
+          # ending up sandwiched between unrelated dates.
+          #
+          # This version treats the title, marker and preamble as fixed,
+          # regenerated fresh each run rather than carried over from the old
+          # file, and merges into the top dated section when it already matches
+          # today's date instead of adding a second header for the same day.
+          DATE="$DATE" SHA="$SHA" NEW_ENTRIES="$NEW_ENTRIES" python3 <<'PYEOF'
+          import os
 
-          mv "$TMP" CHANGELOG.md
+          date = os.environ["DATE"]
+          sha = os.environ["SHA"]
+          new_entries = os.environ["NEW_ENTRIES"]
+
+          PREAMBLE = (
+              "All notable changes to GutCheck, newest first. Each section is dated by the day\n"
+              "the work reached `main`.\n"
+              "\n"
+              "New sections are prepended automatically after every successful CI run on\n"
+              "`main`; the marker above records where the bot last read from. See CLAUDE.md\n"
+              "before editing this file by hand."
+          )
+
+          with open("CHANGELOG.md") as f:
+              old = f.read()
+
+          # Strip the title, marker, and preamble block, so they don't
+          # accumulate copy after copy. What is left starts at the first
+          # dated ("## ") header, i.e. the actual changelog content.
+          lines = old.splitlines()
+          i = 0
+          if i < len(lines) and lines[i].strip() == "# Changelog":
+              i += 1
+          while i < len(lines) and lines[i].strip() == "":
+              i += 1
+          if i < len(lines) and lines[i].startswith("<!-- changelog:last_sha="):
+              i += 1
+          while i < len(lines) and not lines[i].startswith("## "):
+              i += 1
+
+          rest_lines = lines[i:]
+          top_header = rest_lines[0] if rest_lines else ""
+
+          if top_header == f"## {date}":
+              # Same-day release: fold into the existing section for today
+              # rather than adding a second header for the same date.
+              body = "\n".join(rest_lines[1:]).lstrip("\n")
+              new_rest = f"## {date}\n\n{new_entries}\n\n{body}"
+          else:
+              rest = "\n".join(rest_lines)
+              new_rest = f"## {date}\n\n{new_entries}\n\n{rest}"
+
+          out = (
+              "# Changelog\n\n"
+              f"<!-- changelog:last_sha={sha} -->\n\n"
+              f"{PREAMBLE}\n\n"
+              f"{new_rest.rstrip()}\n"
+          )
+
+          with open("CHANGELOG.md", "w") as f:
+              f.write(out)
+          PYEOF
 
       - name: Commit and push if changed
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,21 @@
 
 <!-- changelog:last_sha=ff0a7ef16e2cf8b38fbf607f057bc20d2ab288b2 -->
 
-## 2026-08-07
-
-- docs: correct the loop-prevention comments after the retarget (#397) (4601518)
-- fix(meals): show the meal name in lists, and stop the save form emptying (#363) (#398) (28e728d)
-- fix(nutrition): route searched foods through the canonical detail builder (#362) (#399) (ce36763)
-- docs(changelog): update after successful CI on main [skip ci] (ee06a79)
-
-
-
-## 2026-08-05
-
-- ci: write the changelog to development, since main rejects direct pushes (#395) (3ff680b)
-
-
-
 All notable changes to GutCheck, newest first. Each section is dated by the day
 the work reached `main`.
 
 New sections are prepended automatically after every successful CI run on
 `main`; the marker above records where the bot last read from. See CLAUDE.md
 before editing this file by hand.
+
+## 2026-08-07
+
+### Fixed
+- Meal lists showed the meal type ("Lunch") instead of the saved name, so two lunches on the same day were indistinguishable. The save confirmation also appeared over a form the app had already cleared, which read as a failure (#363)
+- Vitamins & Minerals always showed no data for searched foods. The search path wrote nutrition detail keys (`calcium_dv`, `iron_dv`, …) that the detail view never read (#362)
+
+### Changed
+- Corrected stale comments describing changelog-workflow loop prevention, left inaccurate by the retarget onto `development` (#397)
 
 ## 2026-08-05
 
@@ -34,6 +28,7 @@ before editing this file by hand.
 - `main` and `development` reconciled after diverging in both directions (#392)
 - `CHANGELOG.md` is now a real changelog — newest first, dated by when work reached `main` — and the convention is documented in CLAUDE.md (#391, #394)
 - Bumped `github/codeql-action` 4.37.3 → 4.37.4 (#390)
+- Changelog automation retargeted to commit on `development` instead of `main`, whose ruleset rejects direct pushes (#395)
 
 ### Security
 - Changelog automation no longer triggers itself. `ios.yml` runs on every push to `main`, so the bot's own commit started a build whose success re-ran the bot, indefinitely. Guarded with `[skip ci]` and a commit-message check (#393)

--- a/GutCheck/GutCheck/Services/FoodSearchModels.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchModels.swift
@@ -296,7 +296,6 @@ struct FoodSearchResult: Identifiable, Codable {
     /// Display formatting should still use the user's locale.
     static let storageLocale = Locale(identifier: "en_US_POSIX")
 
-    /// Convert to FoodItem for logging meals
     /// The canonical `nutritionDetails` dictionary for this result.
     ///
     /// Split out of `toFoodItem()` so callers that only want the nutrition

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -736,11 +736,7 @@ struct MealCalendarRow: View {
                 // Content
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(alignment: .firstTextBaseline) {
-                        // The name is what distinguishes two lunches on the same
-                        // day. Fall back to the meal type when there isn't one.
-                        Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                             ? meal.type.rawValue.capitalized
-                             : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
+                        Text(displayTitle)
                             .typography(Typography.headline)
                             .foregroundStyle(ColorTheme.primaryText)
 
@@ -788,6 +784,13 @@ struct MealCalendarRow: View {
         .disabled(isNavigating)
     }
     
+    // The name is what distinguishes two lunches on the same day. Fall back
+    // to the meal type when there isn't one, or it's only whitespace.
+    private var displayTitle: String {
+        let trimmed = meal.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? meal.type.rawValue.capitalized : trimmed
+    }
+
     private var mealIcon: String {
         switch meal.type {
         case .breakfast:

--- a/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
+++ b/GutCheck/GutCheck/Views/Calendar/Components/MealSummaryCard.swift
@@ -3,13 +3,16 @@ import SwiftUI
 struct MealSummaryCard: View {
     let meal: Meal
     
+    // The name is what distinguishes two lunches on the same day. Fall back
+    // to the meal type when there isn't one, or it's only whitespace.
+    private var displayTitle: String {
+        let trimmed = meal.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? meal.type.rawValue.capitalized : trimmed
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // The name is what distinguishes two lunches on the same day.
-            // Fall back to the meal type when there isn't one.
-            Text(meal.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                 ? meal.type.rawValue.capitalized
-                 : meal.name.trimmingCharacters(in: .whitespacesAndNewlines))
+            Text(displayTitle)
                 .typography(Typography.headline)
                 .foregroundStyle(.primary)
             


### PR DESCRIPTION
Addresses Copilot's review on #400. One of the four items turned out to be a real, actively-compounding bug rather than a nit.

## The changelog structure bug (found while checking Copilot's report)

Every bot run spliced a brand-new `## DATE` header above whatever was left of the old file, carrying the preamble paragraph along verbatim as part of "the rest of the file." Two releases landing the same day produced two adjacent `## 2026-08-05` headers — confirmed on the live file, which by the time of this PR had **three** date sections and the preamble sandwiched between two of them.

Rewrote the update step in Python (was awk/sed): title, marker and preamble are now fixed and regenerated fresh each run rather than carried over, and a run whose date matches the existing top section merges into it instead of adding a second header. Verified offline against four scenarios — fresh file, next-day run, same-day run (the exact regression), and a third same-day run on top of that — each yields exactly one header per date and exactly one preamble.

Hand-repaired the current `CHANGELOG.md` to match.

## The other three, all straightforward

- Stray leftover doc-comment line above `nutritionDetailStrings()` from the #399 extraction (`toFoodItem()` already carries the real copy).
- `MealSummaryCard` and `MealCalendarRow` each trimmed `meal.name` twice in the same expression. Extracted a `displayTitle` computed property in both.

## Verification

Builds clean for iOS Simulator (iPhone 17 Pro Max / iOS 26.5). **Not re-verified on device** — the Swift changes are a comment deletion and a mechanical refactor with no behavior change from what #398/#399 already confirmed working, and the changelog fix was verified by simulating the bot's own merge logic offline against real file content rather than by running the app. Saying so explicitly rather than implying more than was done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)