### PR TITLE
Release: unknown risk state for unassessable foods (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- changelog:last_sha=ff0a7ef16e2cf8b38fbf607f057bc20d2ab288b2 -->
+<!-- changelog:last_sha=f53fe0141b95ee900d566cf36ae9740aa677cdcd -->
 
 All notable changes to GutCheck, newest first. Each section is dated by the day
 the work reached `main`.
@@ -10,6 +10,9 @@ New sections are prepended automatically after every successful CI run on
 before editing this file by hand.
 
 ## 2026-08-07
+
+- fix: address Copilot review on #400 and repair CHANGELOG.md structure (#401) (3156286)
+- docs(changelog): update after successful CI on main [skip ci] (dd3931e)
 
 ### Fixed
 - Meal lists showed the meal type ("Lunch") instead of the saved name, so two lunches on the same day were indistinguishable. The save confirmation also appeared over a form the app had already cleared, which read as a failure (#363)

--- a/GutCheck/GutCheck/Models/Core/MealRiskModels.swift
+++ b/GutCheck/GutCheck/Models/Core/MealRiskModels.swift
@@ -11,16 +11,26 @@ import SwiftUI
 // MARK: - Risk Level
 
 enum MealRiskLevel: String, Hashable, CaseIterable {
+    /// Nothing to analyse — no ingredients, no compounds, no history.
+    ///
+    /// Distinct from `.low`, which means the food *was* analysed and came back
+    /// clean. Collapsing the two is how a Big Mac scored a green 0 and read as
+    /// "No known risk factors": the app had no idea what was in it.
+    case unknown
     case low
     case moderate
     case high
 
     var displayName: String {
-        rawValue.capitalized
+        switch self {
+        case .unknown: return "Unknown"
+        default: return rawValue.capitalized
+        }
     }
 
     var icon: String {
         switch self {
+        case .unknown: return "questionmark.circle.fill"
         case .low: return "checkmark.shield.fill"
         case .moderate: return "exclamationmark.triangle.fill"
         case .high: return "xmark.shield.fill"
@@ -29,11 +39,14 @@ enum MealRiskLevel: String, Hashable, CaseIterable {
 
     var color: Color {
         switch self {
+        // Deliberately not green. Unknown is not reassurance.
+        case .unknown: return ColorTheme.secondaryText
         case .low: return ColorTheme.success
         case .moderate: return ColorTheme.warning
         case .high: return ColorTheme.error
         }
     }
+
 }
 
 // MARK: - Risk Data Source
@@ -42,6 +55,10 @@ enum RiskDataSource: String, Hashable {
     case historicalCorrelation
     case compoundAnalysis
     case combined
+    /// Nothing was available to assess — no history, no compounds, no
+    /// ingredients. Distinct from `.compoundAnalysis`, which claims a compound
+    /// analysis actually ran and found nothing.
+    case insufficientData
 }
 
 // MARK: - Food Item Risk Detail

--- a/GutCheck/GutCheck/Services/FoodCompoundDatabase.swift
+++ b/GutCheck/GutCheck/Services/FoodCompoundDatabase.swift
@@ -87,6 +87,62 @@ struct CompositeFood {
     let description: String
 }
 
+extension FoodCompoundDatabase {
+
+    /// Well-known menu items mapped to the generic food words the composite
+    /// table actually matches on.
+    ///
+    /// Composite matching is substring-based on words like "burger" and
+    /// "sandwich". Branded names contain none of them, so a Big Mac matched
+    /// nothing, inferred no ingredients, and came out the far end with an
+    /// empty profile and a reassuring zero risk score.
+    ///
+    /// This is a maintenance treadmill by nature — it only ever covers what is
+    /// listed. It is a floor, not a solution: the real fix is using the
+    /// ingredient text the search APIs already return, tracked separately.
+    ///
+    /// Every value here must be a keyword an actual `CompositeFood` matches.
+    /// Aliasing to a composite that does not exist (a "breakfast sandwich"
+    /// entry, say) looks like coverage while doing nothing — the same species
+    /// of silent gap this table exists to close. Anything without a real
+    /// target is deliberately left out: unmapped branded items now fall
+    /// through to an honest "unknown" rather than a false zero, so an
+    /// incomplete table is merely incomplete, not misleading.
+    static let brandedNameAliases: [String: String] = [
+        // → "burger"
+        "big mac": "burger",
+        "quarter pounder": "burger",
+        "whopper": "burger",
+        "baconator": "burger",
+        "mcdouble": "burger",
+        "dave's single": "burger",
+        // → "taco"
+        "crunchwrap": "taco",
+        "chalupa": "taco",
+        "gordita": "taco",
+        // → "ice cream"
+        "frosty": "ice cream",
+        "blizzard": "ice cream",
+        "mcflurry": "ice cream",
+        // → "fries"
+        "world famous fries": "fries",
+        "curly fries": "fries",
+        // → "hot dog"
+        "chili dog": "hot dog",
+        "coney": "hot dog"
+    ]
+
+    /// Appends the generic equivalent of any branded menu name found in `text`,
+    /// leaving the original intact so both can match.
+    static func expandBrandedName(_ text: String) -> String {
+        var expanded = text
+        for (brandedName, generic) in brandedNameAliases where text.contains(brandedName) {
+            expanded += " \(generic)"
+        }
+        return expanded
+    }
+}
+
 // MARK: - Food Compound Database
 
 class FoodCompoundDatabase {
@@ -913,8 +969,12 @@ class FoodCompoundDatabase {
     /// Get likely ingredients for a food item (including breaking down composite foods)
     func getIngredientsForFood(name: String, providedIngredients: [String]) -> [String] {
         var allIngredients = providedIngredients
-        let searchText = name.lowercased()
-        
+        // Menu names are matched first and folded into the search text, so a
+        // "Big Mac" can reach the burger composite that "big mac (mcdonalds)"
+        // otherwise misses entirely — composite matching is substring-based on
+        // generic food words, which branded names simply don't contain.
+        let searchText = Self.expandBrandedName(name.lowercased())
+
         // Check if this is a composite food we know about
         for compositeFood in compositeFoods {
             for keyword in compositeFood.keywords {

--- a/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
+++ b/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
@@ -78,8 +78,16 @@ import Foundation
             itemRisks.append(detail)
         }
 
-        let overallScore = computeOverallScore(from: itemRisks)
-        let overallLevel = riskLevel(for: overallScore)
+        // Unknown items carry no score, so they are excluded from the maths
+        // rather than counted as zeros — averaging them in would drag a risky
+        // meal's score down purely because one item couldn't be assessed.
+        let assessable = itemRisks.filter { $0.riskLevel != .unknown }
+        let overallScore = computeOverallScore(from: assessable)
+
+        let overallLevel: MealRiskLevel = assessable.isEmpty && !itemRisks.isEmpty
+            ? .unknown
+            : riskLevel(for: overallScore)
+
         let explanation = generateOverallExplanation(itemRisks: itemRisks, overallLevel: overallLevel)
 
         return MealRiskAssessment(
@@ -139,7 +147,16 @@ import Foundation
                 medCount: medCompounds.count,
                 compounds: compounds
             )
+        } else if item.ingredients.isEmpty {
+            // Nothing was analysed: no history, no compounds, and no ingredient
+            // list to derive compounds from. Reporting 0 here is what let a Big
+            // Mac read as "No known risk factors" — the app simply had no idea
+            // what was in it. Say so instead.
+            score = 0
+            dataSource = .insufficientData
+            explanation = "No ingredient data for \(item.name), so its risk can't be assessed"
         } else {
+            // Genuinely analysed and came back clean.
             score = 0
             dataSource = .compoundAnalysis
             explanation = "No known risk factors for \(item.name)"
@@ -147,11 +164,13 @@ import Foundation
 
         score = min(100, max(0, score))
 
+        let isUnknown = matchedPattern == nil && compounds.isEmpty && item.ingredients.isEmpty
+
         return FoodItemRiskDetail(
             id: UUID(),
             foodName: item.name,
             riskScore: score,
-            riskLevel: riskLevel(for: score),
+            riskLevel: isUnknown ? .unknown : riskLevel(for: score),
             explanation: explanation,
             matchedTriggerPattern: matchedPattern,
             flaggedCompounds: compounds,
@@ -212,17 +231,27 @@ import Foundation
     private func generateOverallExplanation(itemRisks: [FoodItemRiskDetail], overallLevel: MealRiskLevel) -> String {
         let highCount = itemRisks.filter { $0.riskLevel == .high }.count
         let modCount = itemRisks.filter { $0.riskLevel == .moderate }.count
+        let unknownCount = itemRisks.filter { $0.riskLevel == .unknown }.count
+
+        // Any unassessable item is worth saying out loud, whatever the rest of
+        // the meal scored — otherwise a confident-looking score quietly rests
+        // on incomplete data.
+        let caveat = unknownCount > 0
+            ? " \(unknownCount) item(s) couldn't be assessed."
+            : ""
 
         switch overallLevel {
+        case .unknown:
+            return "No ingredient data for this meal, so its risk can't be assessed."
         case .high:
-            return "\(highCount) high-risk item(s) detected. Consider alternatives."
+            return "\(highCount) high-risk item(s) detected. Consider alternatives." + caveat
         case .moderate:
             if highCount > 0 {
-                return "\(highCount) high-risk and \(modCount) moderate-risk item(s) in this meal."
+                return "\(highCount) high-risk and \(modCount) moderate-risk item(s) in this meal." + caveat
             }
-            return "\(modCount) item(s) with moderate risk based on your history."
+            return "\(modCount) item(s) with moderate risk based on your history." + caveat
         case .low:
-            return "This meal looks safe based on your history."
+            return "This meal looks safe based on your history." + caveat
         }
     }
 }

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -421,31 +421,43 @@ struct UnifiedFoodDetailView: View {
             }
             
             // Ingredients
-            if !foodItem.ingredients.isEmpty {
-                Button(action: {
-                    detailService.showingIngredients = true
-                }) {
-                    DetailSectionRow(
-                        icon: "list.bullet",
-                        title: "Ingredients",
-                        subtitle: "\(foodItem.ingredients.count) ingredients"
-                    )
-                }
+            //
+            // Always shown, even when empty. Hiding the row made "we have no
+            // data" indistinguishable from "this food has no ingredients" —
+            // and IngredientsView already carries a written empty state that
+            // was unreachable because the row was removed before you could
+            // tap it.
+            Button(action: {
+                detailService.showingIngredients = true
+            }) {
+                DetailSectionRow(
+                    icon: "list.bullet",
+                    title: "Ingredients",
+                    subtitle: foodItem.ingredients.isEmpty
+                        ? "No ingredient data available"
+                        : "\(foodItem.ingredients.count) ingredients"
+                )
             }
-            
+
             // Allergens & Health Indicators
+            //
+            // Also always shown. An absent warnings section reads as "nothing
+            // to worry about", which is exactly the wrong message when the
+            // truth is that nothing could be checked.
             let totalWarnings = foodItem.allergens.count + healthIndicators.count
-            if totalWarnings > 0 {
-                Button(action: {
-                    detailService.showingAllergens = true
-                }) {
-                    DetailSectionRow(
-                        icon: "exclamationmark.triangle.fill",
-                        title: "Allergens & Warnings", 
-                        subtitle: getAllergensAndHealthSummary(),
-                        iconColor: ColorTheme.error
-                    )
-                }
+            Button(action: {
+                detailService.showingAllergens = true
+            }) {
+                DetailSectionRow(
+                    icon: totalWarnings > 0 ? "exclamationmark.triangle.fill" : "questionmark.circle",
+                    title: "Allergens & Warnings",
+                    subtitle: totalWarnings > 0
+                        ? getAllergensAndHealthSummary()
+                        : (foodItem.ingredients.isEmpty
+                            ? "Can't be checked without ingredient data"
+                            : "No warnings detected"),
+                    iconColor: totalWarnings > 0 ? ColorTheme.error : ColorTheme.secondaryText
+                )
             }
         }
     }

--- a/GutCheck/GutCheck/Views/Meal/MealRiskAssessmentCard.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealRiskAssessmentCard.swift
@@ -44,7 +44,9 @@ struct MealRiskAssessmentCard: View {
         .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
         .accessibilityIdentifier(AccessibilityIdentifiers.MealBuilder.riskAssessmentCard)
         .accessibleGroup(
-            label: "Risk Assessment: \(assessment.overallRiskLevel.displayName) risk, score \(assessment.overallRiskScore). \(assessment.overallExplanation)",
+            label: assessment.overallRiskLevel == .unknown
+                ? "Risk Assessment: unknown. \(assessment.overallExplanation)"
+                : "Risk Assessment: \(assessment.overallRiskLevel.displayName) risk, score \(assessment.overallRiskScore). \(assessment.overallExplanation)",
             hint: "Tap to \(isExpanded ? "collapse" : "expand") risk details"
         )
     }
@@ -79,7 +81,9 @@ struct MealRiskAssessmentCard: View {
     }
 
     private var riskScoreBadge: some View {
-        Text("\(assessment.overallRiskScore)")
+        // "?" rather than a number when nothing could be assessed — printing 0
+        // would assert a measurement the app never made.
+        Text(assessment.overallRiskLevel == .unknown ? "?" : "\(assessment.overallRiskScore)")
             .typography(Typography.headline)
             .foregroundStyle(.white)
             .frame(width: 40, height: 40)
@@ -136,7 +140,7 @@ struct MealRiskAssessmentCard: View {
                             .foregroundStyle(ColorTheme.primary)
                     }
 
-                    Text("\(itemRisk.riskScore)")
+                    Text(itemRisk.riskLevel == .unknown ? "?" : "\(itemRisk.riskScore)")
                         .typography(Typography.caption)
                         .foregroundStyle(itemRisk.riskLevel.color)
                         .bold()
@@ -150,13 +154,18 @@ struct MealRiskAssessmentCard: View {
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(itemRisk.foodName): \(itemRisk.riskLevel.displayName) risk, score \(itemRisk.riskScore). \(itemRisk.explanation)")
+        .accessibilityLabel(
+            itemRisk.riskLevel == .unknown
+            ? "\(itemRisk.foodName): risk unknown. \(itemRisk.explanation)"
+            : "\(itemRisk.foodName): \(itemRisk.riskLevel.displayName) risk, score \(itemRisk.riskScore). \(itemRisk.explanation)"
+        )
     }
 
     // MARK: - Styling
 
     private var cardBackgroundColor: Color {
         switch assessment.overallRiskLevel {
+        case .unknown: return ColorTheme.surface
         case .low: return ColorTheme.surface
         case .moderate: return ColorTheme.warning.opacity(0.05)
         case .high: return ColorTheme.error.opacity(0.05)
@@ -165,6 +174,7 @@ struct MealRiskAssessmentCard: View {
 
     private var borderColor: Color {
         switch assessment.overallRiskLevel {
+        case .unknown: return ColorTheme.border
         case .low: return ColorTheme.border
         case .moderate: return ColorTheme.warning.opacity(0.3)
         case .high: return ColorTheme.error.opacity(0.3)

--- a/GutCheck/GutCheckTests/BrandedFoodRiskTests.swift
+++ b/GutCheck/GutCheckTests/BrandedFoodRiskTests.swift
@@ -1,0 +1,139 @@
+//
+//  BrandedFoodRiskTests.swift
+//  GutCheckTests
+//
+//  A Big Mac scored 0 with "No known risk factors" — a green shield on one of
+//  the most trigger-dense items on any menu — because nothing about it could be
+//  analysed and the app reported that absence as safety.
+//
+
+import Testing
+@testable import GutCheck
+
+@Suite("Branded food name aliasing")
+struct BrandedNameAliasTests {
+
+    private func inferredIngredients(for name: String) -> [String] {
+        FoodCompoundDatabase.shared.getIngredientsForFood(name: name, providedIngredients: [])
+    }
+
+    @Test("A Big Mac resolves to burger ingredients")
+    func bigMacResolves() {
+        // The exact string the search API returns, which matched no composite
+        // keyword: "burger" does not appear anywhere in it.
+        let ingredients = inferredIngredients(for: "Big Mac (Mcdonalds)")
+
+        #expect(!ingredients.isEmpty, "expected burger ingredients, got none")
+        #expect(ingredients.contains { $0.contains("beef") })
+        #expect(ingredients.contains { $0.contains("bun") })
+    }
+
+    @Test("Other branded names resolve too")
+    func otherBrandedNames() {
+        #expect(!inferredIngredients(for: "Whopper").isEmpty)
+        #expect(!inferredIngredients(for: "Crunchwrap Supreme").isEmpty)
+        #expect(!inferredIngredients(for: "Frosty").isEmpty)
+    }
+
+    @Test("Every alias points at a composite that actually exists")
+    func aliasesHaveRealTargets() {
+        // An alias to a non-existent composite looks like coverage and does
+        // nothing — the same silent-gap failure this table exists to close.
+        // Caught two of these in review; this makes it impossible to reship.
+        for (branded, generic) in FoodCompoundDatabase.brandedNameAliases {
+            let resolved = inferredIngredients(for: branded)
+            #expect(
+                !resolved.isEmpty,
+                "alias '\(branded)' → '\(generic)' resolved to nothing; no composite matches '\(generic)'"
+            )
+        }
+    }
+
+    @Test("Aliasing does not disturb names that already matched")
+    func genericNamesUnaffected() {
+        let burger = inferredIngredients(for: "cheeseburger")
+
+        #expect(!burger.isEmpty)
+        #expect(burger.contains { $0.contains("beef") })
+    }
+
+    @Test("An unrecognised name still yields nothing rather than a wrong guess")
+    func unknownNameStaysUnknown() {
+        // Better to report "unknown" than to invent ingredients.
+        #expect(inferredIngredients(for: "Zzyzx Brand Mystery Item").isEmpty)
+    }
+}
+
+@Suite("Unknown vs low risk")
+@MainActor
+struct UnknownRiskTests {
+
+    private func item(name: String, ingredients: [String] = []) -> FoodItem {
+        FoodItem(name: name, quantity: "1 serving", ingredients: ingredients)
+    }
+
+    @Test("A food with no ingredient data is unknown, not low risk")
+    func noDataIsUnknown() throws {
+        let assessment = try #require(
+            MealRiskPredictionService.shared.predictRisk(for: [item(name: "Zzyzx Mystery Item")])
+        )
+
+        let detail = assessment.foodItemRisks[0]
+
+        // The bug: this reported .low with score 0 and a green shield.
+        #expect(detail.riskLevel == .unknown)
+        #expect(!detail.explanation.contains("No known risk factors"))
+    }
+
+    @Test("A food that was analysed and came back clean is still low risk")
+    func analysedCleanStaysLow() throws {
+        // Has ingredients, so it genuinely was assessed.
+        let assessment = try #require(
+            MealRiskPredictionService.shared.predictRisk(
+                for: [item(name: "Plain Water", ingredients: ["water"])]
+            )
+        )
+
+        #expect(assessment.foodItemRisks[0].riskLevel != .unknown)
+    }
+
+    @Test("Unknown items don't drag a risky meal's score down")
+    func unknownDoesNotDilute() throws {
+        let service = MealRiskPredictionService.shared
+
+        let riskyAlone = try #require(
+            service.predictRisk(for: [item(name: "Fries", ingredients: ["potatoes", "oil", "salt"])])
+        )
+        let riskyPlusUnknown = try #require(
+            service.predictRisk(for: [
+                item(name: "Fries", ingredients: ["potatoes", "oil", "salt"]),
+                item(name: "Zzyzx Mystery Item")
+            ])
+        )
+
+        // Adding an unassessable item must not make the meal look safer.
+        #expect(riskyPlusUnknown.overallRiskScore >= riskyAlone.overallRiskScore)
+    }
+
+    @Test("A meal of only unknown items is reported as unknown")
+    func whollyUnknownMeal() throws {
+        let assessment = try #require(
+            MealRiskPredictionService.shared.predictRisk(for: [item(name: "Zzyzx Mystery Item")])
+        )
+
+        #expect(assessment.overallRiskLevel == .unknown)
+        #expect(assessment.overallExplanation.contains("can't be assessed"))
+    }
+
+    @Test("An unassessable item is called out even when the rest scored")
+    func caveatSurfacedAlongsideScore() throws {
+        let assessment = try #require(
+            MealRiskPredictionService.shared.predictRisk(for: [
+                item(name: "Fries", ingredients: ["potatoes", "oil", "salt"]),
+                item(name: "Zzyzx Mystery Item")
+            ])
+        )
+
+        #expect(assessment.overallExplanation.contains("couldn't be assessed"))
+    }
+}


### PR DESCRIPTION
`main` has no commits `development` lacks. Two commits ship.

## Landing

- #403 — stop reporting 'no data' as 'no risk' (closes #356)
- b557f17 — the changelog bot's prior entry, carried along

## Why this one matters

A Big Mac scored **0, green shield, "No known risk factors"** — one of the most trigger-dense items on any menu, reported as clean, because the app had no idea what was in it and presented that absence as reassurance. For an app whose whole purpose is spotting dietary triggers, that was the worst available failure mode.

`MealRiskLevel` now separates `.unknown` from `.low`: analysed-and-clean versus nothing-to-analyse. Unknown renders grey with a `?` rather than a number, is excluded from the meal score instead of averaged in as a zero (which made risky meals look *safer*), and is named in the explanation even when the rest of the meal scored.

Ingredients and Allergens sections now always render with real empty states rather than vanishing — an absent warnings section reads as "nothing to worry about" when the truth is "nothing could be checked."

## Verification

Simulator, iPhone 17 Pro Max / iOS 26.5, original state reproduced first:

| | Before | After |
|---|---|---|
| Big Mac (Mcdonalds) | 0, green, "No known risk factors" | **48, amber, "1 item(s) with moderate risk"** |
| Tags | none | Dairy, High Sodium, Nightshade |

10 new tests pass. `Build and Test` and `Analyze (actions)` green on #403.

## Known limitation, stated plainly

The branded-name alias table is a floor, not a fix — it only covers what's listed. The real answer is using the ingredient text the search APIs already return. That's now safe to defer, because unmapped items fall through to an honest "unknown" rather than a false zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)