### PR TITLE
feat(risk): persist the meal risk assessment and surface it in history (#360)

### DIFF
--- a/GutCheck/GutCheck/Models/Core/MealRiskSnapshot.swift
+++ b/GutCheck/GutCheck/Models/Core/MealRiskSnapshot.swift
@@ -1,0 +1,160 @@
+//
+//  MealRiskSnapshot.swift
+//  GutCheck
+//
+//  Persisted record of the risk assessment a meal was given when it was logged.
+//
+
+import Foundation
+
+// MARK: - Meal Risk Snapshot
+
+/// What the app told the user about a meal's risk at the moment they saved it.
+///
+/// This is deliberately a *snapshot* rather than something recomputed when the
+/// meal is read back. Both inputs to the assessment move underneath us: the
+/// compound database grows with every release, and the user's trigger patterns
+/// shift as they log more symptoms. Recomputing would silently rewrite history —
+/// a meal the user was warned about could later read as safe, which is precisely
+/// the record you want intact when correlating meals against symptoms.
+///
+/// `schemaVersion` is the escape hatch. It marks which assessment the snapshot
+/// came from, so a future release that wants to re-score old meals can tell
+/// stale snapshots from current ones instead of guessing.
+///
+/// The domain types (`TriggerPattern`, `FoodCompound`) are intentionally *not*
+/// stored wholesale. They are live analysis models and change shape freely; a
+/// historical record that decodes only while those types stand still is not a
+/// record. Everything needed to redraw the assessment is flattened out here.
+struct MealRiskSnapshot: Codable, Hashable {
+
+    /// Bump when the meaning of a stored field changes, not merely when a field
+    /// is added — added fields decode as nil on old records already.
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+
+    /// `nil` when nothing in the meal could be assessed. Following the same rule
+    /// as `Meal.nutrition`: absence of data is stored as absence, never as a
+    /// zero, so a meal the app knew nothing about can't read back as a safe 0.
+    let overallRiskScore: Int?
+
+    /// Stored raw so an unrecognised value from a newer build degrades to
+    /// `.unknown` rather than failing the whole decode — matching how
+    /// `StoredMeal` keeps `typeRawValue`.
+    let overallRiskLevelRawValue: String
+
+    let overallExplanation: String
+    let assessedAt: Date
+    let hasHistoricalData: Bool
+    let foodItemRisks: [FoodItemRiskSnapshot]
+
+    var overallRiskLevel: MealRiskLevel {
+        // Unknown, not low. An unreadable level means we don't know what the
+        // user was told, which is not the same as having told them it was fine.
+        MealRiskLevel(rawValue: overallRiskLevelRawValue) ?? .unknown
+    }
+}
+
+// MARK: - Food Item Risk Snapshot
+
+/// The persisted form of a single `FoodItemRiskDetail`.
+struct FoodItemRiskSnapshot: Codable, Hashable {
+    /// Carried over from the live detail so re-rendering the same snapshot
+    /// keeps stable `ForEach` identity instead of churning on every read.
+    let id: UUID
+
+    let foodName: String
+
+    /// `nil` when the item could not be assessed. See `MealRiskSnapshot`.
+    let riskScore: Int?
+
+    let riskLevelRawValue: String
+    let explanation: String
+    let dataSourceRawValue: String
+
+    /// Names only. The full `FoodCompound` records live in a database that is
+    /// edited between releases; the names are what the user actually read.
+    let flaggedCompoundNames: [String]
+
+    /// The food whose history matched, when the score came from the user's own
+    /// data. Nil for compound-only or unassessed items.
+    let matchedTriggerFoodName: String?
+
+    var riskLevel: MealRiskLevel {
+        MealRiskLevel(rawValue: riskLevelRawValue) ?? .unknown
+    }
+
+    var dataSource: RiskDataSource {
+        // An unreadable source means we can't claim an analysis ran.
+        RiskDataSource(rawValue: dataSourceRawValue) ?? .insufficientData
+    }
+}
+
+// MARK: - Capture
+
+extension FoodItemRiskSnapshot {
+    init(_ detail: FoodItemRiskDetail) {
+        self.init(
+            id: detail.id,
+            foodName: detail.foodName,
+            // The live model represents "unassessed" as score 0 with level
+            // `.unknown`; the stored form drops the 0 so the distinction does
+            // not depend on a reader remembering to check the level first.
+            riskScore: detail.riskLevel == .unknown ? nil : detail.riskScore,
+            riskLevelRawValue: detail.riskLevel.rawValue,
+            explanation: detail.explanation,
+            dataSourceRawValue: detail.dataSource.rawValue,
+            flaggedCompoundNames: detail.flaggedCompounds.map(\.name),
+            matchedTriggerFoodName: detail.matchedTriggerPattern?.foodName
+        )
+    }
+}
+
+extension MealRiskSnapshot {
+    init(_ assessment: MealRiskAssessment) {
+        self.init(
+            schemaVersion: Self.currentSchemaVersion,
+            overallRiskScore: assessment.overallRiskLevel == .unknown ? nil : assessment.overallRiskScore,
+            overallRiskLevelRawValue: assessment.overallRiskLevel.rawValue,
+            overallExplanation: assessment.overallExplanation,
+            assessedAt: assessment.assessedAt,
+            hasHistoricalData: assessment.hasHistoricalData,
+            foodItemRisks: assessment.foodItemRisks.map(FoodItemRiskSnapshot.init)
+        )
+    }
+}
+
+// MARK: - Replay
+
+extension MealRiskSnapshot {
+    /// Rebuilds the assessment for display, so meal history renders through the
+    /// same `MealRiskAssessmentCard` the meal builder uses.
+    ///
+    /// `matchedTriggerPattern` comes back nil: the full pattern is not stored,
+    /// and reconstructing one from today's history would be exactly the silent
+    /// rewrite this type exists to prevent. The card reads `dataSource` to
+    /// decide whether to show the "from your history" marker, so nothing in the
+    /// rendering depends on the pattern itself.
+    var assessment: MealRiskAssessment {
+        MealRiskAssessment(
+            overallRiskScore: overallRiskScore ?? 0,
+            overallRiskLevel: overallRiskLevel,
+            foodItemRisks: foodItemRisks.map { snapshot in
+                FoodItemRiskDetail(
+                    id: snapshot.id,
+                    foodName: snapshot.foodName,
+                    riskScore: snapshot.riskScore ?? 0,
+                    riskLevel: snapshot.riskLevel,
+                    explanation: snapshot.explanation,
+                    matchedTriggerPattern: nil,
+                    flaggedCompounds: [],
+                    dataSource: snapshot.dataSource
+                )
+            },
+            overallExplanation: overallExplanation,
+            assessedAt: assessedAt,
+            hasHistoricalData: hasHistoricalData
+        )
+    }
+}

--- a/GutCheck/GutCheck/Models/Meal.swift
+++ b/GutCheck/GutCheck/Models/Meal.swift
@@ -61,6 +61,14 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, LocalRecord {
     var createdAt: Date = Date.now
     var updatedAt: Date = Date.now
 
+    /// The risk assessment the user was shown when this meal was saved.
+    ///
+    /// Optional, and nil for every meal logged before this was recorded — those
+    /// records genuinely have no assessment, and inventing one now by scoring
+    /// them against today's compound database would put words in the app's
+    /// mouth. The UI treats nil as "not recorded" rather than "no risk".
+    var riskSnapshot: MealRiskSnapshot?
+
     // MARK: - Privacy Classification
 
     /// How sensitive this meal is. Everything is stored on-device, so this no
@@ -92,7 +100,8 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, LocalRecord {
          foodItems: [FoodItem],
          notes: String? = nil,
          tags: [String] = [],
-         createdBy: String = "") {
+         createdBy: String = "",
+         riskSnapshot: MealRiskSnapshot? = nil) {
         self.id = id
         self.name = name
         self.date = date
@@ -102,6 +111,7 @@ struct Meal: Identifiable, Codable, Hashable, Equatable, LocalRecord {
         self.notes = notes
         self.tags = tags
         self.createdBy = createdBy
+        self.riskSnapshot = riskSnapshot
     }
 }
 

--- a/GutCheck/GutCheck/Models/Persistence/StoredMeal.swift
+++ b/GutCheck/GutCheck/Models/Persistence/StoredMeal.swift
@@ -36,6 +36,16 @@ final class StoredMeal {
     /// ingredient breakdown can run to several kilobytes.
     @Attribute(.externalStorage) var foodItemsData: Data
 
+    /// JSON-encoded `MealRiskSnapshot`, or nil when the meal carries no
+    /// assessment.
+    ///
+    /// Optional on purpose. Every row written before this property existed has
+    /// no value for it, and SwiftData's lightweight migration can only add a new
+    /// attribute without a rewrite if it is optional — a non-optional `Data`
+    /// would need a default that then reads back as "an assessment happened and
+    /// found nothing", which is the confusion this whole feature is fixing.
+    var riskSnapshotData: Data?
+
     init(
         id: String,
         name: String,
@@ -47,7 +57,8 @@ final class StoredMeal {
         createdBy: String,
         createdAt: Date,
         updatedAt: Date,
-        foodItemsData: Data
+        foodItemsData: Data,
+        riskSnapshotData: Data? = nil
     ) {
         self.id = id
         self.name = name
@@ -60,6 +71,7 @@ final class StoredMeal {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.foodItemsData = foodItemsData
+        self.riskSnapshotData = riskSnapshotData
     }
 }
 
@@ -78,7 +90,8 @@ extension StoredMeal {
             createdBy: meal.createdBy,
             createdAt: meal.createdAt,
             updatedAt: meal.updatedAt,
-            foodItemsData: PersistenceCoding.encode(meal.foodItems)
+            foodItemsData: PersistenceCoding.encode(meal.foodItems),
+            riskSnapshotData: meal.riskSnapshot.map(PersistenceCoding.encode)
         )
     }
 
@@ -96,6 +109,11 @@ extension StoredMeal {
         createdBy = meal.createdBy
         updatedAt = Date.now
         foodItemsData = PersistenceCoding.encode(meal.foodItems)
+        // Overwritten rather than merged: the snapshot describes a specific set
+        // of food items, and an edit that changed them would leave a retained
+        // old snapshot explaining food the meal no longer contains. Callers that
+        // edit a meal recompute; callers that round-trip one carry it through.
+        riskSnapshotData = meal.riskSnapshot.map(PersistenceCoding.encode)
     }
 
     var domainModel: Meal {
@@ -108,7 +126,13 @@ extension StoredMeal {
             foodItems: PersistenceCoding.decode([FoodItem].self, from: foodItemsData) ?? [],
             notes: notes,
             tags: tags,
-            createdBy: createdBy
+            createdBy: createdBy,
+            // Stays nil for meals logged before risk was recorded, and for a
+            // snapshot that no longer decodes — both mean "no assessment on
+            // file", which the UI shows as such rather than as a clean bill.
+            riskSnapshot: riskSnapshotData.flatMap {
+                PersistenceCoding.decode(MealRiskSnapshot.self, from: $0)
+            }
         )
         meal.createdAt = createdAt
         meal.updatedAt = updatedAt

--- a/GutCheck/GutCheck/Services/FoodDetailService.swift
+++ b/GutCheck/GutCheck/Services/FoodDetailService.swift
@@ -44,6 +44,7 @@ enum FoodDetailStyle {
     case standard       // Standard detail view
     case full          // Full detail with editing capabilities
     case nutrition     // Focus on nutrition information
+    case readOnly      // Full detail for an already-logged item: look, don't touch
 }
 
 /// Configuration for food detail presentation
@@ -92,6 +93,19 @@ struct FoodDetailConfig {
                 showServingControls: false,
                 showDetailedSections: false,
                 showCancelButton: false  // Nutrition views typically in navigation
+            )
+        case .readOnly:
+            // Viewing an item on a meal already in history. Ingredients and
+            // allergens are the point of opening it, so the detail sections
+            // stay; adding it to the meal being built, or re-scaling a serving
+            // that was already eaten, are not offered.
+            return FoodDetailConfig(
+                style: .readOnly,
+                showAddToMeal: false,
+                allowEditing: false,
+                showServingControls: false,
+                showDetailedSections: true,
+                showCancelButton: true  // Presented as a sheet from meal details
             )
         }
     }

--- a/GutCheck/GutCheck/Services/MealBuilderService.swift
+++ b/GutCheck/GutCheck/Services/MealBuilderService.swift
@@ -123,6 +123,13 @@ import Combine
         // Generate meal name if empty
         let finalMealName = mealName.isEmpty ? generateDefaultMealName() : mealName
         
+        // Captured at save time, not on read. The user has just been shown this
+        // assessment in the builder; the saved meal should say the same thing
+        // when they come back to it, however the compound database and their
+        // symptom history have moved on since. An edit recomputes, because the
+        // food items it describes have changed.
+        let riskSnapshot = MealRiskPredictionService.shared.riskSnapshot(for: currentMeal)
+
         let meal = Meal(
             id: editingMealId ?? UUID().uuidString,
             name: finalMealName,
@@ -132,9 +139,10 @@ import Combine
             foodItems: currentMeal,
             notes: notes.isEmpty ? nil : notes,
             tags: extractTags(),
-            createdBy: userId
+            createdBy: userId,
+            riskSnapshot: riskSnapshot
         )
-        
+
         
         try await mealRepository.save(meal)
         

--- a/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
+++ b/GutCheck/GutCheck/Services/MealRiskPredictionService.swift
@@ -100,6 +100,15 @@ import Foundation
         )
     }
 
