### PR TITLE
Log foods at a real serving size instead of per 100 g (#359)

### DIFF
--- a/GutCheck/AccessibilityIdentifiers.swift
+++ b/GutCheck/AccessibilityIdentifiers.swift
@@ -101,7 +101,14 @@ enum AccessibilityIdentifiers {
             "foodSearch.result.\(index)"
         }
     }
-    
+
+    // MARK: - Food Detail
+    enum FoodDetail {
+        static let servingPicker = "foodDetail.serving.picker"
+        static let servingStepper = "foodDetail.serving.stepper"
+        static let servingSummary = "foodDetail.serving.summary"
+    }
+
     // MARK: - Symptom Logging
     enum SymptomLogger {
         static let view = "symptomLogger.view"

--- a/GutCheck/GutCheck/Models/FoodItem.swift
+++ b/GutCheck/GutCheck/Models/FoodItem.swift
@@ -32,7 +32,26 @@ struct FoodItem: Identifiable, Codable, Hashable, Equatable {
     var source: FoodInputSource = .manual
     var barcodeValue: String? = nil      // If scanned via barcode
     var isUserEdited: Bool = false       // Indicates manual override
-    
+
+    // MARK: - Serving size
+    //
+    // All three are optional so that meals written before serving selection
+    // existed still decode: the synthesised decoder skips a missing optional
+    // but throws on a missing non-optional, and `foodItems` is stored as a
+    // JSON blob inside `StoredMeal`.
+
+    /// Portions this food can be logged as, as offered by the search source.
+    var servingOptions: [ServingOption]? = nil
+
+    /// The portion `nutrition` and `nutritionDetails` currently describe.
+    /// `nil` for items that predate serving selection or come from a source
+    /// that named no portion at all.
+    var selectedServing: ServingOption? = nil
+
+    /// How many of `selectedServing` this item is. Kept as its own field
+    /// rather than being read back out of `quantity`, which is display text.
+    var servingCount: Double? = nil
+
     init(
         id: String = UUID().uuidString,
         name: String,
@@ -44,7 +63,10 @@ struct FoodItem: Identifiable, Codable, Hashable, Equatable {
         source: FoodInputSource = .manual,
         barcodeValue: String? = nil,
         isUserEdited: Bool = false,
-        nutritionDetails: [String: String] = [:]
+        nutritionDetails: [String: String] = [:],
+        servingOptions: [ServingOption]? = nil,
+        selectedServing: ServingOption? = nil,
+        servingCount: Double? = nil
     ) {
         self.id = id
         self.name = name
@@ -57,5 +79,14 @@ struct FoodItem: Identifiable, Codable, Hashable, Equatable {
         self.barcodeValue = barcodeValue
         self.isUserEdited = isUserEdited
         self.nutritionDetails = nutritionDetails
+        self.servingOptions = servingOptions
+        self.selectedServing = selectedServing
+        self.servingCount = servingCount
+    }
+
+    /// The weight `nutrition` currently describes, when it is known.
+    var servingGrams: Double? {
+        guard let selectedServing else { return estimatedWeightInGrams }
+        return selectedServing.gramWeight * (servingCount ?? 1)
     }
 }

--- a/GutCheck/GutCheck/Models/Nutrition/OpenFoodFactsModels.swift
+++ b/GutCheck/GutCheck/Models/Nutrition/OpenFoodFactsModels.swift
@@ -33,6 +33,14 @@ struct OpenFoodFactsProduct: Codable, Identifiable {
     let allergensTags: [String]?
     let tracesTags: [String]?
 
+    /// Net weight of the whole product, e.g. 220 for a Big Mac.
+    ///
+    /// For a single-serve item this *is* the portion, and it is often the only
+    /// weight a record carries — plenty of fast-food entries declare no
+    /// `serving_size` at all.
+    let productQuantity: LenientDouble?
+    let productQuantityUnit: String?
+
     private enum CodingKeys: String, CodingKey {
         case id = "code"
         case productName = "product_name"
@@ -46,6 +54,18 @@ struct OpenFoodFactsProduct: Codable, Identifiable {
         case traces
         case allergensTags = "allergens_tags"
         case tracesTags = "traces_tags"
+        case productQuantity = "product_quantity"
+        case productQuantityUnit = "product_quantity_unit"
+    }
+
+    /// Whole-product weight in grams, or `nil` when the record gives none or
+    /// measures it in something other than grams.
+    var productWeightInGrams: Double? {
+        guard let grams = productQuantity?.value, grams > 0 else { return nil }
+        // `product_quantity_unit` is absent on older records, which by
+        // OpenFoodFacts convention means grams.
+        let unit = (productQuantityUnit ?? "g").lowercased()
+        return unit == "g" ? grams : nil
     }
 
     /// Ingredient text in English when available, falling back to whatever
@@ -198,5 +218,32 @@ struct OpenFoodFactsSearchResponse: Codable {
         case products, count, page
         case pageCount = "page_count"
         case pageSize = "page_size"
+    }
+}
+// MARK: - Lenient Numbers
+
+/// A number OpenFoodFacts may have written as either a JSON number or a string.
+///
+/// Contributors enter these fields by hand through several different clients,
+/// so `"product_quantity": 220` and `"product_quantity": "220"` both occur in
+/// the same search response. Decoding as `Double?` throws on the second form
+/// and takes the whole product down with it.
+struct LenientDouble: Codable, Hashable {
+    let value: Double?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let number = try? container.decode(Double.self) {
+            value = number
+        } else if let text = try? container.decode(String.self) {
+            value = Double(text.trimmingCharacters(in: .whitespaces))
+        } else {
+            value = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
     }
 }

--- a/GutCheck/GutCheck/Models/ServingSize.swift
+++ b/GutCheck/GutCheck/Models/ServingSize.swift
@@ -1,0 +1,195 @@
+//
+//  ServingSize.swift
+//  GutCheck
+//
+//  Portions a food can be logged as, and the rules for picking a sensible
+//  default from what a search source offers.
+//
+//  Both food sources report nutrition against 100 g and describe real portions
+//  separately — USDA in `foodMeasures` ("1 McDonald's Big Mac", 205 g),
+//  OpenFoodFacts in `serving_size`/`product_quantity`. Logging everything at
+//  100 g recorded 46% of a Big Mac (#359). Portion size is one of the stronger
+//  predictors of a post-meal symptom, so the correlation engine cares about
+//  this at least as much as the calorie count does.
+//
+
+import Foundation
+
+// MARK: - Serving Option
+
+/// A portion a food can be logged as, together with what it weighs.
+///
+/// Both halves matter. The label is what a person recognises ("1 medium fast
+/// food order"); the weight is what the nutrition maths and any later trigger
+/// analysis actually use. Showing them together keeps the choice auditable —
+/// a user can see that "1 medium" meant 145 g and disagree with it.
+struct ServingOption: Codable, Hashable, Identifiable {
+
+    /// How the source names this portion, e.g. "1 McDonald's Big Mac".
+    let label: String
+
+    /// What that portion weighs. Always greater than zero.
+    let gramWeight: Double
+
+    /// Stable across a rebuild of the same list, so SwiftUI selection survives
+    /// a redraw. Two options with the same name and weight *are* the same
+    /// option as far as picking goes.
+    var id: String { "\(label)|\(gramWeight)" }
+
+    /// Fails rather than storing a portion that cannot be used: an empty label
+    /// gives the user nothing to choose, and a zero or negative weight would
+    /// divide the nutrition maths by zero.
+    init?(label: String, gramWeight: Double) {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, gramWeight > 0, gramWeight.isFinite else { return nil }
+        self.label = trimmed
+        self.gramWeight = gramWeight
+    }
+
+    /// A plain weight portion — the fallback offered when a source describes no
+    /// household measures at all.
+    static func grams(_ grams: Double) -> ServingOption? {
+        ServingOption(label: "\(formattedWeight(grams)) g", gramWeight: grams)
+    }
+
+    /// "1 McDonald's Big Mac · 205 g", but just "100 g" when the label is
+    /// already a weight — repeating it as "100 g · 100 g" reads as a bug.
+    ///
+    /// The same suppression covers volumes: an OpenFoodFacts serving of
+    /// "25 ml" is stored with a gram weight because that is what the nutrition
+    /// scaling needs, but printing "25 ml · 25 g" would assert a density the
+    /// source never gave.
+    var displayName: String {
+        labelIsAQuantity ? label : "\(label) · \(Self.formattedWeight(gramWeight)) g"
+    }
+
+    /// How this portion reads on a food row: "2 × 1 medium fast food order · 290 g".
+    ///
+    /// The count is folded into the printed weight so the row always states the
+    /// total actually being logged, not the weight of one unit.
+    func quantityDescription(count: Double) -> String {
+        let total = gramWeight * count
+        let weight = "\(Self.formattedWeight(total)) g"
+
+        guard count != 1 else {
+            return labelIsAQuantity ? label : "\(label) · \(weight)"
+        }
+
+        let countText = count.formatted(.number.precision(.fractionLength(0...2)))
+        return "\(countText) × \(label) · \(weight)"
+    }
+
+    /// True when the label is nothing but a number and a unit ("100 g", "25 ml").
+    private var labelIsAQuantity: Bool {
+        label.range(
+            of: #"^\d+(\.\d+)?\s*(g|kg|mg|ml|cl|l|oz|fl oz|lb)$"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
+    }
+
+    /// Whole grams for anything a kitchen scale would show whole, one decimal
+    /// for the small stuff (a single shoestring fry is 2 g).
+    static func formattedWeight(_ grams: Double) -> String {
+        let digits = grams < 10 ? 0...1 : 0...0
+        return grams.formatted(.number.precision(.fractionLength(digits)).grouping(.never))
+    }
+}
+
+// MARK: - Resolver
+
+/// Turns the raw portions a source hands over into a list worth showing, and
+/// picks which one to start on.
+enum ServingSizeResolver {
+
+    /// Portion words that appear in both food names and measure names.
+    /// "McDonald's, French Fries, Medium" and "1 medium fast food order" are
+    /// the same portion said twice, and the issue is explicit that restaurant
+    /// sizes must map to their real weights rather than a 100 g baseline.
+    private static let sizeWords: Set<String> = [
+        "small", "medium", "large", "regular", "kids", "child", "junior", "jumbo"
+    ]
+
+    /// Words that carry no identity, so matching on them would pair a food with
+    /// an unrelated measure.
+    private static let ignoredWords: Set<String> = [
+        "the", "and", "with", "raw", "nfs", "yields", "quantity", "not",
+        "specified", "shape", "cut", "any", "each", "serving", "servings",
+        "prepared", "cooked", "included"
+    ]
+
+    /// Deduplicates and orders the portions for display.
+    ///
+    /// Ascending weight rather than source order: sources rank measures by
+    /// their own internal conventions (USDA's `rank` puts "1 fry" first), and a
+    /// list that runs small to large is the one a person can scan.
+    static func normalize(_ options: [ServingOption]) -> [ServingOption] {
+        var seen = Set<String>()
+        return options
+            .filter { seen.insert($0.id).inserted }
+            .sorted { $0.gramWeight < $1.gramWeight }
+    }
+
+    /// Picks the portion to start on.
+    ///
+    /// - Parameters:
+    ///   - name: the food's own name, which often states the portion.
+    ///   - options: the normalized list the user can choose from.
+    ///   - preferredGrams: a weight the source itself treats as one portion
+    ///     when it names no portion — USDA's "Quantity not specified" measure.
+    /// - Returns: the default, or `nil` when nothing in the list is a better
+    ///   guess than the source's own baseline.
+    static func defaultOption(
+        forFoodNamed name: String,
+        from options: [ServingOption],
+        preferredGrams: Double? = nil
+    ) -> ServingOption? {
+        guard !options.isEmpty else { return nil }
+
+        let nameWords = words(in: name)
+
+        // 1. The name already states a size. "Medium" in the name and
+        //    "1 medium fast food order" in the measures are the same thing, and
+        //    nothing else in the list should outrank that.
+        if let sized = options.first(where: { option in
+            !sizeWords.isDisjoint(with: words(in: option.label).intersection(nameWords))
+        }) {
+            return sized
+        }
+
+        // 2. Otherwise prefer the measure that names this food. A Big Mac's
+        //    measures also list a Mac Jr and a Grand Mac; only one of the three
+        //    is what was searched for.
+        let named = options
+            .map { (option: $0, score: words(in: $0.label).intersection(nameWords).count) }
+            .filter { $0.score > 0 }
+        if let best = named.max(by: { left, right in
+            if left.score != right.score { return left.score < right.score }
+            // Same amount of name in both: side with whatever weight the source
+            // itself calls one portion.
+            return distance(left.option, from: preferredGrams) > distance(right.option, from: preferredGrams)
+        }) {
+            return best.option
+        }
+
+        // 3. Nothing matched by name, so fall back to the measure that weighs
+        //    what the source treats as one portion. Exact match only — a
+        //    "nearest weight" rule would happily return a single fry.
+        if let preferredGrams {
+            return options.first { abs($0.gramWeight - preferredGrams) < 0.5 }
+        }
+
+        return nil
+    }
+
+    private static func distance(_ option: ServingOption, from grams: Double?) -> Double {
+        guard let grams else { return 0 }
+        return abs(option.gramWeight - grams)
+    }
+
+    /// Lowercased words of three or more letters, minus the ones that say
+    /// nothing about which food this is.
+    private static func words(in text: String) -> Set<String> {
+        let parts = text.lowercased().split { !$0.isLetter && !$0.isNumber }
+        return Set(parts.map(String.init).filter { $0.count >= 3 && !ignoredWords.contains($0) })
+    }
+}

--- a/GutCheck/GutCheck/Models/ServingSize.swift
+++ b/GutCheck/GutCheck/Models/ServingSize.swift
@@ -68,11 +68,21 @@ struct ServingOption: Codable, Hashable, Identifiable {
     /// The count is folded into the printed weight so the row always states the
     /// total actually being logged, not the weight of one unit.
     func quantityDescription(count: Double) -> String {
+        // Volume labels never get a gram suffix, at any count. "2 × 25 ml · 50 g"
+        // asserts a density the source never gave — the same reason
+        // `displayName` omits it. This guard used to apply only when count was
+        // 1, so the claim reappeared the moment the stepper moved.
+        guard !labelIsAQuantity else {
+            guard count != 1 else { return label }
+            let countText = count.formatted(.number.precision(.fractionLength(0...2)))
+            return "\(countText) × \(label)"
+        }
+
         let total = gramWeight * count
         let weight = "\(Self.formattedWeight(total)) g"
 
         guard count != 1 else {
-            return labelIsAQuantity ? label : "\(label) · \(weight)"
+            return "\(label) · \(weight)"
         }
 
         let countText = count.formatted(.number.precision(.fractionLength(0...2)))

--- a/GutCheck/GutCheck/Services/FoodSearchModels.swift
+++ b/GutCheck/GutCheck/Services/FoodSearchModels.swift
@@ -31,7 +31,20 @@ struct FoodSearchResult: Identifiable, Codable {
     let servingUnit: String?
     let servingQty: Double?
     let servingWeight: Double?
-    
+
+    /// Real portions this food can be logged as, smallest first.
+    ///
+    /// Sources describe these separately from the nutrition they report, and
+    /// the app used to throw them away — which is how a Big Mac came to be
+    /// logged as 100 g (#359). Empty means the source offered nothing beyond
+    /// its own baseline.
+    let servingOptions: [ServingOption]
+
+    /// Which of `servingOptions` to start on, already resolved by the source
+    /// service — it is the only place that knows how to read that source's
+    /// idea of a default portion.
+    let defaultServing: ServingOption?
+
     // Ingredients
     let ingredients: String?
 
@@ -119,6 +132,8 @@ struct FoodSearchResult: Identifiable, Codable {
         servingUnit: String? = nil,
         servingQty: Double? = nil,
         servingWeight: Double? = nil,
+        servingOptions: [ServingOption] = [],
+        defaultServing: ServingOption? = nil,
         ingredients: String? = nil,
         declaredAllergens: [String] = [],
         saturatedFat: Double? = nil,
@@ -184,6 +199,8 @@ struct FoodSearchResult: Identifiable, Codable {
         self.servingUnit = servingUnit
         self.servingQty = servingQty
         self.servingWeight = servingWeight
+        self.servingOptions = servingOptions
+        self.defaultServing = defaultServing
         self.ingredients = ingredients
         self.declaredAllergens = declaredAllergens
         self.saturatedFat = saturatedFat
@@ -306,14 +323,18 @@ struct FoodSearchResult: Identifiable, Codable {
     /// conversions. `NutritionDetailsView` looks these labels up directly, so
     /// a second hand-rolled dictionary drifts out of sync and silently drops
     /// nutrients — which is exactly what #362 turned out to be.
-    func nutritionDetailStrings() -> [String: String] {
+    /// - Parameter factor: multiplies every nutrient on the way out, for
+    ///   callers logging a portion other than the one the source reported.
+    ///   Applied here rather than to the finished strings so the conversion
+    ///   still happens once, on the typed value.
+    func nutritionDetailStrings(scaledBy factor: Double = 1) -> [String: String] {
         var nutritionDetails: [String: String] = [:]
 
         // Grams stay grams; anything labelled mg/mcg is converted first so the
         // number and suffix agree.
         func addDetail(_ label: String, _ value: Double?, unit: String, formatter: (Double) -> String = Self.amount) {
             guard let value else { return }
-            nutritionDetails[label] = "\(formatter(value))\(unit)"
+            nutritionDetails[label] = "\(formatter(value * factor))\(unit)"
         }
 
         addDetail("Calories", calories, unit: "kcal")
@@ -357,22 +378,33 @@ struct FoodSearchResult: Identifiable, Codable {
         return nutritionDetails
     }
 
-    /// Convert to FoodItem for logging meals
-    func toFoodItem(quantity: String? = nil) -> FoodItem {
-        let finalQuantity = quantity ?? {
-            if let servingQty = servingQty, let servingUnit = servingUnit {
-                return "\(servingQty) \(servingUnit)"
-            }
-            return "1 serving"
-        }()
+    // MARK: - Serving size
 
-        return FoodItem(
-            name: brand != nil ? "\(brand!) \(name)" : name,
-            quantity: finalQuantity,
-            estimatedWeightInGrams: servingWeight,
-            ingredients: IngredientTextParser.split(ingredients),
-            allergens: declaredAllergens,
-            nutrition: NutritionInfo(
+    /// The weight the stored nutrition figures describe.
+    ///
+    /// Both services normalise their per-100 g source data to a per-serving
+    /// figure before building a result, so this is `servingWeight` when the
+    /// source declared one and the 100 g the APIs report against otherwise.
+    var baseServingGrams: Double {
+        guard let servingWeight, servingWeight > 0 else { return 100 }
+        return servingWeight
+    }
+
+    /// What to multiply the stored figures by to log `serving` of this food.
+    /// `nil` means "leave them as the source reported them".
+    func scaleFactor(for serving: ServingOption?, count: Double = 1) -> Double {
+        guard let serving else { return count }
+        return (serving.gramWeight * count) / baseServingGrams
+    }
+
+    /// The macro summary, scaled the same way `nutritionDetailStrings` is.
+    ///
+    /// Shares the unit decisions with the detail dictionary — in particular
+    /// sodium crossing from grams to milligrams — so a caller that builds both
+    /// cannot get one right and the other wrong.
+    func nutritionInfo(scaledBy factor: Double = 1) -> NutritionInfo {
+        NutritionScaling.scaled(
+            NutritionInfo(
                 calories: calories.map { Int($0) },
                 protein: protein,
                 carbs: carbs,
@@ -381,8 +413,40 @@ struct FoodSearchResult: Identifiable, Codable {
                 sugar: sugar,
                 sodium: sodiumMilligrams
             ),
+            by: factor
+        )
+    }
+
+    /// Convert to FoodItem for logging meals.
+    ///
+    /// Defaults to `defaultServing` — the source's own idea of one portion —
+    /// rather than the 100 g it happens to report nutrition against.
+    func toFoodItem(quantity: String? = nil) -> FoodItem {
+        let serving = defaultServing
+        let factor = scaleFactor(for: serving)
+
+        let finalQuantity = quantity ?? {
+            if let serving {
+                return serving.quantityDescription(count: 1)
+            }
+            if let servingQty, let servingUnit {
+                return "\(servingQty) \(servingUnit)"
+            }
+            return "1 serving"
+        }()
+
+        return FoodItem(
+            name: brand != nil ? "\(brand!) \(name)" : name,
+            quantity: finalQuantity,
+            estimatedWeightInGrams: serving?.gramWeight ?? servingWeight,
+            ingredients: IngredientTextParser.split(ingredients),
+            allergens: declaredAllergens,
+            nutrition: nutritionInfo(scaledBy: factor),
             source: .manual,
-            nutritionDetails: nutritionDetailStrings()
+            nutritionDetails: nutritionDetailStrings(scaledBy: factor),
+            servingOptions: servingOptions,
+            selectedServing: serving,
+            servingCount: serving.map { _ in 1 }
         )
     }
 }

--- a/GutCheck/GutCheck/Services/NutritionScaling.swift
+++ b/GutCheck/GutCheck/Services/NutritionScaling.swift
@@ -1,0 +1,63 @@
+//
+//  NutritionScaling.swift
+//  GutCheck
+//
+//  Scales an already-built food item's nutrition to a different portion.
+//
+//  `FoodSearchResult` can rescale before it builds anything, because it still
+//  holds typed numbers. By the time a `FoodItem` exists the micronutrients are
+//  strings in `nutritionDetails`, and the serving picker has to move those too
+//  — before this existed, doubling the serving doubled Calories while
+//  Saturated Fat and every vitamin stayed put.
+//
+
+import Foundation
+
+enum NutritionScaling {
+
+    /// Units whose value scales with the portion.
+    ///
+    /// Deliberately a *format* rule rather than a list of nutrient labels.
+    /// `nutritionDetails` also carries non-nutrient entries — "brand" is written
+    /// straight into it — and a second copy of the label vocabulary is exactly
+    /// what drifted out of sync in #362. Anything that is not a bare number
+    /// followed by one of these units is left alone.
+    private static let scalableUnits: Set<String> = ["g", "mg", "mcg", "kcal"]
+
+    static func scaled(_ nutrition: NutritionInfo, by factor: Double) -> NutritionInfo {
+        NutritionInfo(
+            // Rounded rather than truncated: 261 kcal at 2.05 servings is
+            // 535.05, and `Int()` would report that as 535 by luck and 534 the
+            // moment the factor moved a hair the other way.
+            calories: nutrition.calories.map { Int((Double($0) * factor).rounded()) },
+            protein: nutrition.protein.map { $0 * factor },
+            carbs: nutrition.carbs.map { $0 * factor },
+            fat: nutrition.fat.map { $0 * factor },
+            fiber: nutrition.fiber.map { $0 * factor },
+            sugar: nutrition.sugar.map { $0 * factor },
+            sodium: nutrition.sodium.map { $0 * factor }
+        )
+    }
+
+    /// Scales every `"<number><unit>"` entry, leaving everything else untouched.
+    static func scaled(_ details: [String: String], by factor: Double) -> [String: String] {
+        details.mapValues { scaledValue($0, by: factor) }
+    }
+
+    private static func scaledValue(_ value: String, by factor: Double) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+
+        guard let numberRange = trimmed.range(of: #"^[0-9][0-9.,]*"#, options: .regularExpression) else {
+            return value
+        }
+
+        let unit = trimmed[numberRange.upperBound...].trimmingCharacters(in: .whitespaces)
+        guard scalableUnits.contains(unit.lowercased()) else { return value }
+        guard let number = NutrientValueParser.number(from: String(trimmed[numberRange])) else { return value }
+
+        // Written back through the same formatter that produced it, so the
+        // fixed `en_US_POSIX` separator convention `NutrientValueParser`
+        // depends on survives the round trip.
+        return "\(FoodSearchResult.amount(number * factor))\(unit)"
+    }
+}

--- a/GutCheck/GutCheck/Services/OpenFoodFactsService.swift
+++ b/GutCheck/GutCheck/Services/OpenFoodFactsService.swift
@@ -100,6 +100,12 @@ class OpenFoodFactsService {
         // Pre-calculate nutrition values to help compiler
         let brandName = product.brands?.components(separatedBy: ",").first?.trimmingCharacters(in: .whitespacesAndNewlines)
         let productNameSafe = product.productName ?? "Unknown Product"
+
+        let servings = servingOptions(
+            for: product,
+            baseGrams: servingQty,
+            baseUnit: servingUnit
+        )
         
         // Basic macronutrients
         let calories = nutriments?.energyKcal100g.map { $0 * multiplier }
@@ -153,6 +159,8 @@ class OpenFoodFactsService {
             servingUnit: servingUnit,
             servingQty: servingQty,
             servingWeight: servingQty,
+            servingOptions: servings.options,
+            defaultServing: servings.defaultOption,
             ingredients: product.bestIngredientsText,
             declaredAllergens: product.normalizedAllergens,
             saturatedFat: saturatedFat,
@@ -183,6 +191,97 @@ class OpenFoodFactsService {
         )
     }
     
+    // MARK: - Serving sizes
+
+    /// Heaviest whole product still treated as one portion when the record
+    /// declares no serving size.
+    ///
+    /// A judgement call, and the reason it exists: fast-food records routinely
+    /// carry only `product_quantity` (a Big Mac is 220 g with no serving size),
+    /// and defaulting those to 100 g is the bug in #359. Above this a package
+    /// is far more likely to be a jar or a bag that nobody eats in one sitting,
+    /// where guessing "the whole thing" would be the larger error. The picker
+    /// still offers the whole package either way.
+    private static let maxSingleServingPackageGrams: Double = 500
+
+    /// Reads the portions an OpenFoodFacts record offers.
+    ///
+    /// - Parameter baseGrams: the weight the caller has already scaled this
+    ///   product's nutrition to, offered as the fallback choice.
+    private func servingOptions(
+        for product: OpenFoodFactsProduct,
+        baseGrams: Double,
+        baseUnit: String
+    ) -> (options: [ServingOption], defaultOption: ServingOption?) {
+
+        var options: [ServingOption] = []
+
+        // The record's declared serving, kept as written ("30 g", "1 biscuit
+        // (25 g)") so the user sees the source's own words.
+        let declaredServing = product.servingSize
+            .flatMap { text -> ServingOption? in
+                guard let grams = Self.weightInGrams(from: text) else { return nil }
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // A record that writes its serving size as a bare "219" gets a
+                // unit added; keeping it verbatim renders as "219 · 219 g".
+                return trimmed.contains(where: \.isLetter)
+                    ? ServingOption(label: trimmed, gramWeight: grams)
+                    : ServingOption.grams(grams)
+            }
+        if let declaredServing { options.append(declaredServing) }
+
+        let wholePackage = product.productWeightInGrams
+            .flatMap { ServingOption(label: "Whole package", gramWeight: $0) }
+        if let wholePackage { options.append(wholePackage) }
+
+        // The baseline the nutrition was scaled to — usually 100 g, and always
+        // available as an escape hatch. Labelled in the source's own unit so a
+        // drink measured in millilitres is not silently relabelled as grams.
+        let baselineWeight = baseGrams > 0 ? baseGrams : 100
+        let baseline = ServingOption(
+            label: "\(ServingOption.formattedWeight(baselineWeight)) \(baseUnit)",
+            gramWeight: baselineWeight
+        )
+        if let baseline { options.append(baseline) }
+
+        let normalized = ServingSizeResolver.normalize(options)
+
+        // Declared serving first — it is the source stating what one portion
+        // is. Otherwise the whole package, but only when it is small enough to
+        // plausibly be one. Failing both, the baseline, so the picker always
+        // shows the portion the figures actually describe.
+        let defaultOption: ServingOption? = declaredServing
+            ?? wholePackage.flatMap { $0.gramWeight <= Self.maxSingleServingPackageGrams ? $0 : nil }
+            ?? baseline
+
+        return (normalized, defaultOption)
+    }
+
+    /// Grams from a free-text weight, or `nil` when the text names a unit that
+    /// is not a weight.
+    ///
+    /// A bare number is read as grams: OpenFoodFacts records a serving size of
+    /// `"219"` for the European Big Mac, and that is what the contributor meant.
+    /// Volumes are rejected rather than assumed to weigh the same — a serving
+    /// option prints its gram weight, and printing one for millilitres would
+    /// assert a density the record never gave.
+    static func weightInGrams(from text: String) -> Double? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pattern = #"^(\d+(?:[.,]\d+)?)\s*([a-zA-Z]*)"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)),
+              let numberRange = Range(match.range(at: 1), in: trimmed),
+              let unitRange = Range(match.range(at: 2), in: trimmed),
+              let value = Double(String(trimmed[numberRange]).replacingOccurrences(of: ",", with: ".")),
+              value > 0
+        else { return nil }
+
+        let unit = String(trimmed[unitRange]).lowercased()
+        let gramUnits: Set<String> = ["", "g", "gr", "gram", "grams", "gramme", "grammes"]
+        return gramUnits.contains(unit) ? value : nil
+    }
+
     // Helper method to parse serving size strings like "100g", "1 cup", "30 ml"
     private func parseServingSize(_ servingSize: String) -> (quantity: Double, unit: String) {
         let trimmed = servingSize.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/GutCheck/GutCheck/Services/USDAFoodService.swift
+++ b/GutCheck/GutCheck/Services/USDAFoodService.swift
@@ -102,6 +102,8 @@ class USDAFoodService {
             .capitalized
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
+        let servings = servingOptions(for: food, name: name, servingQty: servingQty, servingUnit: servingUnit)
+
         return FoodSearchResult(
             id: String(food.fdcId),
             name: name,
@@ -118,6 +120,8 @@ class USDAFoodService {
             servingUnit: servingUnit,
             servingQty: servingQty,
             servingWeight: servingQty,
+            servingOptions: servings.options,
+            defaultServing: servings.defaultOption,
             ingredients: food.ingredients,
             // Additional fats (g/100g)
             saturatedFat: grams(1258),
@@ -178,6 +182,72 @@ class USDAFoodService {
             theobromine: fromMg(1058)
         )
     }
+
+    // MARK: - Serving sizes
+
+    /// The text FNDDS uses for the measure that carries its default portion
+    /// weight without naming a portion. Useless as a label, but its weight is
+    /// the best hint available for which named measure to start on.
+    private static let unnamedMeasureText = "quantity not specified"
+
+    /// Reads the portions a USDA record offers.
+    ///
+    /// `foodMeasures` is where the useful portions live and it is the same
+    /// search response the app already fetches — no extra request. Survey
+    /// (FNDDS) foods, which is what a restaurant item resolves to, carry
+    /// entries like "1 McDonald's Big Mac" at 205 g while reporting nutrition
+    /// per 100 g. Branded foods instead declare `servingSize` plus a household
+    /// description, so both are folded in.
+    private func servingOptions(
+        for food: USDAFood,
+        name: String,
+        servingQty: Double,
+        servingUnit: String
+    ) -> (options: [ServingOption], defaultOption: ServingOption?) {
+
+        let measures = food.foodMeasures ?? []
+
+        // The weight the source itself treats as one portion, when it says so.
+        let unnamedGrams = measures.first {
+            $0.disseminationText?.lowercased().trimmingCharacters(in: .whitespaces) == Self.unnamedMeasureText
+        }?.gramWeight
+
+        var options: [ServingOption] = measures.compactMap { measure in
+            guard let text = measure.disseminationText,
+                  text.lowercased().trimmingCharacters(in: .whitespaces) != Self.unnamedMeasureText,
+                  let grams = measure.gramWeight
+            else { return nil }
+            return ServingOption(label: text, gramWeight: grams)
+        }
+
+        // A branded record's own serving: "1 ONZ" or "3 pieces" at a declared
+        // weight. Only trustworthy when the unit is grams — `servingSize` can
+        // be millilitres, and the nutrition scaling already assumes water
+        // density there without this making a second claim about it.
+        if servingUnit == "g", servingQty > 0, servingQty != 100,
+           let household = food.householdServingFullText,
+           let option = ServingOption(label: household, gramWeight: servingQty) {
+            options.append(option)
+        }
+
+        // Grams is always available as an escape hatch, and doubles as the
+        // baseline that used to be the only choice.
+        let baseline = ServingOption.grams(servingQty > 0 ? servingQty : 100)
+        if let baseline { options.append(baseline) }
+
+        let normalized = ServingSizeResolver.normalize(options)
+
+        // Falling back to the baseline rather than to nothing keeps the picker
+        // and the logged figures in agreement: an unselected picker next to a
+        // portion the app chose anyway is the confusing state.
+        let defaultOption = ServingSizeResolver.defaultOption(
+            forFoodNamed: name,
+            from: normalized,
+            preferredGrams: unnamedGrams
+        ) ?? baseline
+
+        return (normalized, defaultOption)
+    }
 }
 
 // MARK: - Errors
@@ -224,7 +294,18 @@ struct USDAFood: Codable {
     let servingSize: Double?
     let servingSizeUnit: String?
     let householdServingFullText: String?
+
+    /// Household portions with their gram weights — "1 McDonald's Big Mac",
+    /// 205 g. Present on Survey (FNDDS) records and empty on most others.
+    let foodMeasures: [USDAFoodMeasure]?
+
     let foodNutrients: [USDAFoodNutrient]
+}
+
+struct USDAFoodMeasure: Codable {
+    /// How the portion reads, e.g. "1 medium fast food order".
+    let disseminationText: String?
+    let gramWeight: Double?
 }
 
 struct USDAFoodNutrient: Codable {

--- a/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
+++ b/GutCheck/GutCheck/ViewModels/Meal/FoodSearchViewModel.swift
@@ -71,15 +71,22 @@ import Combine
     }
     
     private func createEnhancedFoodItem(from nfood: FoodSearchResult) -> FoodItem {
+        // The portion to log, and how far the source's figures have to move to
+        // describe it. `defaultServing` is the source's own idea of one
+        // portion; when it has none the figures stay as reported.
+        let serving = nfood.defaultServing
+        let servingFactor = nfood.scaleFactor(for: serving)
+
         // Extract serving information
         let servingQty = nfood.servingQty ?? 1.0
         let servingUnit = nfood.servingUnit ?? "serving"
-        let servingWeightGrams = nfood.servingWeight
-        
+        let servingWeightGrams = serving?.gramWeight ?? nfood.servingWeight
+
         // Create quantity string
-        let quantityString = "\(servingQty.formatted(.number)) \(servingUnit)"
-        
-        // Parse ingredients from Nutritionix ingredients string  
+        let quantityString = serving?.quantityDescription(count: 1)
+            ?? "\(servingQty.formatted(.number)) \(servingUnit)"
+
+        // Parse ingredients from Nutritionix ingredients string
         let ingredientList: [String] = parseIngredients(from: nfood.ingredients)
         
         // Nutrition details come from FoodSearchResult.nutritionDetailStrings(),
@@ -91,7 +98,7 @@ import Combine
         // "Calcium"/"calcium". Nothing matched, so Vitamins & Minerals was
         // always empty for searched foods — and magnesium, zinc, selenium and
         // the B vitamins were never written at all.
-        var nutritionDict = nfood.nutritionDetailStrings()
+        var nutritionDict = nfood.nutritionDetailStrings(scaledBy: servingFactor)
 
         if let brand = nfood.brand {
             nutritionDict["brand"] = brand
@@ -104,17 +111,11 @@ import Combine
         let detected = detectAllergens(from: nfood.name, brand: nfood.brand, ingredients: ingredientList)
         let allergens = Array(Set(nfood.declaredAllergens + detected)).sorted()
         
-        // Create main nutrition info for easy access
-        let nutrition = NutritionInfo(
-            calories: nfood.calories.map { Int($0) },
-            protein: nfood.protein,
-            carbs: nfood.carbs,
-            fat: nfood.fat,
-            fiber: nfood.fiber,
-            sugar: nfood.sugar,
-            sodium: nfood.sodiumMilligrams
-        )
-        
+        // Main nutrition info, scaled the same way the detail dictionary above
+        // was. Built by the result itself so the two cannot disagree about
+        // units — sodium in particular crosses grams to milligrams here.
+        let nutrition = nfood.nutritionInfo(scaledBy: servingFactor)
+
         let foodItem = FoodItem(
             id: nfood.id,
             name: nfood.name,
@@ -125,7 +126,10 @@ import Combine
             nutrition: nutrition,
             source: .manual,
             isUserEdited: false,
-            nutritionDetails: nutritionDict
+            nutritionDetails: nutritionDict,
+            servingOptions: nfood.servingOptions.isEmpty ? nil : nfood.servingOptions,
+            selectedServing: serving,
+            servingCount: serving.map { _ in 1 }
         )
         
         // Enrich with ingredient breakdown analysis

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -34,28 +34,51 @@ struct UnifiedFoodDetailView: View {
     init(foodItem: FoodItem, style: FoodDetailStyle = .standard, onUpdate: ((FoodItem) -> Void)? = nil) {
         self._foodItem = State(initialValue: foodItem)
         self.config = FoodDetailConfig.config(for: style)
-        self.baseNutrition = foodItem.nutrition
-        self.baseDetails = foodItem.nutritionDetails
-        self.baseQuantity = foodItem.quantity
         self._customQuantity = State(initialValue: foodItem.quantity)
         self.onUpdate = onUpdate
 
         let options = foodItem.servingOptions ?? []
         self.servingOptions = options
         self._selectedServing = State(initialValue: foodItem.selectedServing)
-        self.baseGrams = foodItem.servingGrams
+
+        // Everything below rescales from `baseNutrition`/`baseQuantity`, so both
+        // must describe *one* unit. An item logged before `servingCount` existed
+        // encoded its multiplier into the quantity string ("2.0 × 100 g") and
+        // saved the already-multiplied nutrition alongside it. Reading the
+        // multiplier back without also dividing the figures out would rescale an
+        // already-scaled item — a 2× item nudged to 2.1 became 4.2× — and rebuild
+        // the string as "2.1 × 2.0 × 100 g".
+        var legacyMultiplier: Double?
+        if foodItem.servingCount == nil,
+           foodItem.quantity.contains("×"),
+           let head = foodItem.quantity.components(separatedBy: "×").first?
+               .trimmingCharacters(in: .whitespaces),
+           let parsed = Double(head), parsed > 0 {
+            legacyMultiplier = parsed
+        }
 
         if let count = foodItem.servingCount {
             self._servingMultiplier = State(initialValue: count)
-        } else if foodItem.quantity.contains("×") {
-            // Items logged before `servingCount` existed encoded the multiplier
-            // into the quantity string as "2.0 × …". Read it back so reopening
-            // one does not silently reset it to a single serving.
-            let components = foodItem.quantity.components(separatedBy: "×")
-            if let multiplierString = components.first?.trimmingCharacters(in: .whitespaces),
-               let detectedMultiplier = Double(multiplierString) {
-                self._servingMultiplier = State(initialValue: detectedMultiplier)
-            }
+        } else if let legacyMultiplier {
+            self._servingMultiplier = State(initialValue: legacyMultiplier)
+        }
+
+        if let legacyMultiplier {
+            // Divide back out to per-unit, and strip the multiplier from the
+            // quantity so the rebuilt string doesn't nest.
+            self.baseNutrition = NutritionScaling.scaled(foodItem.nutrition, by: 1 / legacyMultiplier)
+            self.baseDetails = NutritionScaling.scaled(foodItem.nutritionDetails, by: 1 / legacyMultiplier)
+            self.baseQuantity = foodItem.quantity
+                .components(separatedBy: "×")
+                .dropFirst()
+                .joined(separator: "×")
+                .trimmingCharacters(in: .whitespaces)
+            self.baseGrams = foodItem.servingGrams.map { $0 / legacyMultiplier }
+        } else {
+            self.baseNutrition = foodItem.nutrition
+            self.baseDetails = foodItem.nutritionDetails
+            self.baseQuantity = foodItem.quantity
+            self.baseGrams = foodItem.servingGrams
         }
     }
     

--- a/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
+++ b/GutCheck/GutCheck/Views/Components/UnifiedFoodDetailView.swift
@@ -13,22 +13,44 @@ struct UnifiedFoodDetailView: View {
     @State private var customQuantity: String = ""
     @State private var detailService = FoodDetailService.shared
     
+    /// The portion the view is currently showing. `nil` for foods whose source
+    /// named no portions — a hand-entered custom food — where the stepper falls
+    /// back to being a bare multiplier of whatever was passed in.
+    @State private var selectedServing: ServingOption?
+
     private let config: FoodDetailConfig
     private let baseNutrition: NutritionInfo
+    private let baseDetails: [String: String]
     private let baseQuantity: String
+    private let servingOptions: [ServingOption]
+
+    /// The weight `baseNutrition` describes. Everything is rescaled from this
+    /// rather than from the previous selection, so switching back and forth
+    /// between two servings returns the original numbers instead of drifting.
+    private let baseGrams: Double?
+
     private let onUpdate: ((FoodItem) -> Void)?
-    
+
     init(foodItem: FoodItem, style: FoodDetailStyle = .standard, onUpdate: ((FoodItem) -> Void)? = nil) {
         self._foodItem = State(initialValue: foodItem)
         self.config = FoodDetailConfig.config(for: style)
         self.baseNutrition = foodItem.nutrition
+        self.baseDetails = foodItem.nutritionDetails
         self.baseQuantity = foodItem.quantity
         self._customQuantity = State(initialValue: foodItem.quantity)
         self.onUpdate = onUpdate
-        
-        // Try to detect if this is already an adjusted serving size
-        // Look for the "× " pattern in the quantity string
-        if foodItem.quantity.contains("×") {
+
+        let options = foodItem.servingOptions ?? []
+        self.servingOptions = options
+        self._selectedServing = State(initialValue: foodItem.selectedServing)
+        self.baseGrams = foodItem.servingGrams
+
+        if let count = foodItem.servingCount {
+            self._servingMultiplier = State(initialValue: count)
+        } else if foodItem.quantity.contains("×") {
+            // Items logged before `servingCount` existed encoded the multiplier
+            // into the quantity string as "2.0 × …". Read it back so reopening
+            // one does not silently reset it to a single serving.
             let components = foodItem.quantity.components(separatedBy: "×")
             if let multiplierString = components.first?.trimmingCharacters(in: .whitespaces),
                let detectedMultiplier = Double(multiplierString) {
@@ -124,8 +146,11 @@ struct UnifiedFoodDetailView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
-        .onChange(of: servingMultiplier) { _, newValue in
-            updateNutritionForServing(multiplier: newValue)
+        .onChange(of: servingMultiplier) { _, _ in
+            applyServingSelection()
+        }
+        .onChange(of: selectedServing) { _, _ in
+            applyServingSelection()
         }
     }
     
@@ -192,24 +217,56 @@ struct UnifiedFoodDetailView: View {
             Text("Serving Size")
                 .typography(Typography.headline)
                 .foregroundStyle(ColorTheme.primaryText)
-            
-            HStack {
-                Text("Amount:")
-                    .typography(Typography.subheadline)
-                
-                Stepper(value: $servingMultiplier, in: 0.1...10.0, step: 0.1) {
-                    Text(servingMultiplier.formatted(.number.precision(.fractionLength(1))))
-                        .typography(Typography.headline)
-                        .foregroundStyle(ColorTheme.primary)
+
+            VStack(spacing: 0) {
+                // Only offered when the source described real portions. A
+                // custom food has nothing to choose between, and an empty
+                // picker reads as broken.
+                if !servingOptions.isEmpty {
+                    HStack {
+                        Text("Serving:")
+                            .typography(Typography.subheadline)
+                            .foregroundStyle(ColorTheme.primaryText)
+
+                        Spacer()
+
+                        Picker("Serving", selection: $selectedServing) {
+                            ForEach(servingOptions) { option in
+                                Text(option.displayName).tag(Optional(option))
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .tint(ColorTheme.primary)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.FoodDetail.servingPicker)
+                    }
+                    .padding()
+
+                    Divider().padding(.horizontal)
                 }
+
+                HStack {
+                    Text("Amount:")
+                        .typography(Typography.subheadline)
+                        .foregroundStyle(ColorTheme.primaryText)
+
+                    Stepper(value: $servingMultiplier, in: 0.1...10.0, step: 0.1) {
+                        Text(servingMultiplier.formatted(.number.precision(.fractionLength(1))))
+                            .typography(Typography.headline)
+                            .foregroundStyle(ColorTheme.primary)
+                    }
+                    .accessibilityIdentifier(AccessibilityIdentifiers.FoodDetail.servingStepper)
+                }
+                .padding()
             }
-            .padding()
             .background(ColorTheme.surface)
             .clipShape(.rect(cornerRadius: 12))
-            
-            Text("Per \(customQuantity)")
+
+            // The resolved portion, spelled out. "1 McDonald's Big Mac · 205 g"
+            // is auditable in a way that a bare multiplier never was.
+            Text(customQuantity)
                 .typography(Typography.subheadline)
                 .foregroundStyle(ColorTheme.secondaryText)
+                .accessibilityIdentifier(AccessibilityIdentifiers.FoodDetail.servingSummary)
         }
     }
     
@@ -487,23 +544,43 @@ struct UnifiedFoodDetailView: View {
     
     // MARK: - Helper Methods
     
-    private func updateNutritionForServing(multiplier: Double) {
-        // Update all nutrition values based on serving multiplier
-        foodItem.nutrition.calories = baseNutrition.calories.map { Int(Double($0) * multiplier) }
-        foodItem.nutrition.protein = baseNutrition.protein.map { $0 * multiplier }
-        foodItem.nutrition.carbs = baseNutrition.carbs.map { $0 * multiplier }
-        foodItem.nutrition.fat = baseNutrition.fat.map { $0 * multiplier }
-        foodItem.nutrition.fiber = baseNutrition.fiber.map { $0 * multiplier }
-        foodItem.nutrition.sugar = baseNutrition.sugar.map { $0 * multiplier }
-        foodItem.nutrition.sodium = baseNutrition.sodium.map { $0 * multiplier }
-        
-        // Update quantity description
-        if multiplier == 1.0 {
+    /// Rescales the item to the chosen serving and count.
+    ///
+    /// Always computed against the item the view opened with, never against
+    /// the last state — repeatedly multiplying a running total accumulates
+    /// error, and `Int` calories lose a little precision on every hop.
+    private func applyServingSelection() {
+        let factor = scaleFactor
+
+        foodItem.nutrition = NutritionScaling.scaled(baseNutrition, by: factor)
+
+        // The micronutrients live in `nutritionDetails` as strings and have to
+        // move with the macros. Before this they did not, so a doubled serving
+        // reported double the calories next to unchanged saturated fat.
+        foodItem.nutritionDetails = NutritionScaling.scaled(baseDetails, by: factor)
+
+        if let selectedServing {
+            customQuantity = selectedServing.quantityDescription(count: servingMultiplier)
+            foodItem.estimatedWeightInGrams = selectedServing.gramWeight * servingMultiplier
+        } else if servingMultiplier == 1.0 {
             customQuantity = baseQuantity
         } else {
-            customQuantity = "\(multiplier.formatted(.number.precision(.fractionLength(1)))) × \(baseQuantity)"
+            customQuantity = "\(servingMultiplier.formatted(.number.precision(.fractionLength(1)))) × \(baseQuantity)"
         }
+
         foodItem.quantity = customQuantity
+        foodItem.selectedServing = selectedServing
+        foodItem.servingCount = selectedServing.map { _ in servingMultiplier }
+    }
+
+    /// How far the opened item's figures have to move to describe the current
+    /// selection.
+    private var scaleFactor: Double {
+        guard let selectedServing, let baseGrams, baseGrams > 0 else {
+            // No portion data: the stepper is a plain multiplier, as before.
+            return servingMultiplier
+        }
+        return (selectedServing.gramWeight * servingMultiplier) / baseGrams
     }
     
     // MARK: - Health Analysis Functions

--- a/GutCheck/GutCheckTests/ServingSizeTests.swift
+++ b/GutCheck/GutCheckTests/ServingSizeTests.swift
@@ -1,0 +1,245 @@
+//
+//  ServingSizeTests.swift
+//  GutCheckTests
+//
+//  Pins the serving-size maths from #359: every searched food used to be
+//  logged per 100 g, so a Big Mac recorded 46% of a sandwich. These cover the
+//  three pieces that decide what actually gets logged — which portion is
+//  picked, what it scales the numbers by, and that the micronutrient strings
+//  move with the macros.
+//
+//  Note: CI builds but does not run tests. These are here for when it does,
+//  and for running locally with ⌘U.
+//
+
+import Testing
+@testable import GutCheck
+
+@Suite("Serving sizes")
+struct ServingSizeTests {
+
+    // MARK: - Helpers
+
+    private func option(_ label: String, _ grams: Double) -> ServingOption {
+        guard let option = ServingOption(label: label, gramWeight: grams) else {
+            Issue.record("\(label) at \(grams) g should be a valid serving option")
+            // Never reached; keeps the return type non-optional at call sites.
+            return ServingOption(label: "fallback", gramWeight: 1)!
+        }
+        return option
+    }
+
+    /// The FNDDS measures a "Big Mac (Mcdonalds)" search actually returns,
+    /// minus the "Quantity not specified" entry which is passed separately as
+    /// the source's own preferred weight.
+    private var bigMacMeasures: [ServingOption] {
+        ServingSizeResolver.normalize([
+            option("1 MCDonald's Mac Jr", 135),
+            option("1 McDonald's Big Mac", 205),
+            option("1 McDonald's Grand Mac", 315),
+            option("100 g", 100)
+        ])
+    }
+
+    /// The measures on USDA's "Potato, french fries, restaurant", trimmed to
+    /// the ones that matter here.
+    private var restaurantFryMeasures: [ServingOption] {
+        ServingSizeResolver.normalize([
+            option("1 kids meal order", 70),
+            option("1 small fast food order", 110),
+            option("1 medium fast food order", 145),
+            option("1 large fast food order", 180),
+            option("100 g", 100)
+        ])
+    }
+
+    // MARK: - ServingOption
+
+    @Test("A serving with no weight is not a serving")
+    func rejectsUnusableOptions() {
+        #expect(ServingOption(label: "1 sandwich", gramWeight: 0) == nil)
+        #expect(ServingOption(label: "1 sandwich", gramWeight: -5) == nil)
+        #expect(ServingOption(label: "   ", gramWeight: 205) == nil)
+    }
+
+    @Test("A named portion shows its weight, a weight does not repeat itself")
+    func displayNameShowsWeightOnlyWhenItAddsSomething() {
+        #expect(option("1 McDonald's Big Mac", 205).displayName == "1 McDonald's Big Mac · 205 g")
+        #expect(option("100 g", 100).displayName == "100 g")
+        // A volume keeps the source's own unit rather than claiming a density.
+        #expect(option("25 ml", 25).displayName == "25 ml")
+    }
+
+    @Test("The quantity line states the total weight, not the unit weight")
+    func quantityDescriptionMultipliesTheWeight() {
+        let medium = option("1 medium fast food order", 145)
+        #expect(medium.quantityDescription(count: 1) == "1 medium fast food order · 145 g")
+        #expect(medium.quantityDescription(count: 2) == "2 × 1 medium fast food order · 290 g")
+    }
+
+    // MARK: - Default selection
+
+    @Test("A Big Mac defaults to the Big Mac, not the Mac Jr or the Grand Mac")
+    func defaultsToTheMeasureNamingTheFood() {
+        let chosen = ServingSizeResolver.defaultOption(
+            forFoodNamed: "Big Mac (Mcdonalds)",
+            from: bigMacMeasures,
+            preferredGrams: 205
+        )
+        #expect(chosen?.label == "1 McDonald's Big Mac")
+        #expect(chosen?.gramWeight == 205)
+    }
+
+    @Test("A size word in the name picks the matching portion")
+    func sizeWordInNameWins() {
+        let chosen = ServingSizeResolver.defaultOption(
+            forFoodNamed: "McDonald's, French Fries, Medium",
+            from: restaurantFryMeasures,
+            // The source's own default is the small order; the name is more
+            // specific than that and has to override it.
+            preferredGrams: 110
+        )
+        #expect(chosen?.label == "1 medium fast food order")
+        #expect(chosen?.gramWeight == 145)
+    }
+
+    @Test("With nothing to match on, the source's own portion weight decides")
+    func fallsBackToThePreferredWeight() {
+        let chosen = ServingSizeResolver.defaultOption(
+            forFoodNamed: "Potato, french fries, restaurant",
+            from: restaurantFryMeasures,
+            preferredGrams: 110
+        )
+        #expect(chosen?.label == "1 small fast food order")
+    }
+
+    @Test("An unmatched weight picks nothing rather than the nearest portion")
+    func doesNotGuessWhenNothingMatches() {
+        // 33 g is nowhere in the list. Returning "1 kids meal order" because it
+        // happens to be closest would be a fabricated portion.
+        let chosen = ServingSizeResolver.defaultOption(
+            forFoodNamed: "Potato, french fries, restaurant",
+            from: restaurantFryMeasures,
+            preferredGrams: 33
+        )
+        #expect(chosen == nil)
+    }
+
+    @Test("Portions are deduplicated and ordered smallest first")
+    func normalizeSortsAndDeduplicates() {
+        let normalized = ServingSizeResolver.normalize([
+            option("1 large fast food order", 180),
+            option("1 small fast food order", 110),
+            option("1 small fast food order", 110),
+            option("1 kids meal order", 70)
+        ])
+        #expect(normalized.map(\.gramWeight) == [70, 110, 180])
+    }
+
+    // MARK: - Scaling
+
+    /// A Big Mac as the app receives it: nutrition reported against 100 g, with
+    /// the sandwich itself offered as a 205 g portion.
+    private func bigMacResult() -> FoodSearchResult {
+        FoodSearchResult(
+            id: "test-big-mac",
+            name: "Big Mac (Mcdonalds)",
+            calories: 261,
+            protein: 12.6,
+            carbs: 20.5,
+            fat: 14.4,
+            // Grams, per the convention both sources normalise to.
+            sodium: 0.46,
+            servingUnit: "g",
+            servingQty: 100,
+            servingWeight: 100,
+            servingOptions: bigMacMeasures,
+            defaultServing: option("1 McDonald's Big Mac", 205)
+        )
+    }
+
+    @Test("A searched food logs its own portion, not the 100 g it was reported against")
+    func scaleFactorUsesTheChosenPortion() {
+        let result = bigMacResult()
+        #expect(result.baseServingGrams == 100)
+        #expect(abs(result.scaleFactor(for: result.defaultServing) - 2.05) < 0.000_001)
+        #expect(abs(result.scaleFactor(for: result.defaultServing, count: 2) - 4.10) < 0.000_001)
+        // No portion data at all leaves the source's figures alone.
+        #expect(result.scaleFactor(for: nil) == 1)
+    }
+
+    @Test("Building a food item applies the default portion")
+    func toFoodItemUsesTheDefaultServing() {
+        let item = bigMacResult().toFoodItem()
+
+        #expect(item.quantity == "1 McDonald's Big Mac · 205 g")
+        #expect(item.estimatedWeightInGrams == 205)
+        #expect(item.selectedServing?.label == "1 McDonald's Big Mac")
+        #expect(item.servingCount == 1)
+
+        // 261 kcal per 100 g over 205 g. Not McDonald's published 563 — that is
+        // a different record — but the whole sandwich rather than 46% of it.
+        #expect(item.nutrition.calories == 535)
+        // Sodium still crosses grams to milligrams on the way out.
+        #expect(abs((item.nutrition.sodium ?? 0) - 943) < 0.5)
+    }
+
+    @Test("Calories round rather than truncate")
+    func caloriesRound() {
+        // 261 × 2.05 is 535.05; 261 × 1.999 is 521.7, which truncation would
+        // report as 521.
+        #expect(NutritionScaling.scaled(NutritionInfo(calories: 261), by: 1.999).calories == 522)
+        #expect(NutritionScaling.scaled(NutritionInfo(calories: 261), by: 2.05).calories == 535)
+    }
+
+    @Test("Micronutrient strings scale with the macros")
+    func detailStringsScale() {
+        let details = [
+            "Calories": "261kcal",
+            "Saturated Fat": "5.2g",
+            "Sodium": "460.5mg",
+            "Selenium": "26.5mcg"
+        ]
+        let scaled = NutritionScaling.scaled(details, by: 2)
+
+        #expect(scaled["Calories"] == "522kcal")
+        #expect(scaled["Saturated Fat"] == "10.4g")
+        #expect(scaled["Sodium"] == "921mg")
+        #expect(scaled["Selenium"] == "53mcg")
+    }
+
+    @Test("Non-nutrient entries are left alone")
+    func detailScalingIgnoresNonNutrients() {
+        // "brand" is written into the same dictionary, and a brand that starts
+        // with a digit must not be multiplied.
+        let scaled = NutritionScaling.scaled(
+            ["brand": "McDonald's", "name": "7 Up", "Protein": "12.6g"],
+            by: 2
+        )
+
+        #expect(scaled["brand"] == "McDonald's")
+        #expect(scaled["name"] == "7 Up")
+        #expect(scaled["Protein"] == "25.2g")
+    }
+
+    @Test("Scaled values survive being read back")
+    func scaledValuesRoundTripThroughTheParser() {
+        // The strings are re-parsed by NutritionDetailsView, so the fixed
+        // en_US_POSIX separator convention has to survive the rewrite.
+        let scaled = NutritionScaling.scaled(["Sodium": "1093mg"], by: 1.5)
+        #expect(NutrientValueParser.number(from: scaled["Sodium"] ?? "") == 1639.5)
+    }
+
+    // MARK: - OpenFoodFacts weights
+
+    @Test("A bare serving size is grams, a volume is not a weight")
+    func parsesOpenFoodFactsWeights() {
+        // OpenFoodFacts records the European Big Mac's serving size as "219".
+        #expect(OpenFoodFactsService.weightInGrams(from: "219") == 219)
+        #expect(OpenFoodFactsService.weightInGrams(from: "30 g") == 30)
+        #expect(OpenFoodFactsService.weightInGrams(from: "30g (1 biscuit)") == 30)
+        #expect(OpenFoodFactsService.weightInGrams(from: "25 ml") == nil)
+        #expect(OpenFoodFactsService.weightInGrams(from: "1 cup") == nil)
+        #expect(OpenFoodFactsService.weightInGrams(from: "") == nil)
+    }
+}

--- a/GutCheck/GutCheckTests/ServingSizeTests.swift
+++ b/GutCheck/GutCheckTests/ServingSizeTests.swift
@@ -243,3 +243,29 @@ struct ServingSizeTests {
         #expect(OpenFoodFactsService.weightInGrams(from: "") == nil)
     }
 }
+
+// MARK: - Review regressions (#407)
+
+@Suite("Serving description does not invent grams for volumes")
+struct VolumeServingDescriptionTests {
+
+    @Test("A volume label gets no gram suffix at any count")
+    func volumeNeverGetsGrams() throws {
+        // Printing "2 × 25 ml · 50 g" asserts a density the source never gave.
+        // The guard originally applied only when count == 1, so the claim came
+        // back the moment the stepper moved.
+        let option = try #require(ServingOption(label: "25 ml", gramWeight: 25))
+
+        #expect(option.quantityDescription(count: 1) == "25 ml")
+        #expect(!option.quantityDescription(count: 2).contains(" g"))
+        #expect(option.quantityDescription(count: 2) == "2 × 25 ml")
+    }
+
+    @Test("A named portion still states its total weight")
+    func namedPortionKeepsWeight() throws {
+        let option = try #require(ServingOption(label: "1 medium fast food order", gramWeight: 145))
+
+        #expect(option.quantityDescription(count: 1) == "1 medium fast food order · 145 g")
+        #expect(option.quantityDescription(count: 2) == "2 × 1 medium fast food order · 290 g")
+    }
+}


### PR DESCRIPTION
Closes #359.

## The problem

Every searched food was logged **per 100 g** with no way to pick a portion. The item detail showed `Serving Size · Amount: 1.0 [− +]` and the caption `Per 100 g`. Reproduced on the simulator before touching anything: a Big Mac logged as **100 g / 231–240 kcal** against a real ~205 g sandwich.

The stepper was a unitless multiplier, so logging a real sandwich meant working out 2.05 and typing it.

Beyond calories: portion size is one of the stronger predictors of a post-meal symptom, and a trigger engine that sees 100 g of every component cannot distinguish a few fries from a large.

## Where the data was

The issue said the fix was purely at the UI layer, since `FoodSearchResult` already carries `servingUnit`/`servingQty`/`servingWeight`. **That turned out to be only half right and worth flagging.** Those fields exist, but for every food the issue names they all read 100 g — a Big Mac's USDA record declares no `servingSize`, and OpenFoodFacts' Big Mac declares no `serving_size`. A UI-only change would have offered a picker with one entry in it.

The real portions were in two fields neither service decoded:

- **USDA `foodMeasures`**, on the same search response the app already fetches — `1 McDonald's Big Mac` at 205 g, `1 medium fast food order` at 145 g, and the small/large orders alongside it. No new API calls.
- **OpenFoodFacts `product_quantity`**, the net weight of the whole product — 220 g for a Big Mac Bacon. Many fast-food records carry that and no serving size at all.

## What changed

- **`ServingOption` / `ServingSizeResolver`** (new) — a portion with its gram weight, plus the rules for choosing a default: a size word shared with the food's own name wins ("…, French Fries, **Medium**" → `1 medium fast food order`), then the measure that names the food (a Big Mac's list also contains a Mac Jr and a Grand Mac), then the weight the source itself treats as one portion. It returns *nothing* rather than picking the nearest weight, so an unmatched food falls back to the old baseline instead of inventing a portion.
- **`NutritionScaling`** (new) — moves an existing item's figures to a different portion, including the micronutrient strings in `nutritionDetails`. Those never moved with the old multiplier: doubling a serving used to double the calories while saturated fat and every vitamin stayed put. It scales by *format* (a bare number plus `g`/`mg`/`mcg`/`kcal`) rather than by a list of nutrient labels, so it cannot drift from `nutritionDetailStrings()` the way #362 did — and non-nutrient entries like `brand` pass through untouched.
- **`nutritionDetailStrings()` gained a scale factor** rather than a second dictionary. It is still the only place that knows label names, units and gram conversions. `FoodSearchResult.nutritionInfo(scaledBy:)` was split out for the same reason: the view model was building its own `NutritionInfo`, and that is exactly the boundary sodium's g→mg conversion sits on.
- **Detail view** gained a serving picker beside the stepper and prints the resolved portion and weight. That string is `FoodItem.quantity`, so the item row and Meal Details pick it up with no changes of their own.
- Rescaling is always computed against the item the view opened with, never the previous selection — repeatedly multiplying a running total accumulates error, and `Int` calories lose precision on every hop. Verified by switching serving and back and landing on the original numbers.

The three new `FoodItem` fields are optional so meals written by earlier builds still decode (`foodItems` is a JSON blob inside `StoredMeal`, and the synthesised decoder throws on a missing non-optional).

## Acceptance

| From the issue | Result |
| --- | --- |
| Big Mac defaults to one sandwich | ✅ `1 McDonald's Big Mac · 205 g` |
| …and records ~563 kcal | ⚠️ **535 kcal.** See below. |
| Medium fries defaults to a medium | ⚠️ Defaults to `1 small fast food order · 110 g`; medium is one tap away. See below. |
| …and records ~320 kcal | ✅ 318 kcal at the default |
| Serving and gram weight visible on the item row and in Meal Details | ✅ |
| Changing the serving updates meal totals and risk inputs | ✅ |

**On the two numbers that don't land exactly.** 563 kcal and 111 g are McDonald's published figures; USDA's own record says the sandwich is 205 g at 261 kcal/100 g, which is 535. I did not want to hard-code a table of restaurant weights to hit a round number — the app would then be asserting portion data no source gave it. Same for the fries: USDA names the record "Potato, french fries, restaurant" with no size in it, and its own default portion is the 110 g small order (318 kcal, which is what the issue expected from a medium anyway). When the *name* does carry a size the rule fires and picks the matching measure — that path is covered by a test. All of small/medium/large are in the picker with their real weights.

**One judgement call worth review.** For OpenFoodFacts records with no declared serving, the whole package becomes the default only when it weighs 500 g or less. Above that a package is far more likely to be a jar or a bag nobody finishes in one sitting, where guessing "the whole thing" would be the larger error. The threshold is arbitrary; it is a named constant with the reasoning next to it, and the picker still offers the whole package either way.

**Explicitly not done.** `MealRiskPredictionService` scores on food name and compound matches — it does not weight by portion at all. Food items now reach it carrying a real gram weight and correctly scaled nutrition, and the sodium-derived flags do change with the portion (a Big Mac at 205 g trips "High Sodium" where 100 g did not), but making the risk model itself portion-aware is a separate change and out of scope here.

## Verification

Built and **verified on the simulator** — iPhone 17 Pro Max, iOS 26.5 (`B2B3417D-6332-403D-B4A6-31CC09AAEB94`). CLAUDE.md names iPhone 16 Pro; that runtime is not installed on this machine.

- Reproduced the original behaviour on the pre-change build first: Big Mac at `100 g`, `Amount: 1.0`, `Per 100 g`, 240 kcal into the meal.
- After: `1 McDonald's Big Mac · 205 g`, 535 kcal; picker lists Mac Jr 135 g / Big Mac 205 g / Grand Mac 315 g / 100 g; selecting Grand Mac gives 822 kcal and 1527 mg sodium, and every micronutrient moves with it.
- Stepper to 1.2 → `1.2 × 1 McDonald's Big Mac · 246 g`, 642 kcal.
- Fries: default `1 small fast food order · 110 g` / 318 kcal; picker offers kids 70 g, value 85 g, small 110 g, medium 145 g, large 180 g; medium gives 419 kcal.
- Meal saved and reopened — Meal Details shows both items with serving and weight, total 1,061 kcal.
- A meal saved by the **previous** build still decodes and displays (`Big Mac™ Bacon, 100 g, 240 calories`).
- Checked in **both light and dark**.

**Tests**: 15 new tests in `GutCheckTests/ServingSizeTests.swift` covering default selection, scale factors, calorie rounding, detail-string scaling and its round trip through `NutrientValueParser`, and the OpenFoodFacts weight parser. Run locally with `-only-testing:GutCheckTests/ServingSizeTests` — all pass. CI does not run tests.

Full suite run locally: two pre-existing failures, both confirmed present on `origin/development` before this branch — `DashboardDataStoreTests` (known-racy, #382) and `MealDetailViewModelTests/"loadMeal with nil mealId does nothing"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)