### PR TITLE
fix(serving): recognise comma-decimal labels, scale risk badge icon with type

### DIFF
--- a/GutCheck/GutCheck/Models/ServingSize.swift
+++ b/GutCheck/GutCheck/Models/ServingSize.swift
@@ -90,9 +90,16 @@ struct ServingOption: Codable, Hashable, Identifiable {
     }
 
     /// True when the label is nothing but a number and a unit ("100 g", "25 ml").
+    ///
+    /// Accepts either decimal separator. Labels built locally go through
+    /// `formattedWeight`, which formats in the user's locale — so in a
+    /// comma-decimal locale a label reads "2,5 g", and a period-only pattern
+    /// stopped recognising it as a quantity. That put the gram suffix back on
+    /// volume labels for those users: the invented-density bug, but only in
+    /// locales the tests weren't running in.
     private var labelIsAQuantity: Bool {
         label.range(
-            of: #"^\d+(\.\d+)?\s*(g|kg|mg|ml|cl|l|oz|fl oz|lb)$"#,
+            of: #"^\d+([.,]\d+)?\s*(g|kg|mg|ml|cl|l|oz|fl oz|lb)$"#,
             options: [.regularExpression, .caseInsensitive]
         ) != nil
     }

--- a/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
+++ b/GutCheck/GutCheck/Views/Calendar/CalendarView.swift
@@ -794,8 +794,12 @@ struct MealCalendarRow: View {
     
     private func riskBadge(_ level: MealRiskLevel) -> some View {
         HStack(spacing: 5) {
+            // Same typography as the text beside it, so Dynamic Type scales
+            // the pair together instead of growing the label around a frozen
+            // 11 pt icon.
             Image(systemName: level.icon)
-                .font(.system(size: 11, weight: .semibold))
+                .typography(Typography.caption)
+                .fontWeight(.semibold)
             Text("\(level.displayName) risk")
                 .typography(Typography.caption)
         }

--- a/GutCheck/GutCheckTests/ServingSizeTests.swift
+++ b/GutCheck/GutCheckTests/ServingSizeTests.swift
@@ -269,3 +269,27 @@ struct VolumeServingDescriptionTests {
         #expect(option.quantityDescription(count: 2) == "2 × 1 medium fast food order · 290 g")
     }
 }
+
+@Suite("Quantity labels in comma-decimal locales")
+struct CommaDecimalLabelTests {
+
+    @Test("A comma-decimal volume label is still recognised as a quantity")
+    func commaVolumeLabel() throws {
+        // formattedWeight builds labels in the user's locale, so a French
+        // device produces "2,5 ml". A period-only pattern stopped treating it
+        // as a quantity and put the gram suffix back — the invented-density
+        // bug, but only in locales the tests weren't running in.
+        let option = try #require(ServingOption(label: "2,5 ml", gramWeight: 2.5))
+
+        #expect(!option.displayName.contains(" g"))
+        #expect(!option.quantityDescription(count: 2).contains(" g"))
+    }
+
+    @Test("A comma-decimal weight label gets no doubled suffix")
+    func commaWeightLabel() throws {
+        let option = try #require(ServingOption(label: "2,5 g", gramWeight: 2.5))
+
+        // Already a quantity; appending "· 2.5 g" would print the weight twice.
+        #expect(option.displayName == "2,5 g")
+    }
+}


### PR DESCRIPTION
Addresses Copilot's review on #408 (the release PR — these land on `development` first so the release stays reviewable).

**1. Comma-decimal locales resurrected the invented-density bug.** `labelIsAQuantity` only accepted `.` decimals, but the labels it inspects are built by `formattedWeight` **in the user's locale** — a French device produces `2,5 ml`, which stopped matching, so volume labels got the gram suffix back. Third instance of the locale-decimal bug class in this codebase (after #355's storage locale and `NutrientValueParser`); it only surfaces off en-US devices, which is why tests kept missing it. Pattern now accepts either separator — recognition side only, display stays locale-correct. Regression tests added.

**2. Risk badge icon frozen under Dynamic Type.** The badge paired a fixed 11 pt icon with `.typography` text, so accessibility sizes grew the label around a frozen icon. Now shares `Typography.caption`. One correction to the review: `mealIcon` two rows up is *also* fixed-size, so "icons elsewhere use .typography" isn't quite right — but the pairing argument stands on its own. `mealIcon` left alone as out of scope.

**Verification:** 19/19 serving tests pass, build clean (iPhone 17 Pro Max / iOS 26.5). Badge change not re-driven on device — one-modifier swap to the documented Typography mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)