### PR TITLE
test: make the nil-mealId test actually exercise the nil branch

### DIFF
--- a/GutCheck/GutCheckTests/ViewModels/MealDetailViewModelTests.swift
+++ b/GutCheck/GutCheckTests/ViewModels/MealDetailViewModelTests.swift
@@ -72,9 +72,31 @@ struct MealDetailViewModelTests {
         let repo = MockMealRepository()
         let vm = MealDetailViewModel(meal: meal, mealRepository: repo)
 
+        // Both initialisers set a non-nil mealId, so the guard in loadMeal()
+        // can only be reached by clearing it. The original version of this test
+        // asserted no fetch straight after init(meal:) — which fetches — and so
+        // failed deterministically while appearing to cover the nil branch.
+        vm.mealId = nil
+
         await vm.loadMeal()
 
         #expect(repo.fetchCallCount == 0)
+    }
+
+    @Test("Init with Meal still loads, refreshing possibly-stale data")
+    func initWithMealRefetches() async {
+        let meal = makeMeal()
+        let repo = MockMealRepository()
+        let vm = MealDetailViewModel(meal: meal, mealRepository: repo)
+
+        await vm.loadMeal()
+
+        // Pinning current behaviour rather than asserting it is ideal. The meal
+        // is already in hand, so this round-trip is redundant on the face of it
+        // — but it also picks up edits made since the list was rendered, and
+        // MealDetailView.task calls it on this path today. Changing that is a
+        // product decision, not a test fix.
+        #expect(repo.fetchCallCount == 1)
     }
 
     @Test("loadMeal not found sets error")


### PR DESCRIPTION
`"loadMeal with nil mealId does nothing"` failed deterministically in isolation on `development`. Confirmed pre-existing and unrelated to recent work.

## What was wrong

The test built the view model with `init(meal:)`, which sets `self.mealId = meal.id` — never nil — then asserted `fetchCallCount == 0`. `loadMeal()`'s `guard let id = mealId` therefore always passed and always fetched. The test both **failed and covered nothing**: the branch it named was never reached.

Fixed by setting `vm.mealId = nil` before the call, so the guard is genuinely exercised.

## One premise in the brief doesn't hold

The task suggested `MealDetailView.task` already guards this init path so `loadMeal()` is never called on it in the app. It isn't so:

```swift
.task {
    if viewModel.mealId != nil {
        await viewModel.loadMeal()
    }
}
```

The guard is `!= nil`, and `init(meal:)` sets `mealId` non-nil — so opening a meal from history **does** re-fetch it today. The guard never suppresses anything, because *neither* initialiser can leave `mealId` nil.

## Why I didn't change production code

Given that, the "already-loaded meal shouldn't re-fetch" reading is a real product question, not a test bug — and one with an argument on each side. The round-trip is redundant on its face, but it also picks up edits made since the list was rendered, and `MealDetailView` relies on it today. Silently removing that inside a test fix would be changing behaviour under cover of a cleanup.

So I left `MealDetailViewModel` alone and added a second test pinning the current behaviour, so it's recorded deliberately rather than incidentally. If you do want the re-fetch gone, that's a small follow-up and the test now makes the change visible.

Worth noting `mealId` is declared `String?` and `loadMeal()` guards for nil, but no initialiser produces nil — so that guard is defensive-only. Keeping it covered is still worthwhile; it just needs a test that reaches it.

## Verification

- 17/17 `MealDetailViewModelTests` pass
- Build clean for iOS Simulator, iPhone 17 Pro Max / iOS 26.5 (CLAUDE.md names iPhone 16 Pro; that simulator is not installed)
- **Test-only change** — `git diff --stat` touches one test file, no production code

`DashboardDataStoreTests` failures ignored as instructed (known-racy, #382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