+    /// The assessment for these items in the form stored with a saved meal.
+    ///
+    /// Callers save this alongside the meal so history shows what the user was
+    /// actually told, rather than re-scoring against a compound database and a
+    /// symptom history that will both have moved on by the time they look back.
+    func riskSnapshot(for foodItems: [FoodItem]) -> MealRiskSnapshot? {
+        predictRisk(for: foodItems).map(MealRiskSnapshot.init)
+    }
+
     // MARK: - Per-Food Assessment
 
     private func assessFoodItem(_ item: FoodItem) -> FoodItemRiskDetail {
@@ -185,11 +194,28 @@ import Foundation
         return min(75, raw)
     }
 
+    /// Worst item, plus a bump for each *additional* risky one.
+    ///
+    /// This replaces `0.6 × max + 0.4 × average`. Averaging made the score fall
+    /// when a harmless item was added — fries alone scored 54, fries next to a
+    /// plain glass of water scored less — which is backwards for a trigger
+    /// warning. Eating something safe alongside a trigger does not dilute the
+    /// trigger. #356 stopped *unassessable* items diluting; genuinely low-scoring
+    /// ones still did.
+    ///
+    /// The bump is capped so a plate of several mild items cannot creep past a
+    /// single genuinely severe one.
     private func computeOverallScore(from itemRisks: [FoodItemRiskDetail]) -> Int {
         guard !itemRisks.isEmpty else { return 0 }
-        let maxScore = itemRisks.map(\.riskScore).max() ?? 0
-        let avgScore = itemRisks.map(\.riskScore).reduce(0, +) / itemRisks.count
-        return min(100, Int(Double(maxScore) * 0.6 + Double(avgScore) * 0.4))
+        let scores = itemRisks.map(\.riskScore)
+        let maxScore = scores.max() ?? 0
+
+        // Only items that actually scored count towards compounding, so adding
+        // a zero-risk item leaves the meal's score untouched — never lower.
+        let additionalRiskyItems = max(0, scores.filter { $0 > 0 }.count - 1)
+        let compoundingBump = min(20, additionalRiskyItems * 5)
+
+        return min(100, maxScore + compoundingBump)
     }
 
     private func riskLevel(for score: Int) -> MealRiskLevel {

--- a/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/MealBuilderModelView.swift
@@ -150,7 +150,10 @@ import Foundation
                     foodItems: foodItems,
                     notes: notes.isEmpty ? nil : notes,
                     tags: extractTags(),
-                    createdBy: userId
+                    createdBy: userId,
+                    // Snapshot the assessment the user was shown, rather than
+                    // re-scoring later against a database that will have moved.
+                    riskSnapshot: MealRiskPredictionService.shared.riskSnapshot(for: foodItems)
                 )
                 
                 // Save to repository (using the new repository pattern)

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -761,6 +761,14 @@ struct MealCalendarRow: View {
                             .multilineTextAlignment(.leading)
                     }
 
+                    // Risk level as it stood when the meal was logged, so the
+                    // history is scannable without opening each entry. Absent —
+                    // not shown as "low" — for meals with no assessment on
+                    // file, which is not the same as one that found nothing.
+                    if let riskLevel = meal.riskSnapshot?.overallRiskLevel {
+                        riskBadge(riskLevel)
+                    }
+
                     // Per-meal macro breakdown, shown only when there's data.
                     if meal.nutrition.protein != nil || meal.nutrition.carbs != nil || meal.nutrition.fat != nil {
                         HStack(spacing: 14) {
@@ -784,6 +792,22 @@ struct MealCalendarRow: View {
         .disabled(isNavigating)
     }
     
+    private func riskBadge(_ level: MealRiskLevel) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: level.icon)
+                .font(.system(size: 11, weight: .semibold))
+            Text("\(level.displayName) risk")
+                .typography(Typography.caption)
+        }
+        .foregroundStyle(level.color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(level.color.opacity(0.12), in: Capsule())
+        .padding(.top, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(level.displayName) risk")
+    }
+
     // The name is what distinguishes two lunches on the same day. Fall back
     // to the meal type when there isn't one, or it's only whitespace.
     private var displayTitle: String {

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -41,7 +41,7 @@ struct UnifiedFoodDetailView: View {
         switch config.style {
         case .compact:
             compactView
-        case .standard, .full, .nutrition:
+        case .standard, .full, .nutrition, .readOnly:
             fullDetailView
         }
     }

--- a/GutCheck/GutCheck/Views/Meal/MealConfirmationViewModel.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealConfirmationViewModel.swift
@@ -32,6 +32,14 @@ import SwiftUI
         isSaving = true
         defer { isSaving = false }
         
+        // The meal arrives already built, so fill in the risk snapshot only when
+        // the caller didn't. Overwriting one that's already there would replace
+        // what the user was shown with a fresh score computed after the fact.
+        var meal = meal
+        if meal.riskSnapshot == nil {
+            meal.riskSnapshot = MealRiskPredictionService.shared.riskSnapshot(for: meal.foodItems)
+        }
+
         do {
             // Persist via MealRepository
             try await MealRepository.shared.save(meal)

--- a/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
+++ b/GutCheck/GutCheck/Views/Meal/MealDetailView.swift
@@ -5,7 +5,10 @@ struct MealDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppRouter.self) var router
     @Environment(RefreshManager.self) var refreshManager
-    
+
+    /// Non-nil while a food item's read-only detail sheet is up.
+    @State private var inspectingFoodItem: FoodItem?
+
     // New initializer that takes a meal ID
     init(mealId: String) {
         self._viewModel = State(wrappedValue: MealDetailViewModel(mealId: mealId))
@@ -69,11 +72,19 @@ struct MealDetailView: View {
         ScrollView {
             VStack(spacing: 24) {
                 mealHeaderSection
+                riskAssessmentSection
                 foodItemsSection
                 nutritionSummarySection
                 notesSection
             }
             .padding(.bottom, 80)
+        }
+        .sheet(item: $inspectingFoodItem) { foodItem in
+            // Read-only: this meal is already in history, so the sheet is for
+            // looking up what was in the item, not for editing it here.
+            UnifiedFoodDetailView(foodItem: foodItem, style: .readOnly)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         .navigationTitle("Meal Details")
         .navigationBarTitleDisplayMode(.inline)
@@ -124,6 +135,49 @@ struct MealDetailView: View {
         .padding(.horizontal)
     }
     
+    @ViewBuilder
+    private var riskAssessmentSection: some View {
+        if let snapshot = viewModel.meal.riskSnapshot {
+            // Replayed from what the user was shown when they logged the meal,
+            // not re-scored now — see `MealRiskSnapshot`.
+            MealRiskAssessmentCard(assessment: snapshot.assessment)
+                .padding(.horizontal)
+        } else if !viewModel.meal.foodItems.isEmpty {
+            // Logged before assessments were kept. Saying so beats either
+            // showing nothing or quietly scoring it against today's data.
+            noRiskRecordCard
+        }
+    }
+
+    private var noRiskRecordCard: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "questionmark.circle.fill")
+                .typography(Typography.title2)
+                .foregroundStyle(ColorTheme.secondaryText)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Risk Assessment")
+                    .typography(Typography.headline)
+                    .foregroundStyle(ColorTheme.primaryText)
+
+                Text("This meal was logged before risk assessments were saved, so none was recorded.")
+                    .typography(Typography.caption)
+                    .foregroundStyle(ColorTheme.secondaryText)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .background(ColorTheme.surface)
+        .clipShape(.rect(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(ColorTheme.border, lineWidth: 1.5)
+        )
+        .padding(.horizontal)
+        .accessibilityElement(children: .combine)
+    }
+
     @ViewBuilder
     private var foodItemsSection: some View {
         if !viewModel.meal.foodItems.isEmpty {
@@ -197,29 +251,46 @@ struct MealDetailView: View {
     // MARK: - UI Components
 
     private func foodItemRow(_ foodItem: FoodItem) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(foodItem.name)
-                    .typography(Typography.subheadline)
-                    .foregroundStyle(ColorTheme.primaryText)
-                
-                Text(foodItem.quantity)
+        Button {
+            HapticManager.shared.light()
+            inspectingFoodItem = foodItem
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(foodItem.name)
+                        .typography(Typography.subheadline)
+                        .foregroundStyle(ColorTheme.primaryText)
+
+                    Text(foodItem.quantity)
+                        .typography(Typography.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                Spacer()
+
+                if let calories = foodItem.nutrition.calories {
+                    Text("\(calories) calories")
+                        .typography(Typography.caption)
+                        .foregroundStyle(ColorTheme.secondaryText)
+                }
+
+                // The rows used to look identical to static text, so nobody
+                // knew there was anything behind them.
+                Image(systemName: "chevron.right")
                     .typography(Typography.caption)
-                    .foregroundStyle(ColorTheme.secondaryText)
+                    .foregroundStyle(ColorTheme.secondaryText.opacity(0.5))
             }
-            
-            Spacer()
-            
-            if let calories = foodItem.nutrition.calories {
-                Text("\(calories) calories")
-                    .typography(Typography.caption)
-                    .foregroundStyle(ColorTheme.secondaryText)
-            }
+            .padding()
+            .background(ColorTheme.surface)
+            .clipShape(.rect(cornerRadius: 12))
+            .contentShape(Rectangle())
         }
-        .padding()
-        .background(ColorTheme.surface)
-        .clipShape(.rect(cornerRadius: 12))
+        .buttonStyle(.plain)
         .padding(.horizontal)
+        .accessibleButton(
+            label: "\(foodItem.name), \(foodItem.quantity)",
+            hint: "Shows ingredients, allergens and nutrition for this item"
+        )
     }
     
     private func nutritionSummaryCard(nutrition: NutritionInfo) -> some View {

--- a/GutCheck/GutCheckTests/MealRiskSnapshotTests.swift
+++ b/GutCheck/GutCheckTests/MealRiskSnapshotTests.swift
@@ -1,0 +1,262 @@
+//
+//  MealRiskSnapshotTests.swift
+//  GutCheckTests
+//
+//  The risk assessment used to be computed while building a meal and dropped on
+//  save. These cover the persisted snapshot that replaced that — in particular
+//  that "couldn't assess it" survives the round trip as unknown rather than
+//  quietly arriving back as a reassuring zero.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import GutCheck
+
+@Suite("Meal risk snapshot persistence")
+@MainActor
+struct MealRiskSnapshotTests {
+
+    // MARK: - Fixtures
+
+    private func detail(
+        name: String,
+        score: Int,
+        level: MealRiskLevel,
+        source: RiskDataSource,
+        explanation: String = "because"
+    ) -> FoodItemRiskDetail {
+        FoodItemRiskDetail(
+            id: UUID(),
+            foodName: name,
+            riskScore: score,
+            riskLevel: level,
+            explanation: explanation,
+            matchedTriggerPattern: nil,
+            flaggedCompounds: [],
+            dataSource: source
+        )
+    }
+
+    private func assessment(_ details: [FoodItemRiskDetail], overall: Int, level: MealRiskLevel) -> MealRiskAssessment {
+        MealRiskAssessment(
+            overallRiskScore: overall,
+            overallRiskLevel: level,
+            foodItemRisks: details,
+            overallExplanation: "explanation",
+            assessedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            hasHistoricalData: true
+        )
+    }
+
+    private func meal(riskSnapshot: MealRiskSnapshot?) -> Meal {
+        Meal(
+            id: "meal-under-test",
+            name: "Test Meal",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .lunch,
+            source: .manual,
+            foodItems: [FoodItem(name: "Fries", quantity: "1 serving")],
+            createdBy: "tester",
+            riskSnapshot: riskSnapshot
+        )
+    }
+
+    /// Writes the meal to a real (in-memory) store and reads it back, so the
+    /// test exercises the SwiftData attribute rather than just the structs.
+    private func roundTripThroughStore(_ meal: Meal) throws -> Meal {
+        let container = try SwiftDataStack.inMemoryContainer()
+        let context = ModelContext(container)
+
+        context.insert(StoredMeal(meal))
+        try context.save()
+
+        let id = meal.id
+        let descriptor = FetchDescriptor<StoredMeal>(predicate: #Predicate { $0.id == id })
+        let stored = try #require(try context.fetch(descriptor).first)
+        return stored.domainModel
+    }
+
+    // MARK: - Round trip
+
+    @Test("A saved meal comes back with the score and per-item breakdown it had")
+    func snapshotSurvivesSave() throws {
+        let snapshot = MealRiskSnapshot(assessment(
+            [
+                detail(name: "Fries", score: 54, level: .moderate, source: .compoundAnalysis,
+                       explanation: "Fries contains Solanine, Trans Fats which may cause digestive issues"),
+                detail(name: "Water", score: 0, level: .low, source: .compoundAnalysis)
+            ],
+            overall: 54,
+            level: .moderate
+        ))
+
+        let loaded = try roundTripThroughStore(meal(riskSnapshot: snapshot))
+        let restored = try #require(loaded.riskSnapshot)
+
+        #expect(restored.overallRiskScore == 54)
+        #expect(restored.overallRiskLevel == .moderate)
+        #expect(restored.foodItemRisks.count == 2)
+        #expect(restored.foodItemRisks[0].foodName == "Fries")
+        #expect(restored.foodItemRisks[0].riskScore == 54)
+        #expect(restored.foodItemRisks[0].explanation.contains("Solanine"))
+        #expect(restored.foodItemRisks[0].dataSource == .compoundAnalysis)
+        #expect(restored.schemaVersion == MealRiskSnapshot.currentSchemaVersion)
+    }
+
+    @Test("Unknown stays unknown rather than round-tripping as a low-risk zero")
+    func unknownSurvivesAsUnknown() throws {
+        let snapshot = MealRiskSnapshot(assessment(
+            [detail(name: "Zzyzx Mystery Item", score: 0, level: .unknown, source: .insufficientData)],
+            overall: 0,
+            level: .unknown
+        ))
+
+        let loaded = try roundTripThroughStore(meal(riskSnapshot: snapshot))
+        let restored = try #require(loaded.riskSnapshot)
+
+        #expect(restored.overallRiskLevel == .unknown)
+        #expect(restored.overallRiskLevel != .low)
+        // Absent, not zero — the same rule `Meal.nutrition` follows.
+        #expect(restored.overallRiskScore == nil)
+
+        let item = try #require(restored.foodItemRisks.first)
+        #expect(item.riskLevel == .unknown)
+        #expect(item.riskScore == nil)
+        #expect(item.dataSource == .insufficientData)
+    }
+
+    @Test("An unknown item keeps its unknown level when replayed for the card")
+    func unknownSurvivesReplay() throws {
+        let snapshot = MealRiskSnapshot(assessment(
+            [
+                detail(name: "Fries", score: 54, level: .moderate, source: .compoundAnalysis),
+                detail(name: "Zzyzx Mystery Item", score: 0, level: .unknown, source: .insufficientData)
+            ],
+            overall: 54,
+            level: .moderate
+        ))
+
+        let replayed = try #require(try roundTripThroughStore(meal(riskSnapshot: snapshot)).riskSnapshot).assessment
+
+        #expect(replayed.overallRiskScore == 54)
+        #expect(replayed.overallRiskLevel == .moderate)
+        #expect(replayed.foodItemRisks[1].riskLevel == .unknown)
+        #expect(replayed.foodItemRisks[1].dataSource == .insufficientData)
+    }
+
+    @Test("Item identity is stable across reads so the list doesn't churn")
+    func itemIdentityIsStable() throws {
+        let original = detail(name: "Fries", score: 54, level: .moderate, source: .compoundAnalysis)
+        let snapshot = MealRiskSnapshot(assessment([original], overall: 54, level: .moderate))
+
+        let restored = try #require(try roundTripThroughStore(meal(riskSnapshot: snapshot)).riskSnapshot)
+
+        #expect(restored.foodItemRisks[0].id == original.id)
+    }
+
+    // MARK: - Existing records
+
+    @Test("A meal saved before risk was recorded still loads, with no assessment")
+    func preExistingMealLoads() throws {
+        // What every row already in the store looks like: no risk column value.
+        let loaded = try roundTripThroughStore(meal(riskSnapshot: nil))
+
+        #expect(loaded.riskSnapshot == nil)
+        #expect(loaded.name == "Test Meal")
+        #expect(loaded.foodItems.count == 1)
+    }
+
+    @Test("Decoding a Meal from JSON without the risk key succeeds")
+    func legacyJSONDecodes() throws {
+        // Meals are also encoded whole in a few places; an added optional must
+        // not make older payloads undecodable.
+        let json = """
+        {
+          "id": "legacy", "name": "Old Lunch", "date": 0, "type": "lunch",
+          "source": "manual", "foodItems": [], "tags": [], "createdBy": "",
+          "createdAt": 0, "updatedAt": 0
+        }
+        """
+        let decoded = try JSONDecoder().decode(Meal.self, from: Data(json.utf8))
+
+        #expect(decoded.riskSnapshot == nil)
+        #expect(decoded.name == "Old Lunch")
+    }
+
+    @Test("Unreadable stored bytes read as no assessment, not a clean bill")
+    func corruptSnapshotDegradesToNil() throws {
+        let stored = StoredMeal(meal(riskSnapshot: nil))
+        stored.riskSnapshotData = Data("not json".utf8)
+
+        #expect(stored.domainModel.riskSnapshot == nil)
+    }
+
+    // MARK: - Forward compatibility
+
+    @Test("A risk level this build doesn't know reads as unknown, not low")
+    func unrecognisedLevelIsUnknown() throws {
+        let json = """
+        {
+          "schemaVersion": 99,
+          "overallRiskLevelRawValue": "catastrophic",
+          "overallExplanation": "from a future build",
+          "assessedAt": 0,
+          "hasHistoricalData": false,
+          "foodItemRisks": [{
+            "id": "\(UUID().uuidString)",
+            "foodName": "Something",
+            "riskLevelRawValue": "catastrophic",
+            "explanation": "e",
+            "dataSourceRawValue": "telepathy",
+            "flaggedCompoundNames": []
+          }]
+        }
+        """
+        let snapshot = try JSONDecoder().decode(MealRiskSnapshot.self, from: Data(json.utf8))
+
+        #expect(snapshot.overallRiskLevel == .unknown)
+        #expect(snapshot.foodItemRisks[0].riskLevel == .unknown)
+        #expect(snapshot.foodItemRisks[0].dataSource == .insufficientData)
+    }
+}
+
+// MARK: - Aggregation
+
+@Suite("Meal risk aggregation")
+@MainActor
+struct MealRiskAggregationTests {
+
+    private let service = MealRiskPredictionService.shared
+
+    private func item(_ name: String, ingredients: [String] = []) -> FoodItem {
+        FoodItem(name: name, quantity: "1 serving", ingredients: ingredients)
+    }
+
+    @Test("Adding a zero-risk item never lowers the meal's score")
+    func safeItemDoesNotDilute() throws {
+        let fries = item("Fries", ingredients: ["potatoes", "oil", "salt"])
+        // Has ingredients, so it is genuinely assessed — and comes back clean.
+        let water = item("Plain Water", ingredients: ["water"])
+
+        let alone = try #require(service.predictRisk(for: [fries]))
+        let withSafeItem = try #require(service.predictRisk(for: [fries, water]))
+
+        #expect(withSafeItem.overallRiskScore >= alone.overallRiskScore)
+    }
+
+    @Test("A second risky item raises the score rather than averaging it away")
+    func riskyItemsCompound() throws {
+        let fries = item("Fries", ingredients: ["potatoes", "oil", "salt"])
+        let cheese = item("Cheddar Cheese", ingredients: ["milk", "cheese"])
+
+        let alone = try #require(service.predictRisk(for: [fries]))
+        let both = try #require(service.predictRisk(for: [fries, cheese]))
+
+        // Only meaningful if the second item actually scored.
+        let secondScored = both.foodItemRisks.dropFirst().contains { $0.riskScore > 0 }
+        if secondScored {
+            #expect(both.overallRiskScore > alone.overallRiskScore)
+        }
+    }
+}


### PR DESCRIPTION
Closes #360.

The risk assessment was computed while building a meal and discarded on save. Meal Details showed food names, calories and totals — no score, no per-item breakdown, no compound explanations — and the food rows weren't tappable, so ingredients and allergens were unreachable once the meal was logged.

## What changed

**`MealRiskSnapshot`** (`Models/Core/MealRiskSnapshot.swift`) — a versioned `Codable` record of the assessment, persisted with the meal.

It stores a *snapshot* rather than recomputing on read. Both inputs move underneath us: the compound database grows with every release, and trigger patterns shift as the user logs symptoms. Recomputing would silently rewrite history — a meal the user was warned about could later read as safe, which is exactly the record you want intact when correlating against symptoms. `schemaVersion` marks which assessment produced it so a future release can re-score old meals deliberately rather than by accident.

It deliberately does **not** store `TriggerPattern` / `FoodCompound` wholesale. Those are live analysis models that change shape freely; a historical record that only decodes while they stand still isn't a record. Everything needed to redraw the card is flattened out. `matchedTriggerPattern` comes back nil on replay — the card uses `dataSource` for the "from your history" marker, so nothing in the rendering depends on it.

**Persistence** — new optional `StoredMeal.riskSnapshotData`. Optional on purpose: existing rows have no value for it, and SwiftData's lightweight migration only adds an attribute without a rewrite if it's optional. A non-optional `Data` would need a default that reads back as "an assessment ran and found nothing", which is the confusion #356 just fixed. Verified against the simulator's existing store — the column was added in place and both pre-existing meals still load.

**The unknown/zero distinction is preserved end to end**, following the rule `Meal.nutrition` already uses:
- scores are stored `nil`, not `0`, when nothing could be assessed
- an unrecognised `riskLevelRawValue` decodes to `.unknown`, never `.low`
- an unrecognised `dataSourceRawValue` decodes to `.insufficientData`
- unreadable stored bytes read as "no assessment on file", not a clean bill
- meals with no snapshot show an explicit "logged before risk assessments were saved" card rather than nothing or a green zero

**UI** — Meal Details renders through the same `MealRiskAssessmentCard` the builder uses (collapsed summary, expandable per-item breakdown). Food rows now open `UnifiedFoodDetailView` read-only, via a new `.readOnly` `FoodDetailStyle` with no add-to-meal button and no serving controls, but detail sections kept — ingredients and allergens are the point of opening it. The Meals list row carries a risk-level pill; absent, not "low", when there's no snapshot.

## The aggregation: fixed, deliberately

`0.6 × max + 0.4 × avg` is replaced with:

```swift
let maxScore = scores.max() ?? 0
let additionalRiskyItems = max(0, scores.filter { $0 > 0 }.count - 1)
let compoundingBump = min(20, additionalRiskyItems * 5)
return min(100, maxScore + compoundingBump)
```

I fixed it here rather than deferring, because "adding a zero-risk item never decreases the meal's score" is one of #360's acceptance criteria and the change is small and testable. Only items that actually scored count towards the bump, so adding a safe food leaves the score untouched — never lower. #356 stopped *unassessable* items diluting; genuinely low-scoring ones still did. The bump is capped at 20 so a plate of mild items can't creep past a single severe one.

This is a judgement call worth flagging: the exact bump (5 per item, cap 20) is a reasonable default, not a calibrated one. Nothing in the repo calibrates these constants, so I matched the existing style of hand-picked weights.

## Verification

- **Compiled**: `xcodebuild build -project GutCheck.xcodeproj -scheme GutCheck` on **iPhone 17 Pro Max, iOS 26.5** (`B2B3417D-…`). CLAUDE.md names iPhone 16 Pro; it is not installed on this machine.
- **Unit tested**: 10 new tests in `GutCheckTests/MealRiskSnapshotTests.swift`, run locally with `-parallel-testing-enabled NO` — all pass. They cover the store round trip (real in-memory `ModelContainer`, not just the structs), `.unknown` surviving as `.unknown` with a nil score, stable item identity, a legacy `Meal` JSON payload without the risk key, corrupt bytes degrading to nil, an unrecognised level from a "future build" decoding to `.unknown`, and the aggregation monotonicity. CI does not run tests.
- **Simulator-verified** on iPhone 17 Pro Max / iOS 26.5, installed **over the existing store** so migration was exercised for real:
  - Logged a meal with Big Mac™ Bacon → builder showed **75, High**, "1 high-risk item(s) detected".
  - Saved, confirmed 620 bytes landed in `ZRISKSNAPSHOTDATA` while the two older rows stayed NULL.
  - Reopened from Meals → same **75**, same level, and the expanded card showed the same per-item line: "Big Mac™ Bacon contains Tyramine which may cause digestive issues".
  - Meals list row shows the **High risk** badge.
  - Tapping the food row opens the read-only detail with Ingredients (14) and Allergens & Warnings (7 allergens, 5 health indicators), no add-to-meal, no serving controls.
  - Opened a **pre-existing** meal saved before this change — loads fine, shows the "logged before risk assessments were saved" card.
  - Checked **light and dark**.

## Not done / notes

- Meals saved before this change are not back-filled. Scoring them against today's database would fabricate an assessment the user was never shown; they're marked as unrecorded instead.
- `StoredMeal.apply` overwrites the snapshot rather than merging. A snapshot describes a specific set of food items, so retaining an old one past an edit would explain food the meal no longer contains. All four save paths supply one; `MealDetailViewModel` round-trips the existing one.
- **Pre-existing test failures, unrelated to this branch**: `DashboardDataStoreTests` (known-racy, #382) and `MealDetailViewModelTests/"loadMeal with nil mealId does nothing"`. The latter is a genuine test bug — `MealDetailViewModel(meal:)` sets `mealId = meal.id`, which is never nil, so `loadMeal()` does fetch and `fetchCallCount` is 1. Nothing in this branch touches that file or `MealDetailViewModel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
